### PR TITLE
Remove _r_ prefix from reducer state channels

### DIFF
--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -11,6 +11,7 @@ from langgraph_events._event import Event, Interrupted, Resumed, Scatter
 from langgraph_events._event_log import EventLog
 from langgraph_events._handler import HandlerMeta, extract_handler_meta
 from langgraph_events._internal import (
+    _BASE_FIELDS,
     _InputState,
     _OutputState,
     build_state_schema,
@@ -136,6 +137,11 @@ class EventGraph:
         self._checkpointer = checkpointer
         self._store = store
         self._reducers: dict[str, BaseReducer] = {r.name: r for r in (reducers or [])}
+        conflicts = set(self._reducers.keys()) & set(_BASE_FIELDS.keys())
+        if conflicts:
+            raise ValueError(
+                f"Reducer name(s) {conflicts} conflict with reserved state fields"
+            )
         self._handler_metas: list[HandlerMeta] = []
         self._compiled_graph: CompiledStateGraph | None = None
 
@@ -281,7 +287,7 @@ class EventGraph:
         if self._reducers:
             reducer_fields: dict[str, Any] = {"events": list[Event]}
             for name, r in self._reducers.items():
-                reducer_fields[f"_r_{name}"] = r.output_type()
+                reducer_fields[name] = r.output_type()
             out_schema = TypedDict("_OutputWithReducers", reducer_fields)  # type: ignore[misc,no-redef]
 
         graph: StateGraph[Any] = StateGraph(
@@ -435,8 +441,7 @@ class EventGraph:
         if not new_events:
             return prev_count, []
         reducers = {
-            name: state.get(f"_r_{name}", self._reducers[name].empty)
-            for name in reducer_names
+            name: state.get(name, self._reducers[name].empty) for name in reducer_names
         }
         return len(all_events), [
             StreamFrame(event=e, reducers=reducers) for e in new_events

--- a/src/langgraph_events/_internal.py
+++ b/src/langgraph_events/_internal.py
@@ -47,12 +47,17 @@ class _OutputState(TypedDict):
 def build_state_schema(reducers: dict[str, BaseReducer]) -> type:
     """Create a dynamic TypedDict with per-reducer state channels.
 
-    Each reducer gets its own ``_r_<name>`` channel with a type annotation
-    determined by the reducer's ``state_annotation()`` method.
+    Each reducer gets its own channel (keyed by reducer name) with a type
+    annotation determined by the reducer's ``state_annotation()`` method.
     """
     fields: dict[str, Any] = dict(_BASE_FIELDS)
+    conflicts = set(reducers.keys()) & set(_BASE_FIELDS.keys())
+    if conflicts:
+        raise ValueError(
+            f"Reducer name(s) {conflicts} conflict with reserved state fields"
+        )
     for name, r in reducers.items():
-        fields[f"_r_{name}"] = r.state_annotation()
+        fields[name] = r.state_annotation()
     return TypedDict("_FullState", fields)  # type: ignore[operator]
 
 
@@ -81,13 +86,13 @@ def make_seed_node(
             if prev_cursor == 0:
                 # First run — initialize with default + seed events
                 for name, r in reds.items():
-                    result[f"_r_{name}"] = r.seed(new_events)
+                    result[name] = r.seed(new_events)
             elif new_events:
                 # Subsequent run (checkpointer) — only process new events
                 for name, r in reds.items():
                     collected = r.collect(new_events)
                     if r.has_contributions(collected):
-                        result[f"_r_{name}"] = collected
+                        result[name] = collected
         return result
 
     return seed
@@ -161,7 +166,7 @@ def _build_inject(
         inject[meta.log_param] = EventLog(state["events"])
     for param_name in meta.reducer_params:
         r = reducers.get(param_name)
-        inject[param_name] = state.get(f"_r_{param_name}", r.empty if r else [])
+        inject[param_name] = state.get(param_name, r.empty if r else [])
     if meta.config_param and config is not None:
         inject[meta.config_param] = config
     if meta.store_param and config is not None:
@@ -176,13 +181,13 @@ def _apply_reducers(
 ) -> dict[str, Any]:
     """Run reducer projections on newly produced events.
 
-    Returns per-channel updates keyed by ``_r_<name>``.
+    Returns per-channel updates keyed by reducer name.
     """
     updates: dict[str, Any] = {}
     for name, r in reducers.items():
         result = r.collect(new_events)
         if r.has_contributions(result):
-            updates[f"_r_{name}"] = result
+            updates[name] = result
     return updates
 
 

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -748,6 +748,20 @@ def describe_EventGraph():
 
     def describe_reducer():
 
+        @pytest.mark.parametrize(
+            "reserved_name",
+            ["events", "_cursor", "_pending", "_round"],
+        )
+        def it_rejects_reducer_name_colliding_with_reserved_field(reserved_name):
+            r = Reducer(name=reserved_name, fn=lambda e: [])
+
+            @on(Start)
+            def noop(event: Start) -> Done:
+                return Done(result="x")
+
+            with pytest.raises(ValueError, match="conflict with reserved state fields"):
+                EventGraph([noop], reducers=[r])
+
         def describe_injection():
 
             def it_passes_accumulated_values_to_handler():
@@ -1259,6 +1273,35 @@ def describe_EventGraph():
             # Both handlers run in parallel — should not crash
             assert log.has(ResultA)
             assert log.has(ResultB)
+
+        def it_persists_value_when_subsequent_round_has_no_contribution():
+            class SetValue(Event):
+                value: str = ""
+
+            class Unrelated(Event):
+                pass
+
+            class Result(Event):
+                got: str = ""
+
+            sr = ScalarReducer(
+                name="kept",
+                fn=lambda e: e.value if isinstance(e, SetValue) else None,
+            )
+
+            @on(SetValue)
+            def step1(event: SetValue) -> Unrelated:
+                return Unrelated()
+
+            @on(Unrelated)
+            def step2(event: Unrelated, kept: object) -> Result:
+                return Result(got=str(kept))
+
+            graph = EventGraph([step1, step2], reducers=[sr])
+            log = graph.invoke(SetValue(value="hello"))
+            # Round 2 produces Unrelated (fn returns None) —
+            # scalar must still be "hello", not reverted to None.
+            assert log.latest(Result) == Result(got="hello")
 
         def when_checkpointer():
 


### PR DESCRIPTION
## Summary
- Reducer state channels now use the reducer name directly as the key (e.g. `phase` instead of `_r_phase`), matching `ConversationState` field names
- Adds validation in `EventGraph.__init__` and `build_state_schema` that reducer names don't collide with reserved fields (`events`, `_cursor`, `_pending`, `_round`)
- Parametrized test covers all four reserved field names

## Test plan
- [x] All 179 tests pass (`uv run pytest tests/`)
- [x] Ruff clean (`uv run ruff check src/ tests/`)
- [x] mypy clean (`uv run mypy src/`)
- [x] New parametrized test verifies `ValueError` for each reserved field name

🤖 Generated with [Claude Code](https://claude.com/claude-code)