### PR TITLE
Add query methods to EventLog: first, count, after, before, select

### DIFF
--- a/src/langgraph_events/_event_log.py
+++ b/src/langgraph_events/_event_log.py
@@ -39,6 +39,35 @@ class EventLog:
         """Return ``True`` if any event of *event_type* exists."""
         return any(isinstance(e, event_type) for e in self._events)
 
+    def first(self, event_type: type[T]) -> T | None:
+        """Return the earliest event of *event_type*, or ``None``."""
+        for e in self._events:
+            if isinstance(e, event_type):
+                return e
+        return None
+
+    def count(self, event_type: type[Event]) -> int:
+        """Return the number of events matching *event_type*."""
+        return sum(1 for e in self._events if isinstance(e, event_type))
+
+    def after(self, event_type: type[Event]) -> EventLog:
+        """Return an ``EventLog`` of events after the first *event_type*."""
+        for i, e in enumerate(self._events):
+            if isinstance(e, event_type):
+                return EventLog(self._events[i + 1 :])
+        return EventLog([])
+
+    def before(self, event_type: type[Event]) -> EventLog:
+        """Return an ``EventLog`` of events before the first *event_type*."""
+        for i, e in enumerate(self._events):
+            if isinstance(e, event_type):
+                return EventLog(self._events[:i])
+        return EventLog([])
+
+    def select(self, event_type: type[T]) -> EventLog:
+        """Like ``filter()`` but returns an ``EventLog`` for chaining."""
+        return EventLog([e for e in self._events if isinstance(e, event_type)])
+
     @property
     def events(self) -> tuple[Event, ...]:
         """The events in this log as an immutable tuple."""

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -66,6 +66,74 @@ def describe_EventLog():
             log = EventLog([Alpha(v=1)])
             assert log.has(Event) is True
 
+    def describe_first():
+
+        def it_returns_first_match(log):
+            assert log.first(Alpha) == Alpha(v=1)
+            assert log.first(Beta) == Beta(v=2)
+
+        def when_no_match():
+
+            def it_returns_none():
+                log = EventLog([Alpha(v=1)])
+                assert log.first(Beta) is None
+
+    def describe_count():
+
+        def it_counts_matching_events(log):
+            assert log.count(Alpha) == 2
+            assert log.count(Beta) == 1
+
+        def it_returns_zero_for_absent_type(log):
+            class Gamma(Event):
+                pass
+
+            assert log.count(Gamma) == 0
+
+    def describe_after():
+
+        def it_returns_events_after_first_occurrence(log):
+            result = log.after(Alpha)
+            assert list(result) == [Beta(v=2), Alpha(v=3)]
+
+        def it_returns_empty_log_when_type_absent(log):
+            class Gamma(Event):
+                pass
+
+            result = log.after(Gamma)
+            assert len(result) == 0
+            assert isinstance(result, EventLog)
+
+        def it_supports_chaining(log):
+            result = log.after(Alpha).latest(Alpha)
+            assert result == Alpha(v=3)
+
+    def describe_before():
+
+        def it_returns_events_before_first_occurrence(log):
+            result = log.before(Beta)
+            assert list(result) == [Alpha(v=1)]
+
+        def it_returns_empty_log_when_type_absent(log):
+            class Gamma(Event):
+                pass
+
+            result = log.before(Gamma)
+            assert len(result) == 0
+            assert isinstance(result, EventLog)
+
+    def describe_select():
+
+        def it_returns_event_log_of_matching_events(log):
+            result = log.select(Alpha)
+            assert isinstance(result, EventLog)
+            assert list(result) == [Alpha(v=1), Alpha(v=3)]
+
+        def it_supports_chaining_with_after():
+            log = EventLog([Alpha(v=1), Beta(v=2), Alpha(v=3), Beta(v=4)])
+            result = log.after(Alpha).select(Beta)
+            assert list(result) == [Beta(v=2), Beta(v=4)]
+
     def describe_events():
 
         def it_returns_a_tuple_of_all_events(log):


### PR DESCRIPTION
## Summary
- Add `first()`, `count()`, `after()`, `before()`, `select()` query methods to `EventLog`
- `after()`/`before()` return `EventLog` for temporal slicing; `select()` returns `EventLog` for chainable filtering
- Full test coverage with BDD-style tests for all new methods

## Test plan
- [x] `uv run pytest tests/test_event_log.py -v` — 32 tests pass
- [x] `uv run mypy src/langgraph_events/_event_log.py` — no issues
- [x] `uv run ruff check` — all checks passed
- [x] `_event_log.py` at 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)