### PR TITLE
Make Interrupted a bare marker class

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,28 +346,29 @@ async def call_llm(event: Event, messages: list[BaseMessage]) -> LLMResponded:
 
 ### `Interrupted` / `Resumed`
 
-Return an `Interrupted` event to pause the graph and wait for human input. Resume with `graph.resume(event)` — the event is auto-dispatched (handlers subscribed to its type fire), then the framework creates a `Resumed` event alongside it. `resume()` requires an `Event` instance; passing a plain string or dict raises `TypeError`.
+`Interrupted` is a bare marker class — subclass it with domain-specific fields to pause the graph and wait for human input. Resume with `graph.resume(event)` — the event is auto-dispatched (handlers subscribed to its type fire), then the framework creates a `Resumed` event alongside it. `resume()` requires an `Event` instance; passing a plain string or dict raises `TypeError`.
 
 Requires a **checkpointer** (e.g., `MemorySaver`).
 
 ```python
 from langgraph.checkpoint.memory import MemorySaver
 
+class ConfirmOrder(Interrupted):
+    order_id: str
+    total: float
+
 class Approval(Event):
     approved: bool
 
 @on(OrderPlaced)
-def confirm(event: OrderPlaced) -> Interrupted:
-    return Interrupted(
-        prompt=f"Approve order {event.order_id} for ${event.total}?",
-        payload={"order_id": event.order_id},
-    )
+def confirm(event: OrderPlaced) -> ConfirmOrder:
+    return ConfirmOrder(order_id=event.order_id, total=event.total)
 
 @on(Approval)
 def handle_approval(event: Approval, log: EventLog) -> OrderConfirmed | OrderCancelled:
-    interrupted = log.latest(Interrupted)
+    confirm_event = log.latest(ConfirmOrder)
     if event.approved:
-        return OrderConfirmed(order_id=interrupted.payload["order_id"])
+        return OrderConfirmed(order_id=confirm_event.order_id)
     return OrderCancelled(reason="User declined")
 
 graph = EventGraph([confirm, handle_approval], checkpointer=MemorySaver())
@@ -379,7 +380,8 @@ graph.invoke(OrderPlaced(order_id="A1", total=99.99), config=config)
 # Check state and resume with a typed event
 state = graph.get_state(config)
 if state.is_interrupted:
-    print(state.interrupted.prompt)
+    confirm_event = state.interrupted
+    print(f"Approve order {confirm_event.order_id} for ${confirm_event.total}?")
 log = graph.resume(Approval(approved=True), config=config)
 ```
 
@@ -443,7 +445,7 @@ A supervisor handler fires on task and specialist completions, using tool-callin
 | `EventLog`        | Class      | Immutable query container over events           |
 | `GraphState`      | NamedTuple | `(events, is_interrupted, interrupted)` from `get_state()` |
 | `Halted`          | Event      | Signal immediate graph termination              |
-| `Interrupted`     | Event      | Pause graph for human input                     |
+| `Interrupted`     | Base class | Bare marker — subclass with typed fields to pause graph |
 | `MessageEvent`    | Base class | Mixin for events wrapping LangChain messages    |
 | `message_reducer` | Function   | Built-in reducer for `MessageEvent` projection  |
 | `on`              | Decorator  | Subscribe a handler to one or more event types  |

--- a/examples/human_in_the_loop.graph.md
+++ b/examples/human_in_the_loop.graph.md
@@ -9,7 +9,7 @@ graph LR
     _e2_[ ]:::entry ==> RevisionFeedback
     ContentRequested -->|generate_draft| DraftGenerated
     RevisionRequested -->|generate_draft| DraftGenerated
-    DraftGenerated -->|request_approval| Interrupted
+    DraftGenerated -->|request_approval| ApprovalRequested
     ReviewApproved -->|publish| ContentPublished
     RevisionFeedback -->|request_revision| RevisionRequested
 %% Side-effect handlers: audit_trail (Auditable)

--- a/examples/human_in_the_loop.py
+++ b/examples/human_in_the_loop.py
@@ -62,6 +62,13 @@ class ContentPublished(Auditable):
     content: str = ""
 
 
+class ApprovalRequested(Interrupted):
+    """Pause for human review of a draft."""
+
+    draft: str
+    revision: int = 0
+
+
 # ---------------------------------------------------------------------------
 # LLM
 # ---------------------------------------------------------------------------
