### PR TITLE
Add config and store injection for EventGraph handlers

### DIFF
--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Iterator
 
     from langgraph.graph.state import CompiledStateGraph
+    from langgraph.store.base import BaseStore
 
     from langgraph_events._reducer import Reducer
 
@@ -126,7 +127,7 @@ class EventGraph:
         max_rounds: int = 100,
         reducers: list[Reducer] | None = None,
         checkpointer: Any = None,
-        store: Any = None,
+        store: BaseStore | None = None,
     ) -> None:
         if not handlers:
             raise ValueError("EventGraph requires at least one handler")

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -126,12 +126,14 @@ class EventGraph:
         max_rounds: int = 100,
         reducers: list[Reducer] | None = None,
         checkpointer: Any = None,
+        store: Any = None,
     ) -> None:
         if not handlers:
             raise ValueError("EventGraph requires at least one handler")
 
         self._max_rounds = max_rounds
         self._checkpointer = checkpointer
+        self._store = store
         self._reducers: dict[str, Reducer] = {r.name: r for r in (reducers or [])}
         self._handler_metas: list[HandlerMeta] = []
         self._compiled_graph: CompiledStateGraph | None = None
@@ -150,6 +152,8 @@ class EventGraph:
                     log_param=meta.log_param,
                     is_async=meta.is_async,
                     reducer_params=meta.reducer_params,
+                    config_param=meta.config_param,
+                    store_param=meta.store_param,
                 )
             else:
                 seen_names[meta.name] = 1
@@ -314,6 +318,8 @@ class EventGraph:
         compile_kwargs: dict[str, Any] = {}
         if self._checkpointer is not None:
             compile_kwargs["checkpointer"] = self._checkpointer
+        if self._store is not None:
+            compile_kwargs["store"] = self._store
         self._compiled_graph = graph.compile(**compile_kwargs)
         return self._compiled_graph
 

--- a/src/langgraph_events/_handler.py
+++ b/src/langgraph_events/_handler.py
@@ -59,6 +59,8 @@ class HandlerMeta:
     log_param: str | None
     is_async: bool
     reducer_params: tuple[str, ...] = ()
+    config_param: str | None = None
+    store_param: str | None = None
 
     @property
     def wants_log(self) -> bool:
