### PR TITLE
Fix new interrupts created during resume being silently dropped

### DIFF
--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -433,7 +433,7 @@ class AGUIAdapter:
             )
 
         # Detect interrupts from checkpoint state
-        if not is_resume and not emitted_interrupt_in_stream:
+        if not emitted_interrupt_in_stream:
             snapshot = await self._aget_checkpoint_snapshot(config)
             interrupt_events = (
                 self._interrupts_from_snapshot(snapshot) if snapshot is not None else []

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -799,6 +799,45 @@ def describe_AGUIAdapter():
                 ]
                 assert len(interrupted_events) == 0
 
+            async def it_emits_new_interrupted_event_created_during_resume():
+                @on(UserAsked)
+                def ask(event: UserAsked) -> ApprovalRequested:
+                    return ApprovalRequested(draft="walkthrough preference")
+
+                @on(ApprovalGiven)
+                def request_persona_review(event: ApprovalGiven) -> ApprovalRequested:
+                    return ApprovalRequested(draft="persona review")
+
+                graph = EventGraph(
+                    [ask, request_persona_review],
+                    checkpointer=MemorySaver(),
+                )
+
+                # First run creates an interrupt.
+                config = {"configurable": {"thread_id": "t-resume-new-interrupt"}}
+                await graph.ainvoke(UserAsked(question="go"), config=config)
+
+                # Resume creates a new interrupt, which is suppressed
+                # in-stream and must be detected from the post-stream
+                # checkpoint read.
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="unused"),
+                    resume_factory=lambda inp: ApprovalGiven(approved=True),
+                )
+                events = await _collect(
+                    adapter, _make_input(thread_id="t-resume-new-interrupt")
+                )
+
+                interrupted_events = [
+                    e
+                    for e in events
+                    if e.type == EventType.CUSTOM and e.name == "interrupted"
+                ]
+                assert len(interrupted_events) == 1
+                assert interrupted_events[0].value["draft"] == "persona review"
+                assert events[-1].type == EventType.RUN_FINISHED
+
             def when_stream_emits_interrupt():
 
                 async def it_skips_post_stream_checkpoint_read(


### PR DESCRIPTION
## Summary
- Removed the overly broad `not is_resume` guard on post-stream checkpoint reads in `AGUIAdapter`, which prevented detection of new interrupts that arise during a resume
- The existing `emitted_interrupt_in_stream` flag and `snapshot.next` check are sufficient to prevent duplicate/stale interrupt emission
- Added test for multi-step interrupt chains where resuming one interrupt creates another

## Test plan
- [x] New test `it_emits_new_interrupted_event_created_during_resume` covers the bug scenario
- [x] Existing test `it_does_not_emit_interrupted_during_successful_resume` confirms no regression
- [x] Existing test `it_skips_post_stream_checkpoint_read` confirms no duplicate emissions
- [x] All 265 tests passing, lint/mypy/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)