@@ -123,17 +130,9 @@ async def generate_draft(event: Event, log: EventLog) -> DraftGenerated:
 
 
 @on(DraftGenerated)
-def request_approval(event: DraftGenerated) -> Interrupted:
+def request_approval(event: DraftGenerated) -> ApprovalRequested:
     """Pause the graph and ask the human to review the draft."""
-    return Interrupted(
-        prompt=(
-            f"--- Draft (revision {event.revision}) ---\n\n"
-            f"{event.content}\n\n"
-            "---\n"
-            "Type 'approve' to publish, or provide feedback for revision:"
-        ),
-        payload={"revision": event.revision},
-    )
+    return ApprovalRequested(draft=event.content, revision=event.revision)
 
 
 @on(ReviewApproved)
@@ -146,8 +145,8 @@ def publish(event: ReviewApproved, log: EventLog) -> ContentPublished:
 @on(RevisionFeedback)
 def request_revision(event: RevisionFeedback, log: EventLog) -> RevisionRequested:
     """Request a revision cycle with the human's feedback."""
-    interrupted = log.latest(Interrupted)
-    revision = (interrupted.payload.get("revision", 0) + 1) if interrupted else 1
+    interrupted = log.latest(ApprovalRequested)
+    revision = (interrupted.revision + 1) if interrupted else 1
     return RevisionRequested(feedback=event.feedback, revision=revision)
 
 
@@ -183,9 +182,15 @@ async def main():
                     print(draft.content)
             break
 
-        # Graph is paused — show the interrupt prompt
-        if state.interrupted:
-            print(state.interrupted.prompt)
+        # Graph is paused — show the interrupt details
+        if state.interrupted and isinstance(state.interrupted, ApprovalRequested):
+            i = state.interrupted
+            print(
+                f"--- Draft (revision {i.revision}) ---\n\n"
+                f"{i.draft}\n\n"
+                "---\n"
+                "Type 'approve' to publish, or provide feedback for revision:"
+            )
 
         # Get human input
         human_input = input("\n> ").strip()

--- a/src/langgraph_events/_event.py
+++ b/src/langgraph_events/_event.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import dataclasses
 import types
-from dataclasses import field
 from dataclasses import fields as dc_fields
 from typing import TYPE_CHECKING, Any
 
@@ -124,14 +123,17 @@ class Halted(Event):
 class Interrupted(Event):
     """Special event that pauses the graph for human input.
 
-    When a handler returns an ``Interrupted`` event, the framework calls
-    LangGraph's ``interrupt()`` and the graph pauses. Resume with
+    Subclass with domain-specific fields instead of generic payloads::
+
+        class ApprovalRequested(Interrupted):
+            draft: str
+            revision: int
+
+    When a handler returns an ``Interrupted`` subclass, the framework
+    calls LangGraph's ``interrupt()`` and the graph pauses.  Resume with
     ``graph.resume(event)`` to continue — the event is auto-dispatched
     and a ``Resumed`` event is created alongside it.
     """
