### PR TITLE
Harden injections, hint parsing, and EventLog immutability

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ def greet(event: UserMessage) -> Greeting:
     return Greeting(text=f"Hello!")
 ```
 
-Handlers may also request `config: RunnableConfig` or `store: BaseStore` by parameter name.
+Handlers may also request `config: RunnableConfig` or `store: BaseStore` by type annotation (reducer channels are still injected by parameter name).
 
 **Multi-subscription** — a single handler fires on multiple event types:
 

--- a/src/langgraph_events/_event_log.py
+++ b/src/langgraph_events/_event_log.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, overload
 from langgraph_events._event import Event
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
 
 T = TypeVar("T", bound=Event)
 
@@ -19,18 +19,16 @@ class EventLog:
     All queries use ``isinstance`` so subclass events match parent types.
     """
 
-    __slots__ = ("_events", "_events_tuple")
+    __slots__ = ("_events",)
 
-    def __init__(self, events: list[Event]) -> None:
-        self._events = list(events)
-        self._events_tuple: tuple[Event, ...] | None = None
+    def __init__(self, events: Iterable[Event]) -> None:
+        self._events = tuple(events)
 
     @classmethod
-    def _from_owned(cls, events: list[Any]) -> EventLog:
-        """Create an EventLog taking ownership of the list (no copy)."""
+    def _from_owned(cls, events: list[Any] | tuple[Any, ...]) -> EventLog:
+        """Create an EventLog from an already-built events sequence."""
         obj = object.__new__(cls)
-        obj._events = events
-        obj._events_tuple = None
+        obj._events = tuple(events)
         return obj
 
     def filter(self, event_type: type[T]) -> list[T]:
@@ -81,9 +79,7 @@ class EventLog:
     @property
     def events(self) -> tuple[Event, ...]:
         """The events in this log as an immutable tuple."""
-        if self._events_tuple is None:
-            self._events_tuple = tuple(self._events)
-        return self._events_tuple
+        return self._events
 
     # --- container protocol ---
 
@@ -103,6 +99,8 @@ class EventLog:
     def __getitem__(self, index: slice) -> list[Event]: ...
 
     def __getitem__(self, index: int | slice) -> Event | list[Event]:
+        if isinstance(index, slice):
+            return list(self._events[index])
         return self._events[index]
 
     def __repr__(self) -> str:

--- a/src/langgraph_events/_event_log.py
+++ b/src/langgraph_events/_event_log.py
@@ -28,7 +28,7 @@ class EventLog:
     def _from_owned(cls, events: list[Any] | tuple[Any, ...]) -> EventLog:
         """Create an EventLog from an already-built events sequence."""
         obj = object.__new__(cls)
-        obj._events = tuple(events)
+        obj._events = events if isinstance(events, tuple) else tuple(events)
         return obj
 
     def filter(self, event_type: type[T]) -> list[T]:
@@ -62,14 +62,14 @@ class EventLog:
         for i, e in enumerate(self._events):
             if isinstance(e, event_type):
                 return EventLog._from_owned(self._events[i + 1 :])
-        return EventLog._from_owned([])
+        return EventLog._from_owned(())
 
     def before(self, event_type: type[Event]) -> EventLog:
         """Return an ``EventLog`` of events before the first *event_type*."""
         for i, e in enumerate(self._events):
             if isinstance(e, event_type):
                 return EventLog._from_owned(self._events[:i])
-        return EventLog._from_owned([])
+        return EventLog._from_owned(())
 
     def select(self, event_type: type[T]) -> EventLog:
         """Like ``filter()`` but returns an ``EventLog`` for chaining."""

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import typing
+import warnings
 from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict
 
 from langgraph.graph import END, START, StateGraph
@@ -44,7 +45,12 @@ def _parse_return_types(fn: Callable[..., Any]) -> ReturnInfo:
     """Parse handler return annotation into a ``ReturnInfo``."""
     try:
         hints = typing.get_type_hints(fn)
-    except Exception:
+    except Exception as exc:
+        warnings.warn(
+            f"Failed to resolve return type hints for handler {fn.__qualname__!r}; "
+            f"treating as unannotated for topology parsing. ({exc})",
+            stacklevel=3,
+        )
         hints = {}
 
     return_hint = hints.get("return")

--- a/src/langgraph_events/_handler.py
+++ b/src/langgraph_events/_handler.py
@@ -81,7 +81,12 @@ def extract_handler_meta(
 
     try:
         hints = typing.get_type_hints(fn)
-    except Exception:
+    except Exception as exc:
+        warnings.warn(
+            f"Failed to resolve type hints for handler {fn.__qualname__!r}; "
+            f"falling back to signature-only detection. ({exc})",
+            stacklevel=3,
+        )
         hints = {}
 
     # Find the actual parameter name annotated with EventLog

--- a/src/langgraph_events/_internal.py
+++ b/src/langgraph_events/_internal.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import asyncio
 import operator
-from collections.abc import Callable  # noqa: TC003
-from typing import TYPE_CHECKING, Annotated, Any, TypedDict
+from collections.abc import Callable, Coroutine  # noqa: TC003
+from typing import TYPE_CHECKING, Annotated, Any, TypedDict, cast
 
 if TYPE_CHECKING:
     from langchain_core.runnables import RunnableConfig, RunnableLambda
@@ -172,9 +172,20 @@ def _build_inject(
         inject[param_name] = state.get(param_name, r.empty if r else [])
     if meta.config_param and config is not None:
         inject[meta.config_param] = config
-    if meta.store_param and config is not None:
+    if meta.store_param:
+        if config is None:
+            raise ValueError(
+                f"Handler '{meta.name}' requested BaseStore injection, but runtime "
+                "config is missing."
+            )
         runtime = config.get("configurable", {}).get("__pregel_runtime")
-        inject[meta.store_param] = runtime.store if runtime is not None else None
+        store = runtime.store if runtime is not None else None
+        if store is None:
+            raise ValueError(
+                f"Handler '{meta.name}' requested BaseStore injection, but no store "
+                "is configured. Pass store=... to EventGraph(...)."
+            )
+        inject[meta.store_param] = store
     return inject
 
 
@@ -225,16 +236,18 @@ def make_handler_node(
             if meta.is_async:
                 try:
                     asyncio.get_running_loop()
+                except RuntimeError:
+                    # No running loop — safe to use asyncio.run().
+                    coro = cast(
+                        "Coroutine[Any, Any, HandlerReturn]", meta.fn(event, **inject)
+                    )
+                    result = asyncio.run(coro)
+                else:
                     raise RuntimeError(
                         f"Handler {meta.name!r} is async but invoke() was called "
                         f"from within a running event loop (e.g. Jupyter, FastAPI). "
                         f"Use ainvoke() instead."
                     )
-                except RuntimeError as exc:
-                    if "invoke() was called" in str(exc):
-                        raise
-                    # No running loop — safe to use asyncio.run()
-                    result: HandlerReturn = asyncio.run(meta.fn(event, **inject))  # type: ignore[arg-type]
             else:
                 result = meta.fn(event, **inject)
             _collect_result(result, new_events, lg_interrupt)
@@ -251,7 +264,10 @@ def make_handler_node(
         new_events: list[Event] = []
         for event in matching:
             if meta.is_async:
-                result = await meta.fn(event, **inject)  # type: ignore[misc]
+                coro = cast(
+                    "Coroutine[Any, Any, HandlerReturn]", meta.fn(event, **inject)
+                )
+                result = await coro
             else:
                 result = meta.fn(event, **inject)
             _collect_result(result, new_events, lg_interrupt)

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -76,6 +76,16 @@ def describe_EventGraph():
                 log = await graph.ainvoke(Started(data="hello"))
                 assert log.latest(Ended) == Ended(result="HELLO")
 
+            @pytest.mark.asyncio
+            async def it_raises_clear_error_for_invoke_inside_running_loop():
+                @on(Started)
+                async def step(event: Started) -> Ended:
+                    return Ended(result=event.data)
+
+                graph = EventGraph([step])
+                with pytest.raises(RuntimeError, match=r"Use ainvoke\(\) instead"):
+                    graph.invoke(Started(data="hello"))
+
         def describe_branching():
 
             class InputReceived(Event):
@@ -239,8 +249,8 @@ def describe_EventGraph():
             def it_prevents_mutation_from_corrupting_graph_state():
                 @on(Started)
                 def evil_handler(event: Started, log: EventLog) -> Processed:
-                    log._events.append(Ended(result="INJECTED"))
-                    log._events.clear()
+                    with pytest.raises(AttributeError):
+                        log._events.append(Ended(result="INJECTED"))  # type: ignore[attr-defined]
                     return Processed(data="honest")
 
                 @on(Processed)
@@ -282,7 +292,8 @@ def describe_EventGraph():
 
                 @on(Triggered)
                 def handler_a(event: Triggered, log: EventLog) -> ResultAProduced:
-                    log._events.append(Ended(result="from_a"))
+                    with pytest.raises(AttributeError):
+                        log._events.append(Ended(result="from_a"))  # type: ignore[attr-defined]
                     return ResultAProduced(saw_events=len(log))
 
                 @on(Triggered)
@@ -595,6 +606,28 @@ def describe_EventGraph():
                 graph = EventGraph([step], store=store)
                 log = graph.invoke(Started(data="hello"))
                 assert log.latest(Ended) == Ended(result="hello")
+
+            def it_raises_when_store_not_configured_for_sync_handler():
+                from langgraph.store.base import BaseStore
+
+                @on(Started)
+                def step(event: Started, store: BaseStore) -> Ended:
+                    return Ended(result="ok")
+
+                graph = EventGraph([step])
+                with pytest.raises(ValueError, match="no store is configured"):
+                    graph.invoke(Started(data="hello"))
+
+            async def it_raises_when_store_not_configured_for_async_handler():
+                from langgraph.store.base import BaseStore
+
+                @on(Started)
+                async def step(event: Started, store: BaseStore) -> Ended:
+                    return Ended(result="ok")
+
+                graph = EventGraph([step])
+                with pytest.raises(ValueError, match="no store is configured"):
+                    await graph.ainvoke(Started(data="hello"))
 
         def when_handler_requests_neither():
 

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -212,10 +212,11 @@ def describe_EventLog():
 
     def describe_from_owned():
 
-        def it_shares_the_same_list_object():
+        def it_normalizes_to_immutable_tuple_storage():
             events = [Alpha(v=1), Beta(v=2)]
             log = EventLog._from_owned(events)
-            assert log._events is events
+            assert isinstance(log._events, tuple)
+            assert log._events == tuple(events)
 
         def it_produces_functionally_identical_log():
             events = [Alpha(v=1), Beta(v=2), Alpha(v=3)]

--- a/tests/test_on_decorator.py
+++ b/tests/test_on_decorator.py
@@ -235,4 +235,5 @@ def describe_return_hint_parsing():
                 assert any(
                     "Failed to resolve return type hints" in msg for msg in messages
                 )
+                assert all(item.filename == __file__ for item in w)
                 assert "-->|handler| ?" in graph.mermaid()

--- a/tests/test_on_decorator.py
+++ b/tests/test_on_decorator.py
@@ -4,7 +4,7 @@ import warnings
 
 import pytest
 
-from langgraph_events import Event, EventLog, on
+from langgraph_events import Event, EventGraph, EventLog, on
 from langgraph_events._handler import extract_handler_meta
 
 
@@ -194,3 +194,45 @@ def describe_extract_handler_meta():
             meta = extract_handler_meta(handler)
             assert meta.event_types == (EventA, EventB)
             assert meta.wants_log is True
+
+    def when_type_hints_cannot_be_resolved():
+
+        def it_warns_and_falls_back_to_signature_only_detection():
+            @on(SampleEvent)
+            def handler(event: SampleEvent, log: EventLog) -> None:
+                pass
+
+            handler.__annotations__["event"] = "MissingEvent"
+            handler.__annotations__["log"] = "MissingLog"
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                meta = extract_handler_meta(handler)
+
+            assert len(w) == 1
+            assert "Failed to resolve type hints" in str(w[0].message)
+            assert meta.log_param is None
+            assert meta.event_types == (SampleEvent,)
+
+
+def describe_return_hint_parsing():
+
+    def when_return_type_hints_cannot_be_resolved():
+
+        def it_warns_and_treats_handler_as_unannotated():
+            @on(SampleEvent)
+            def handler(event: SampleEvent) -> SampleEvent:
+                return SampleEvent()
+
+            handler.__annotations__["return"] = "MissingReturnEvent"
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                graph = EventGraph([handler])
+
+                messages = [str(item.message) for item in w]
+                assert any("Failed to resolve type hints" in msg for msg in messages)
+                assert any(
+                    "Failed to resolve return type hints" in msg for msg in messages
+                )
+                assert "-->|handler| ?" in graph.mermaid()


### PR DESCRIPTION
## Summary
- fail fast when a handler requests `BaseStore` but no runtime store is configured, and make async-in-sync `invoke()` loop detection robust without relying on exception message parsing
- strengthen `EventLog` immutability by storing events as tuples internally while preserving existing list-like slice semantics
- add warnings when handler/return type hints cannot be resolved, align README injection docs with actual behavior, and add regression tests for all new behaviors

## Validation
- `uv run pytest tests/`
- `uv run ruff check src/ tests/`
- `uv run mypy src/`