### PR TITLE
Replace inline Patterns code with links to runnable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,69 +325,37 @@ result = compiled.invoke(Command(resume="yes"), config)
 
 ## Patterns
 
+The patterns below show how these building blocks compose into complete architectures. Each is backed by a runnable example in the `examples/` directory.
+
 ### Reflection Loop (Generate / Critique / Revise)
 
-```python
-@dataclass(frozen=True)
-class WriteRequest(Event):
-    topic: str
-    max_revisions: int = 3
+A handler subscribes to both the seed event and critique events (`@on(WriteRequest, Critique)`), creating an autonomous improvement cycle. A second handler evaluates each draft and either produces a critique (looping back) or a final result (terminating). `EventLog.latest()` provides lookback to enforce a revision cap.
 
-@dataclass(frozen=True)
-class Draft(Event):
-    content: str
-    revision: int = 0
-
-@dataclass(frozen=True)
-class Critique(Event):
-    feedback: str
-    revision: int = 0
-
-@dataclass(frozen=True)
-class FinalDraft(Event):
-    content: str
-
-@on(WriteRequest, Critique)
-def generate(event: Event, log: EventLog) -> Draft:
-    if isinstance(event, Critique):
-        return Draft(
-            content=f"revised based on: {event.feedback}",
-            revision=event.revision + 1,
-        )
-    return Draft(content=f"first draft about {event.topic}")
-
-@on(Draft)
-def evaluate(event: Draft, log: EventLog) -> Critique | FinalDraft:
-    request = log.latest(WriteRequest)
-    if event.revision >= request.max_revisions:
-        return FinalDraft(content=event.content)
-    return Critique(feedback="needs more detail", revision=event.revision)
-
-graph = EventGraph([generate, evaluate])
-log = graph.invoke(WriteRequest(topic="AI Safety"))
-print(log.latest(FinalDraft))
-```
+See [`examples/reflection_loop.py`](examples/reflection_loop.py) for the full implementation.
 
 ### ReAct Agent with Message Reducer
 
-```python
-messages = message_reducer([SystemMessage(content="You are a helpful assistant with tools.")])
+Multi-subscription (`@on(UserMessageReceived, ToolsExecuted)`) creates the ReAct loop implicitly. The `message_reducer` maintains conversation history incrementally — handlers receive the accumulated message list as a parameter rather than reconstructing it from the event log.
 
-@on(UserMessageReceived, ToolsExecuted)
-async def call_llm(event: Event, messages: list[BaseMessage]) -> LLMResponded:
-    response = await llm.ainvoke(messages)
-    return LLMResponded(message=response)
+See [`examples/react_agent.py`](examples/react_agent.py) for the full implementation.
 
-@on(LLMResponded)
-def execute_tools(event: LLMResponded) -> ToolsExecuted | AnswerProduced:
-    if not event.message.tool_calls:
-        return AnswerProduced(content=event.message.content)
-    ...
+### Multi-Agent Supervisor
 
-graph = EventGraph([call_llm, execute_tools], reducers=[messages])
-```
+A supervisor handler fires on the initial task and on specialist completions (`@on(TaskReceived, ResearchCompleted, CodeProduced)`). It uses tool-calling to make structured routing decisions. A custom `Reducer` projects events into a context channel that the supervisor reads incrementally.
 
-The `messages` parameter is injected by the framework — no manual message history reconstruction needed.
+See [`examples/supervisor.py`](examples/supervisor.py) for the full implementation.
+
+### Fan-Out / Fan-In (Map-Reduce)
+
+`Scatter` fans a batch into individual work items. Per-item handlers process in parallel. A gathering handler uses `EventLog.filter()` to detect completion and produce the combined result.
+
+See [`examples/map_reduce.py`](examples/map_reduce.py) for the full implementation.
+
+### Human-in-the-Loop Approval
+
+`Interrupted` pauses the graph for human input. `Resumed` carries the response back in. Combined with a revision event type, this creates an approval-with-feedback cycle. Requires a checkpointer.
+
+See [`examples/human_in_the_loop.py`](examples/human_in_the_loop.py) for the full implementation.
 
 ## Examples
 
@@ -395,10 +363,11 @@ See the `examples/` directory for complete, runnable demos:
 
 | Example | Pattern | Key Features |
 |---------|---------|--------------|
-| `react_agent.py` | ReAct tool-calling agent | `MessageEvent`, `message_reducer`, `Auditable` |
-| `supervisor.py` | Multi-agent supervisor | Custom `Reducer`, `Auditable` trait |
-| `map_reduce.py` | Fan-out/fan-in pipeline | `Scatter`, `Auditable` |
-| `human_in_the_loop.py` | Approval with revision loop | `Interrupted`/`Resumed`, checkpointer |
+| [`reflection_loop.py`](examples/reflection_loop.py) | Autonomous generate/critique/revise | Multi-subscription `@on`, `EventLog.latest()`, revision cap |
+| [`react_agent.py`](examples/react_agent.py) | ReAct tool-calling agent | `MessageEvent`, `message_reducer`, `Auditable` |
+| [`supervisor.py`](examples/supervisor.py) | Multi-agent supervisor | Custom `Reducer`, tool-calling routing, `Auditable` |
+| [`map_reduce.py`](examples/map_reduce.py) | Fan-out/fan-in pipeline | `Scatter`, `EventLog.filter()`, gather pattern |
+| [`human_in_the_loop.py`](examples/human_in_the_loop.py) | Approval with revision loop | `Interrupted`/`Resumed`, checkpointer, revision cycle |
 
 ## API Reference
 