@@ -89,6 +91,18 @@ def extract_handler_meta(
             log_param = param_name
             break
 
+    # Detect config and store parameters by type hint
+    from langchain_core.runnables import RunnableConfig  # noqa: PLC0415
+    from langgraph.store.base import BaseStore  # noqa: PLC0415
+
+    config_param: str | None = None
+    store_param: str | None = None
+    for param_name, hint in hints.items():
+        if hint is RunnableConfig:
+            config_param = param_name
+        elif hint is BaseStore:
+            store_param = param_name
+
     # Detect reducer parameters by name match
     sig = inspect.signature(fn)
     reducer_params = tuple(name for name in sig.parameters if name in reducer_names)
@@ -99,6 +113,10 @@ def extract_handler_meta(
         known_params = {first_param}  # first param is always the event
         if log_param:
             known_params.add(log_param)
+        if config_param:
+            known_params.add(config_param)
+        if store_param:
+            known_params.add(store_param)
         known_params.update(reducer_names)
         unknown = [
             name
@@ -120,4 +138,6 @@ def extract_handler_meta(
         log_param=log_param,
         is_async=asyncio.iscoroutinefunction(fn),
         reducer_params=reducer_params,
+        config_param=config_param,
+        store_param=store_param,
     )

--- a/src/langgraph_events/_internal.py
+++ b/src/langgraph_events/_internal.py
@@ -12,7 +12,7 @@ from collections.abc import Callable  # noqa: TC003
 from typing import TYPE_CHECKING, Annotated, Any, TypedDict
 
 if TYPE_CHECKING:
-    from langchain_core.runnables import RunnableLambda
+    from langchain_core.runnables import RunnableConfig, RunnableLambda
 
 from langgraph.graph import END
 from langgraph.types import Send  # noqa: TC002
@@ -173,6 +173,7 @@ def make_dispatch(
 def _build_inject(
     meta: HandlerMeta,
     state: StateDict,
+    config: RunnableConfig | None = None,
 ) -> dict[str, Any]:
     """Build keyword arguments to inject into a handler call."""
     inject: dict[str, Any] = {}
@@ -180,6 +181,11 @@ def _build_inject(
         inject[meta.log_param] = EventLog(state["events"])
     for param_name in meta.reducer_params:
         inject[param_name] = state.get(f"_r_{param_name}", [])
+    if meta.config_param and config is not None:
+        inject[meta.config_param] = config
+    if meta.store_param and config is not None:
+        runtime = config.get("configurable", {}).get("__pregel_runtime")
+        inject[meta.store_param] = runtime.store if runtime is not None else None
     return inject
 
 
@@ -219,9 +225,9 @@ def make_handler_node(
 
     reds = reducers or {}
 
-    def _run_handler_sync(state: StateDict) -> StateDict:
+    def _run_handler_sync(state: StateDict, config: RunnableConfig) -> StateDict:
         matching = [e for e in state["_pending"] if isinstance(e, meta.event_types)]
-        inject = _build_inject(meta, state)
+        inject = _build_inject(meta, state, config)
 
         new_events: list[Event] = []
         for event in matching:
@@ -247,9 +253,9 @@ def make_handler_node(
             output.update(_apply_reducers(new_events, reds))
         return output
 
-    async def _run_handler_async(state: StateDict) -> StateDict:
+    async def _run_handler_async(state: StateDict, config: RunnableConfig) -> StateDict:
         matching = [e for e in state["_pending"] if isinstance(e, meta.event_types)]
-        inject = _build_inject(meta, state)
+        inject = _build_inject(meta, state, config)
 
         new_events: list[Event] = []
         for event in matching:

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -525,6 +525,71 @@ def describe_EventGraph():
                 log = await graph.ainvoke(Start(data="x"))
                 assert log.latest(End) == End(result="x")
 
+    def describe_config_and_store():
+
+        def when_handler_requests_config():
+
+            def it_receives_a_runnable_config_dict():
+                from langchain_core.runnables import RunnableConfig
+
+                captured: list[RunnableConfig] = []
+
+                @on(Start)
+                def step(event: Start, config: RunnableConfig) -> End:
+                    captured.append(config)
+                    return End(result="ok")
+
+                graph = EventGraph([step])
+                graph.invoke(Start(data="x"))
+                assert len(captured) == 1
+                assert "configurable" in captured[0]
+
+        def when_handler_requests_store():
+
+            def it_can_put_and_get_via_store():
+                from langgraph.store.base import BaseStore
+                from langgraph.store.memory import InMemoryStore
+
+                store = InMemoryStore()
+
+                @on(Start)
+                async def step(event: Start, store: BaseStore) -> End:
+                    await store.aput(("test",), "key1", {"val": event.data})
+                    items = await store.aget(("test",), "key1")
+                    return End(result=items.value["val"])
+
+                graph = EventGraph([step], store=store)
+                log = graph.invoke(Start(data="hello"))
+                assert log.latest(End) == End(result="hello")
+
+        def when_handler_requests_neither():
+
+            def it_works_without_config_or_store():
+                @on(Start)
+                def step(event: Start) -> End:
+                    return End(result=event.data)
+
+                graph = EventGraph([step])
+                log = graph.invoke(Start(data="hi"))
+                assert log.latest(End) == End(result="hi")
+
+        def when_handler_requests_config_and_log():
+
+            def it_injects_both():
+                from langchain_core.runnables import RunnableConfig
+
+                captured: list[tuple] = []
+
+                @on(Start)
+                def step(event: Start, log: EventLog, config: RunnableConfig) -> End:
+                    captured.append((len(log), "configurable" in config))
+                    return End(result="ok")
+
+                graph = EventGraph([step])
+                graph.invoke(Start(data="x"))
+                assert len(captured) == 1
+                assert captured[0] == (1, True)
+
     def describe_halt():
 
         def it_stores_reason_and_is_Event_subclass():


### PR DESCRIPTION
## Summary
- Extend `HandlerMeta` and `extract_handler_meta()` to detect `RunnableConfig` and `BaseStore` type hints on handler parameters
- Inject config and store into handler calls via `_build_inject()`, with store extracted from `config["configurable"]["__pregel_runtime"]`
- Add `store` parameter to `EventGraph.__init__` passed through to `graph.compile()`

## Test plan
- [x] Handler requesting `config: RunnableConfig` receives a valid config dict
- [x] Handler requesting `store: BaseStore` can put/get with `InMemoryStore`
- [x] Handler without config/store still works (backward compat)
- [x] Config and EventLog injection work together
- [x] All 154 tests pass, 95.67% coverage
- [x] ruff check, ruff format, mypy all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)