### PR TITLE
Disallow base Event return type in handler annotations

### DIFF
--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -28,21 +28,18 @@ if TYPE_CHECKING:
     from langgraph_events._reducer import Reducer
 
 
-def _parse_return_types(
-    fn: Callable[..., Any],
-) -> tuple[list[type[Event]], list[type[Event]], bool, bool, bool]:
-    """Parse handler return annotation.
+class ReturnInfo(NamedTuple):
+    """Parsed handler return-type annotation."""
 
-    Returns a 5-tuple:
-    ``(event_types, scatter_types, has_scatter, has_interrupted, has_annotation)``.
+    event_types: list[type[Event]]
+    scatter_types: list[type[Event]]
+    has_scatter: bool
+    has_interrupted: bool
+    has_annotation: bool
 
-    Returns:
-        event_types: Event subclasses the handler can produce (solid edges).
-        scatter_types: Event subclasses produced via Scatter (dashed edges).
-        has_scatter: Whether the handler returns bare (untyped) Scatter.
-        has_interrupted: Whether the handler returns Interrupted.
-        has_annotation: Whether the handler has a return type annotation at all.
-    """
+
+def _parse_return_types(fn: Callable[..., Any]) -> ReturnInfo:
+    """Parse handler return annotation into a ``ReturnInfo``."""
     try:
         hints = typing.get_type_hints(fn)
     except Exception:
@@ -50,7 +47,7 @@ def _parse_return_types(
 
     return_hint = hints.get("return")
     if return_hint is None:
-        return [], [], False, False, False
+        return ReturnInfo([], [], False, False, False)
 
     # If the top-level hint is Scatter[X], wrap it so the loop sees Scatter[X]
     # as a single candidate (otherwise get_args returns the type params).
@@ -80,7 +77,7 @@ def _parse_return_types(
                 has_interrupted = True
             event_types.append(arg)
 
-    return event_types, scatter_types, has_scatter, has_interrupted, True
+    return ReturnInfo(event_types, scatter_types, has_scatter, has_interrupted, True)
 
 
 class GraphState(NamedTuple):
@@ -158,6 +155,16 @@ class EventGraph:
                 seen_names[meta.name] = 1
             self._handler_metas.append(meta)
 
+        self._return_info: dict[str, ReturnInfo] = {}
+        for meta in self._handler_metas:
+            info = _parse_return_types(meta.fn)
+            self._return_info[meta.name] = info
+            if info.has_annotation and any(t is Event for t in info.event_types):
+                raise ValueError(
+                    f"Handler '{meta.name}' return type includes base 'Event'. "
+                    f"Use specific types (e.g., TypeA | TypeB)."
+                )
+
     @staticmethod
     def _mermaid_footer_entry(
         meta: HandlerMeta, has_scatter: bool, solid: list[str], dashed: list[str]
@@ -189,23 +196,21 @@ class EventGraph:
         all_targets: set[str] = set()
 
         for meta in self._handler_metas:
-            event_types, scatter_types, has_scatter, has_interrupted, has_annotation = (
-                _parse_return_types(meta.fn)
-            )
+            info = self._return_info[meta.name]
             label = meta.name
 
-            if has_interrupted:
+            if info.has_interrupted:
                 any_produces_interrupted = True
             if any(issubclass(t, Resumed) for t in meta.event_types):
                 any_subscribes_resumed = True
 
-            solid_targets = [t.__name__ for t in event_types]
-            dashed_targets = [t.__name__ for t in scatter_types]
-            if not has_annotation:
+            solid_targets = [t.__name__ for t in info.event_types]
+            dashed_targets = [t.__name__ for t in info.scatter_types]
+            if not info.has_annotation:
                 solid_targets.append("?")
 
             footer = self._mermaid_footer_entry(
-                meta, has_scatter, solid_targets, dashed_targets
+                meta, info.has_scatter, solid_targets, dashed_targets
             )
             if footer is not None:
                 (scatter_handlers if footer[0] == "scatter" else side_effects).append(

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -89,7 +89,7 @@ def describe_EventGraph():
             @pytest.fixture
             def branching_graph():
                 @on(Input)
-                def route(event: Input) -> Event | None:
+                def route(event: Input) -> FastPath | SlowPath | None:
                     if event.kind == "fast":
                         return FastPath(data=event.data)
                     return SlowPath(data=event.data)
@@ -1543,7 +1543,7 @@ def describe_EventGraph():
                     n: int = 0
 
                 @on(LoopEvent)
-                def looper(event: LoopEvent) -> Event:
+                def looper(event: LoopEvent) -> LoopEvent:
                     return LoopEvent(n=event.n + 1)
 
                 graph = EventGraph([looper], max_rounds=5)
@@ -1741,3 +1741,32 @@ def describe_EventGraph():
                 output = graph.mermaid()
                 assert "-->|handler|" in output
                 assert "-->|handler_2|" in output
+
+        def when_base_event_return_type():
+
+            def it_rejects_base_event_return_type():
+                @on(Start)
+                def handler(event: Start) -> Event:
+                    return Middle(data=event.data)
+
+                with pytest.raises(ValueError, match="base 'Event'"):
+                    EventGraph([handler])
+
+            def it_rejects_event_in_union_return_type():
+                @on(Start)
+                def handler(event: Start) -> Event | None:
+                    return Middle(data=event.data)
+
+                with pytest.raises(ValueError, match="base 'Event'"):
+                    EventGraph([handler])
+
+            def it_allows_event_subclass_return_type():
+                class Auditable(Event):
+                    data: str = ""
+
+                @on(Start)
+                def handler(event: Start) -> Auditable:
+                    return Auditable(data=event.data)
+
+                # Should not raise
+                EventGraph([handler])


### PR DESCRIPTION
## Summary
- Forbid annotating handlers with the base `Event` class as a return type at graph construction time — raises `ValueError` with a clear message
- Replace raw 5-tuple from `_parse_return_types` with `ReturnInfo` NamedTuple for cleaner field access
- Cache parsed return info in `EventGraph.__init__` so `mermaid()` reads from cache instead of re-parsing

## Test plan
- [x] Fix existing tests using `-> Event` to use specific types (`-> FastPath | SlowPath | None`, `-> LoopEvent`)
- [x] Add test: `-> Event` raises `ValueError`
- [x] Add test: `-> Event | None` raises `ValueError`
- [x] Add test: `-> Auditable` (subclass) does not raise
- [x] All 150 tests pass, ruff clean, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)