--- a/examples/reflection_loop.py
+++ b/examples/reflection_loop.py
@@ -1,0 +1,167 @@
+"""Reflection Loop — langgraph-events demo.
+
+Demonstrates the autonomous generate/critique/revise pattern using
+multi-subscription handlers. The `@on(WriteRequest, Critique)` pattern
+creates the revision cycle implicitly — the generate handler fires on
+both the initial request and on critique feedback, looping until a
+quality threshold or revision cap is reached.
+
+Uses `EventLog.latest()` for lookback to enforce a revision cap,
+and union return types (`Critique | FinalDraft`) to branch the flow.
+
+Also demonstrates the **Auditable trait pattern**: events inherit from a marker
+class, and a single `@on(Auditable)` handler auto-logs every marked event as
+it flows through the graph.
+
+Usage:
+    export OPENAI_API_KEY="sk-..."
+    python examples/reflection_loop.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+
+from langgraph_events import Auditable, Event, EventGraph, EventLog, on
+
+# ---------------------------------------------------------------------------
+# Events (past-participle: "what just happened")
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WriteRequest(Auditable):
+    topic: str = ""
+    max_revisions: int = 3
+
+
+@dataclass(frozen=True)
+class Draft(Auditable):
+    content: str = ""
+    revision: int = 0
+
+
+@dataclass(frozen=True)
+class Critique(Auditable):
+    feedback: str = ""
+    revision: int = 0
+
+
+@dataclass(frozen=True)
+class FinalDraft(Auditable):
+    content: str = ""
+
+
+# ---------------------------------------------------------------------------
+# LLM
+# ---------------------------------------------------------------------------
+
+llm = ChatOpenAI(model="gpt-4o-mini")
+
+
+# ---------------------------------------------------------------------------
+# Handlers — the entire loop is just these three functions
+# ---------------------------------------------------------------------------
+
+
+@on(Auditable)
+def audit_trail(event: Auditable) -> None:
+    """Side-effect handler: logs all auditable events as they flow."""
+    print(f"  {event.trail()}")
+
+
+@on(WriteRequest, Critique)
+async def generate(event: Event, log: EventLog) -> Draft:
+    """Generate or revise a draft.
+
+    Fires on both WriteRequest (initial generation) and Critique
+    (revision based on feedback), creating the revision cycle automatically.
+    """
+    if isinstance(event, Critique):
+        prev_draft = log.latest(Draft)
+        messages = [
+            SystemMessage(
+                content=(
+                    "You are a skilled writer revising a draft based on feedback. "
+                    "Preserve the overall structure but address every point in the feedback."
+                )
+            ),
+            HumanMessage(
+                content=(
+                    f"Previous draft:\n{prev_draft.content}\n\n"
+                    f"Feedback:\n{event.feedback}\n\n"
+                    "Please revise the draft."
+                )
+            ),
+        ]
+        revision = event.revision + 1
+    else:
+        messages = [
+            SystemMessage(
+                content=(
+                    "You are a skilled writer. Write a clear, engaging short essay "
+                    "(2-3 paragraphs) on the given topic."
+                )
+            ),
+            HumanMessage(content=f"Write about: {event.topic}"),
+        ]
+        revision = 0
+
+    response = await llm.ainvoke(messages)
+    return Draft(content=response.content, revision=revision)
+
+
+@on(Draft)
+async def evaluate(event: Draft, log: EventLog) -> Critique | FinalDraft:
+    """Evaluate a draft — either critique it or accept it as final.
+
+    Uses EventLog.latest() to look back at the original WriteRequest
+    for the revision cap.
+    """
+    request = log.latest(WriteRequest)
+    if event.revision >= request.max_revisions:
+        return FinalDraft(content=event.content)
+
+    messages = [
+        SystemMessage(
+            content=(
+                "You are a sharp editorial critic. Read the draft and provide "
+                "specific, actionable feedback in 2-3 bullet points. "
+                "Focus on clarity, structure, and persuasiveness."
+            )
+        ),
+        HumanMessage(content=event.content),
+    ]
+    response = await llm.ainvoke(messages)
+    return Critique(feedback=response.content, revision=event.revision)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+async def main():
+    graph = EventGraph([generate, evaluate, audit_trail])
+
+    topic = "why event-driven architecture leads to simpler agent designs"
+    print(f"Topic: {topic}")
+    print("Max revisions: 3\n")
+    print("--- Event Flow ---")
+
+    log = await graph.ainvoke(WriteRequest(topic=topic, max_revisions=3))
+
+    print()
+    drafts = log.filter(Draft)
+    print(f"Total drafts: {len(drafts)} (1 initial + {len(drafts) - 1} revisions)")
+
+    final = log.latest(FinalDraft)
+    print(f"\n=== Final Draft ===\n{final.content}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- Replaced ~55 lines of duplicated inline code in the Patterns section with brief prose descriptions linking to example files
- Added `examples/reflection_loop.py` — a new runnable example for the autonomous generate/critique/revise pattern
- Expanded the Patterns section from 2 to 5 entries, covering all example files (reflection loop, ReAct agent, supervisor, map-reduce, human-in-the-loop)
- Enhanced the Examples table with clickable markdown links and richer feature callouts

## Test plan

- [x] `uv run pytest` — 84/84 tests pass
- [x] `uv run ruff check` — all checks pass
- [x] Pre-commit hooks pass (ruff, ruff format, mypy)
- [x] Visually review README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)