-
-    prompt: str = ""
-    payload: dict[str, Any] = field(default_factory=dict)
 
     def _collect_into(
         self,

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -31,6 +31,16 @@ from langgraph_events import (
 # ---------------------------------------------------------------------------
 
 
+class _StepInterrupt(Interrupted):
+    """Module-level Interrupted subclass for checkpoint-aware tests.
+
+    Defined here (not inside test functions) so that LangGraph's
+    serializer can resolve the class on checkpoint restore.
+    """
+
+    step: int = 0
+
+
 def _data_reducer() -> Reducer:
     """Simple reducer that accumulates Start.data values."""
     return Reducer(name="data_items", event_type=Start, fn=lambda e: [e.data])
@@ -626,17 +636,21 @@ def describe_EventGraph():
 
     def describe_interrupt():
 
-        def it_stores_prompt_and_payload():
-            i = Interrupted(prompt="Approve?", payload={"doc_id": "123"})
-            assert i.prompt == "Approve?"
-            assert i.payload == {"doc_id": "123"}
-            assert isinstance(i, Event)
+        def it_is_a_bare_marker_supporting_typed_subclasses():
+            assert isinstance(Interrupted(), Event)
+
+            class ConfirmNeeded(Interrupted):
+                data: str
+
+            c = ConfirmNeeded(data="test")
+            assert c.data == "test"
+            assert isinstance(c, Interrupted)
 
         def it_stores_value_and_interrupted_reference():
             class Confirm(Event):
                 pass
 
-            i = Interrupted(prompt="Approve?")
+            i = Interrupted()
             confirm = Confirm()
             r = Resumed(value=confirm, interrupted=i)
             assert r.value is confirm
@@ -646,15 +660,15 @@ def describe_EventGraph():
         def it_pauses_and_resumes_with_human_input():
             from langgraph.checkpoint.memory import MemorySaver
 
+            class ConfirmNeeded(Interrupted):
+                data: str
+
             class Confirm(Event):
                 pass
 
             @on(Start)
-            def need_input(event: Start) -> Interrupted:
-                return Interrupted(
-                    prompt="Please confirm",
-                    payload={"data": event.data},
-                )
+            def need_input(event: Start) -> ConfirmNeeded:
+                return ConfirmNeeded(data=event.data)
 
             @on(Confirm)
             def handle_confirm(event: Confirm) -> End:
@@ -679,7 +693,7 @@ def describe_EventGraph():
 
             @on(Start)
             def need_input(event: Start) -> Interrupted:
-                return Interrupted(prompt="confirm?")
+                return Interrupted()
 
             graph = EventGraph([need_input])
             with pytest.raises(ValueError, match=r"resume.*requires a checkpointer"):
@@ -690,7 +704,7 @@ def describe_EventGraph():
 
             @on(Start)
             def need_input(event: Start) -> Interrupted:
-                return Interrupted(prompt="confirm?")
+                return Interrupted()
 
             @on(Resumed)
             def handle_resume(event: Resumed) -> End:
@@ -716,7 +730,7 @@ def describe_EventGraph():
 
             @on(Start)
             def need_input(event: Start) -> Interrupted:
-                return Interrupted(prompt="Approve?")
+                return Interrupted()
 
             @on(Approval)
             def handle_approval(event: Approval) -> End:
@@ -765,7 +779,7 @@ def describe_EventGraph():
 
             @on(Start)
             def need_input(event: Start) -> Interrupted:
-                return Interrupted(prompt="Say something")
+                return Interrupted()
 
             received_messages: list = []
 
@@ -2076,15 +2090,16 @@ def describe_EventGraph():
                     pass
 
                 @on(Start)
-                def ask(event: Start) -> Interrupted:
-                    return Interrupted(prompt="approve?")
+                def ask(event: Start) -> _StepInterrupt:
+                    return _StepInterrupt()
 
                 @on(Resumed)
-                def after_resume(event: Resumed) -> Interrupted | End:
-                    step = event.interrupted.payload.get("step", 0)  # type: ignore[union-attr]
+                def after_resume(event: Resumed) -> _StepInterrupt | End:
+                    prev = event.interrupted
+                    step = prev.step if isinstance(prev, _StepInterrupt) else 0
                     if step >= 2:
                         return End(result="done")
-                    return Interrupted(prompt="again?", payload={"step": step + 1})
+                    return _StepInterrupt(step=step + 1)
 
                 # max_rounds=2 would be exceeded without reset:
                 # Run 1 uses round 1 (seed→ask), then pauses.
@@ -2207,7 +2222,7 @@ def describe_EventGraph():
         def it_connects_interrupted_to_resumed_with_dashed_edge():
             @on(Start)
             def request_approval(event: Start) -> Interrupted:
-                return Interrupted(prompt="approve?")
+                return Interrupted()
 
             @on(Resumed)
             def handle_review(event: Resumed) -> End:


### PR DESCRIPTION
## Summary
- Remove `prompt` and `payload` fields from `Interrupted` — it is now a bare marker class meant to be subclassed with domain-specific typed fields (e.g. `ApprovalRequested(Interrupted)` with `draft: str`, `revision: int`)
- Update README docs, human-in-the-loop example, and all tests to use the subclass pattern
- Fix checkpoint-aware test by defining `_StepInterrupt` at module level (LangGraph's msgpack serializer can't resolve classes defined in local function scopes)

## Test plan
- [x] All 194 tests pass
- [x] Lint, format, type check, mermaid sync all pass
- [x] Verified the serialization fix reproduces and resolves the checkpoint restore issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)