### PR TITLE
Add ScalarReducer for last-write-wins values

### DIFF
--- a/src/langgraph_events/__init__.py
+++ b/src/langgraph_events/__init__.py
@@ -13,7 +13,7 @@ from langgraph_events._event import (
 from langgraph_events._event_log import EventLog
 from langgraph_events._graph import EventGraph, GraphState, StreamFrame
 from langgraph_events._handler import on
-from langgraph_events._reducer import Reducer, message_reducer
+from langgraph_events._reducer import Reducer, ScalarReducer, message_reducer
 from langgraph_events._types import (
     HandlerReturn,  # noqa: F401 (importable but not promoted)
 )
@@ -29,6 +29,7 @@ __all__ = [
     "MessageEvent",
     "Reducer",
     "Resumed",
+    "ScalarReducer",
     "Scatter",
     "StreamFrame",
     "SystemPromptSet",

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from langgraph.graph.state import CompiledStateGraph
     from langgraph.store.base import BaseStore
 
-    from langgraph_events._reducer import Reducer
+    from langgraph_events._reducer import BaseReducer
 
 
 class ReturnInfo(NamedTuple):
@@ -125,7 +125,7 @@ class EventGraph:
         handlers: list[Callable[..., Any]],
         *,
         max_rounds: int = 100,
-        reducers: list[Reducer] | None = None,
+        reducers: list[BaseReducer] | None = None,
         checkpointer: Any = None,
         store: BaseStore | None = None,
     ) -> None:
@@ -135,7 +135,7 @@ class EventGraph:
         self._max_rounds = max_rounds
         self._checkpointer = checkpointer
         self._store = store
-        self._reducers: dict[str, Reducer] = {r.name: r for r in (reducers or [])}
+        self._reducers: dict[str, BaseReducer] = {r.name: r for r in (reducers or [])}
         self._handler_metas: list[HandlerMeta] = []
         self._compiled_graph: CompiledStateGraph | None = None
 
@@ -280,8 +280,8 @@ class EventGraph:
         out_schema: Any = _OutputState
         if self._reducers:
             reducer_fields: dict[str, Any] = {"events": list[Event]}
-            for name in self._reducers:
-                reducer_fields[f"_r_{name}"] = list
+            for name, r in self._reducers.items():
+                reducer_fields[f"_r_{name}"] = r.output_type()
             out_schema = TypedDict("_OutputWithReducers", reducer_fields)  # type: ignore[misc,no-redef]
 
         graph: StateGraph[Any] = StateGraph(

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -411,8 +411,8 @@ class EventGraph:
                             events.append(event)
         return events
 
-    @staticmethod
     def _frames_from_values(
+        self,
         state: dict[str, Any],
         prev_count: int,
         reducer_names: list[str],
@@ -422,7 +422,10 @@ class EventGraph:
         new_events = all_events[prev_count:]
         if not new_events:
             return prev_count, []
-        reducers = {name: state.get(f"_r_{name}", []) for name in reducer_names}
+        reducers = {
+            name: state.get(f"_r_{name}", self._reducers[name].empty)
+            for name in reducer_names
+        }
         return len(all_events), [
             StreamFrame(event=e, reducers=reducers) for e in new_events
         ]

--- a/src/langgraph_events/_internal.py
+++ b/src/langgraph_events/_internal.py
@@ -20,7 +20,7 @@ from langgraph.types import Send  # noqa: TC002
 from langgraph_events._event import Event, Halted, Resumed, Scatter
 from langgraph_events._event_log import EventLog
 from langgraph_events._handler import HandlerMeta  # noqa: TC001
-from langgraph_events._reducer import Reducer  # noqa: TC001
+from langgraph_events._reducer import BaseReducer  # noqa: TC001
 from langgraph_events._types import HandlerReturn, StateDict  # noqa: TC001
 
 # ---------------------------------------------------------------------------
@@ -44,15 +44,15 @@ class _OutputState(TypedDict):
     events: list[Event]
 
 
-def build_state_schema(reducers: dict[str, Reducer]) -> type:
+def build_state_schema(reducers: dict[str, BaseReducer]) -> type:
     """Create a dynamic TypedDict with per-reducer state channels.
 
-    Each reducer gets its own ``_r_<name>`` channel annotated with its
-    ``reducer`` function, e.g. ``Annotated[list, add_messages]``.
+    Each reducer gets its own ``_r_<name>`` channel with a type annotation
+    determined by the reducer's ``state_annotation()`` method.
     """
     fields: dict[str, Any] = dict(_BASE_FIELDS)
     for name, r in reducers.items():
-        fields[f"_r_{name}"] = Annotated[list, r.reducer]
+        fields[f"_r_{name}"] = r.state_annotation()
     return TypedDict("_FullState", fields)  # type: ignore[operator]
 
 
@@ -61,27 +61,8 @@ def build_state_schema(reducers: dict[str, Reducer]) -> type:
 # ---------------------------------------------------------------------------
 
 
-def _validate_and_collect(
-    name: str,
-    reducer: Reducer,
-    events: list[Event],
-) -> list[Any]:
-    """Run a reducer fn over events with type validation."""
-    contributions: list[Any] = []
-    for event in events:
-        contrib = reducer.fn(event)
-        if contrib:
-            if not isinstance(contrib, list):
-                raise TypeError(
-                    f"Reducer {name!r} fn must return a list, "
-                    f"got {type(contrib).__name__}"
-                )
-            contributions.extend(contrib)
-    return contributions
-
-
 def make_seed_node(
-    reducers: dict[str, Reducer] | None = None,
+    reducers: dict[str, BaseReducer] | None = None,
 ) -> Callable[[StateDict], StateDict]:
     """Create the seed node that initialises cursor and pending from input."""
     reds = reducers or {}
@@ -100,15 +81,13 @@ def make_seed_node(
             if prev_cursor == 0:
                 # First run — initialize with default + seed events
                 for name, r in reds.items():
-                    values = list(r.default)
-                    values.extend(_validate_and_collect(name, r, new_events))
-                    result[f"_r_{name}"] = values
+                    result[f"_r_{name}"] = r.seed(new_events)
             elif new_events:
                 # Subsequent run (checkpointer) — only process new events
                 for name, r in reds.items():
-                    contribs = _validate_and_collect(name, r, new_events)
-                    if contribs:
-                        result[f"_r_{name}"] = contribs
+                    collected = r.collect(new_events)
+                    if r.has_contributions(collected):
+                        result[f"_r_{name}"] = collected
         return result
 
     return seed
@@ -173,6 +152,7 @@ def make_dispatch(
 def _build_inject(
     meta: HandlerMeta,
     state: StateDict,
+    reducers: dict[str, BaseReducer],
     config: RunnableConfig | None = None,
 ) -> dict[str, Any]:
     """Build keyword arguments to inject into a handler call."""
@@ -180,7 +160,8 @@ def _build_inject(
     if meta.log_param:
         inject[meta.log_param] = EventLog(state["events"])
     for param_name in meta.reducer_params:
-        inject[param_name] = state.get(f"_r_{param_name}", [])
+        r = reducers.get(param_name)
+        inject[param_name] = state.get(f"_r_{param_name}", r.empty if r else [])
     if meta.config_param and config is not None:
         inject[meta.config_param] = config
     if meta.store_param and config is not None:
@@ -191,23 +172,23 @@ def _build_inject(
 
 def _apply_reducers(
     new_events: list[Event],
-    reducers: dict[str, Reducer],
-) -> dict[str, list[Any]]:
+    reducers: dict[str, BaseReducer],
+) -> dict[str, Any]:
     """Run reducer projections on newly produced events.
 
     Returns per-channel updates keyed by ``_r_<name>``.
     """
-    updates: dict[str, list[Any]] = {}
+    updates: dict[str, Any] = {}
     for name, r in reducers.items():
-        contributions = _validate_and_collect(name, r, new_events)
-        if contributions:
-            updates[f"_r_{name}"] = contributions
+        result = r.collect(new_events)
+        if r.has_contributions(result):
+            updates[f"_r_{name}"] = result
     return updates
 
 
 def make_handler_node(
     meta: HandlerMeta,
-    reducers: dict[str, Reducer] | None = None,
+    reducers: dict[str, BaseReducer] | None = None,
 ) -> RunnableLambda:
     """Wrap a user handler as a LangGraph node.
 
@@ -227,7 +208,7 @@ def make_handler_node(
 
     def _run_handler_sync(state: StateDict, config: RunnableConfig) -> StateDict:
         matching = [e for e in state["_pending"] if isinstance(e, meta.event_types)]
-        inject = _build_inject(meta, state, config)
+        inject = _build_inject(meta, state, reds, config)
 
         new_events: list[Event] = []
         for event in matching:
@@ -255,7 +236,7 @@ def make_handler_node(
 
     async def _run_handler_async(state: StateDict, config: RunnableConfig) -> StateDict:
         matching = [e for e in state["_pending"] if isinstance(e, meta.event_types)]
-        inject = _build_inject(meta, state, config)
+        inject = _build_inject(meta, state, reds, config)
 
         new_events: list[Event] = []
         for event in matching:

--- a/src/langgraph_events/_reducer.py
+++ b/src/langgraph_events/_reducer.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import operator
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -15,8 +16,39 @@ if TYPE_CHECKING:
     from langgraph_events._types import ReducerFn
 
 
+class BaseReducer(ABC):
+    """Abstract base for all reducer types."""
+
+    name: str
+
+    @abstractmethod
+    def state_annotation(self) -> Any:
+        """LangGraph state channel type annotation."""
+
+    @property
+    @abstractmethod
+    def empty(self) -> Any:
+        """Default value when no contributions exist."""
+
+    @abstractmethod
+    def collect(self, events: list[Event]) -> Any:
+        """Gather contributions from events."""
+
+    @abstractmethod
+    def has_contributions(self, result: Any) -> bool:
+        """Whether collect() produced a meaningful update."""
+
+    @abstractmethod
+    def output_type(self) -> Any:
+        """Output schema field type."""
+
+    @abstractmethod
+    def seed(self, events: list[Event]) -> Any:
+        """Initialize with default + seed event contributions."""
+
+
 @dataclass
-class Reducer:
+class Reducer(BaseReducer):
     """Maps events to contributions for a named LangGraph state channel.
 
     The ``fn`` is called once per event when it is produced. Its return
@@ -47,6 +79,86 @@ class Reducer:
     fn: Callable[[Event], list[Any]]
     reducer: ReducerFn = field(default=operator.add)
     default: list[Any] = field(default_factory=list)
+
+    def state_annotation(self) -> Any:
+        return Annotated[list, self.reducer]
+
+    @property
+    def empty(self) -> Any:
+        return list(self.default)
+
+    def collect(self, events: list[Event]) -> Any:
+        contributions: list[Any] = []
+        for event in events:
+            contrib = self.fn(event)
+            if contrib:
+                if not isinstance(contrib, list):
+                    raise TypeError(
+                        f"Reducer {self.name!r} fn must return a list, "
+                        f"got {type(contrib).__name__}"
+                    )
+                contributions.extend(contrib)
+        return contributions
+
+    def has_contributions(self, result: Any) -> bool:
+        return bool(result)
+
+    def output_type(self) -> Any:
+        return list
+
+    def seed(self, events: list[Event]) -> Any:
+        values = list(self.default)
+        values.extend(self.collect(events))
+        return values
+
+
+@dataclass
+class ScalarReducer(BaseReducer):
+    """Last-write-wins reducer that injects a bare value instead of a list.
+
+    The ``fn`` is called once per event. It should return ``T | None``;
+    the last non-None value wins and is injected directly into the handler.
+
+    Example::
+
+        strategy = ScalarReducer(
+            name="strategy",
+            fn=lambda e: e.strategy if isinstance(e, StrategyChosen) else None,
+        )
+
+        @on(TaskReceived)
+        def handle(event: TaskReceived, strategy: str) -> Done:
+            ...
+    """
+
+    name: str
+    fn: Callable[[Event], Any]
+    default: Any = None
+
+    def state_annotation(self) -> Any:
+        return Any | None
+
+    @property
+    def empty(self) -> Any:
+        return self.default
+
+    def collect(self, events: list[Event]) -> Any:
+        result = None
+        for event in events:
+            val = self.fn(event)
+            if val is not None:
+                result = val
+        return result
+
+    def has_contributions(self, result: Any) -> bool:
+        return result is not None
+
+    def output_type(self) -> Any:
+        return Any
+
+    def seed(self, events: list[Event]) -> Any:
+        result = self.collect(events)
+        return result if self.has_contributions(result) else self.default
 
 
 def message_reducer(

--- a/src/langgraph_events/_reducer.py
+++ b/src/langgraph_events/_reducer.py
@@ -16,6 +16,11 @@ if TYPE_CHECKING:
     from langgraph_events._types import ReducerFn
 
 
+def _last_write_wins(existing: Any, new: Any) -> Any:
+    """Binary operator that always takes the newer value."""
+    return new
+
+
 class BaseReducer(ABC):
     """Abstract base for all reducer types."""
 
@@ -119,6 +124,9 @@ class ScalarReducer(BaseReducer):
     The ``fn`` is called once per event. It should return ``T | None``;
     the last non-None value wins and is injected directly into the handler.
 
+    Note: ``None`` signals "no contribution". To store ``None`` as
+    a meaningful value, wrap it (e.g. use a sentinel dataclass).
+
     Example::
 
         strategy = ScalarReducer(
@@ -136,7 +144,7 @@ class ScalarReducer(BaseReducer):
     default: Any = None
 
     def state_annotation(self) -> Any:
-        return Any | None
+        return Annotated[Any, _last_write_wins]
 
     @property
     def empty(self) -> Any:

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -1227,6 +1227,70 @@ def describe_EventGraph():
             log = graph.invoke(Trigger(tag="x"))
             assert log.latest(Result) == Result(summary="tags=['x'],last=x")
 
+        def it_handles_parallel_handler_contributions():
+            class Trigger(Event):
+                value: str = ""
+
+            class ResultA(Event):
+                data: str = ""
+
+            class ResultB(Event):
+                data: str = ""
+
+            sr = ScalarReducer(
+                name="latest",
+                fn=lambda e: (
+                    e.value
+                    if isinstance(e, Trigger)
+                    else (e.data if isinstance(e, (ResultA, ResultB)) else None)
+                ),
+            )
+
+            @on(Trigger)
+            def handler_a(event: Trigger, latest: object) -> ResultA:
+                return ResultA(data=f"a:{event.value}")
+
+            @on(Trigger)
+            def handler_b(event: Trigger, latest: object) -> ResultB:
+                return ResultB(data=f"b:{event.value}")
+
+            graph = EventGraph([handler_a, handler_b], reducers=[sr])
+            log = graph.invoke(Trigger(value="x"))
+            # Both handlers run in parallel — should not crash
+            assert log.has(ResultA)
+            assert log.has(ResultB)
+
+        def when_checkpointer():
+
+            def it_does_not_lose_scalar_on_re_invoke():
+                from langgraph.checkpoint.memory import MemorySaver
+
+                class Trigger(Event):
+                    value: str = ""
+
+                class Result(Event):
+                    got: str = ""
+
+                sr = ScalarReducer(
+                    name="latest",
+                    fn=lambda e: e.value if isinstance(e, Trigger) else None,
+                )
+
+                @on(Trigger)
+                def handle(event: Trigger, latest: object) -> Result:
+                    return Result(got=str(latest))
+
+                graph = EventGraph([handle], reducers=[sr], checkpointer=MemorySaver())
+                config = {"configurable": {"thread_id": "scalar-re-invoke"}}
+
+                # Run 1
+                log1 = graph.invoke(Trigger(value="first"), config=config)
+                assert log1.latest(Result) == Result(got="first")
+
+                # Run 2 — re-invoke on same thread
+                log2 = graph.invoke(Trigger(value="second"), config=config)
+                assert log2.latest(Result) == Result(got="second")
+
     def describe_message_reducer():
 
         def it_projects_message_events():

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -18,6 +18,7 @@ from langgraph_events import (
     MessageEvent,
     Reducer,
     Resumed,
+    ScalarReducer,
     Scatter,
     StreamFrame,
     SystemPromptSet,
@@ -1114,6 +1115,117 @@ def describe_EventGraph():
                 graph.invoke(MsgIn(text="a"))
                 assert snapshots[0] == ["y", "z", "a"]
                 assert snapshots[1] == ["z", "a", "b"]
+
+    def describe_scalar_reducer():
+
+        def it_injects_last_value():
+            class StrategyChosen(Event):
+                strategy: str = ""
+
+            class TaskDone(Event):
+                result: str = ""
+
+            sr = ScalarReducer(
+                name="strategy",
+                fn=lambda e: e.strategy if isinstance(e, StrategyChosen) else None,
+            )
+
+            @on(StrategyChosen)
+            def handle(event: StrategyChosen, strategy: str) -> TaskDone:
+                return TaskDone(result=f"used:{strategy}")
+
+            graph = EventGraph([handle], reducers=[sr])
+            log = graph.invoke(StrategyChosen(strategy="aggressive"))
+            assert log.latest(TaskDone) == TaskDone(result="used:aggressive")
+
+        def it_defaults_to_none():
+            class Trigger(Event):
+                pass
+
+            class Result(Event):
+                got: str = ""
+
+            sr = ScalarReducer(
+                name="mode",
+                fn=lambda e: None,
+            )
+
+            @on(Trigger)
+            def handle(event: Trigger, mode: object) -> Result:
+                return Result(got=str(mode))
+
+            graph = EventGraph([handle], reducers=[sr])
+            log = graph.invoke(Trigger())
+            assert log.latest(Result) == Result(got="None")
+
+        def it_takes_last_non_none_value():
+            class Step(Event):
+                value: str = ""
+
+            class Final(Event):
+                result: str = ""
+
+            sr = ScalarReducer(
+                name="chosen",
+                fn=lambda e: e.value if isinstance(e, Step) and e.value else None,
+            )
+
+            @on(Step)
+            def advance(event: Step, chosen: object) -> Step | Final:
+                if event.value == "b":
+                    return Final(result=f"chosen={chosen}")
+                return Step(value="b")
+
+            graph = EventGraph([advance], reducers=[sr])
+            log = graph.invoke(Step(value="a"))
+            # After seed "a", handler sees "a"; produces Step("b"),
+            # then handler sees "b" (last non-None wins).
+            assert log.latest(Final) == Final(result="chosen=b")
+
+        def it_uses_custom_default():
+            class Trigger(Event):
+                pass
+
+            class Result(Event):
+                got: str = ""
+
+            sr = ScalarReducer(
+                name="mode",
+                fn=lambda e: None,
+                default="fallback",
+            )
+
+            @on(Trigger)
+            def handle(event: Trigger, mode: str) -> Result:
+                return Result(got=mode)
+
+            graph = EventGraph([handle], reducers=[sr])
+            log = graph.invoke(Trigger())
+            assert log.latest(Result) == Result(got="fallback")
+
+        def it_works_alongside_list_reducers():
+            class Trigger(Event):
+                tag: str = ""
+
+            class Result(Event):
+                summary: str = ""
+
+            list_r = Reducer(
+                name="tags",
+                fn=lambda e: [e.tag] if isinstance(e, Trigger) and e.tag else [],
+            )
+            scalar_r = ScalarReducer(
+                name="last_tag",
+                fn=lambda e: e.tag if isinstance(e, Trigger) and e.tag else None,
+            )
+
+            @on(Trigger)
+            def handle(event: Trigger, tags: list, last_tag: object) -> Result:
+                return Result(summary=f"tags={tags},last={last_tag}")
+
+            graph = EventGraph([handle], reducers=[list_r, scalar_r])
+            log = graph.invoke(Trigger(tag="x"))
+            assert log.latest(Result) == Result(summary="tags=['x'],last=x")
 
     def describe_message_reducer():
 


### PR DESCRIPTION
## Summary
- Adds `ScalarReducer` — a last-write-wins reducer where `fn` returns `T | None` and the bare value is injected directly into handlers (no list wrapping)
- Introduces `BaseReducer` ABC with shared method interface (`state_annotation`, `empty`, `collect`, `has_contributions`, `output_type`, `seed`), eliminating type-branching in internal machinery
- Refactors `Reducer` to inherit from `BaseReducer`, moving validation logic into `Reducer.collect()`

## Test plan
- [x] `it_injects_last_value` — fn returns str, handler gets bare string
- [x] `it_defaults_to_none` — handler receives None when no event contributed
- [x] `it_takes_last_non_none_value` — multiple rounds, last non-None wins
- [x] `it_uses_custom_default` — ScalarReducer with default="fallback"
- [x] `it_works_alongside_list_reducers` — mixed scalar + list reducers
- [x] All 166 existing tests pass (no regressions)
- [x] ruff clean, mypy clean, 100% coverage on _reducer.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)