### PR TITLE
Add first-class StateSnapshotFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,15 @@ from langgraph_events import (
     CustomEventFrame,
     LLMStreamEnd,
     LLMToken,
+    STATE_SNAPSHOT_EVENT_NAME,
+    StateSnapshotFrame,
+    emit_state_snapshot,
     emit_custom,
 )
 
 @on(SeedEvent)
 def step(event: SeedEvent) -> ReplyProduced:
+    emit_state_snapshot({"messages": [], "step": "draft"})
     emit_custom("tool.progress", {"pct": 50})
     return ReplyProduced(...)
 
@@ -194,6 +198,8 @@ async for item in graph.astream_events(
         print(item.content, end="")
     elif isinstance(item, LLMStreamEnd):
         print("\n[done]", item.message_id)
+    elif isinstance(item, StateSnapshotFrame):
+        print("snapshot:", item.data)
     elif isinstance(item, CustomEventFrame):
         print("custom:", item.name, item.data)
     else:
@@ -209,7 +215,7 @@ for chunk in compiled.stream({"events": [SeedEvent(...)]}, stream_mode="updates"
 
 `max_rounds` (default: 100) prevents infinite loops — the library auto-sets LangGraph's `recursion_limit` so this is the only knob you need. Override via `invoke(seed, recursion_limit=N)` if needed. All methods have async counterparts: `ainvoke()`, `astream_events()`, `aresume()`, `astream_resume()`. Use `include_llm_tokens=True` for LLM token frames and `include_custom_events=True` for `CustomEventFrame` passthrough.
 
-Use `emit_custom(name, data)` (or `await aemit_custom(name, data)` in async handlers) to emit stream-only telemetry from handlers without importing LangGraph callback APIs directly.
+Use `emit_state_snapshot(data)` / `await aemit_state_snapshot(data)` for typed snapshot frames, and `emit_custom(name, data)` / `await aemit_custom(name, data)` for all other stream-only telemetry without importing LangGraph callback APIs directly. `STATE_SNAPSHOT_EVENT_NAME` is exported for protocol-level integrations.
 
 #### Visualizing the Event Flow
 
@@ -477,9 +483,9 @@ A supervisor handler fires on task and specialist completions, using tool-callin
 | `EventGraph.invoke()` | Method | Run graph synchronously, returns `EventLog` |
 | `EventGraph.ainvoke()` | Method | Async version of `invoke()` |
 | `EventGraph.stream_events()` | Method | Yield events as produced; optional reducer snapshots via `StreamFrame` |
-| `EventGraph.astream_events()` | Method | Async version of `stream_events()`; supports `include_llm_tokens=True` (`LLMToken`/`LLMStreamEnd`) and `include_custom_events=True` (`CustomEventFrame`) |
+| `EventGraph.astream_events()` | Method | Async version of `stream_events()`; supports `include_llm_tokens=True` (`LLMToken`/`LLMStreamEnd`) and `include_custom_events=True` (`CustomEventFrame`/`StateSnapshotFrame`) |
 | `EventGraph.stream_resume()` | Method | Yield events during resume; streaming equivalent of `resume()` |
-| `EventGraph.astream_resume()` | Method | Async version of `stream_resume()`; supports `include_llm_tokens=True` (`LLMToken`/`LLMStreamEnd`) and `include_custom_events=True` (`CustomEventFrame`) |
+| `EventGraph.astream_resume()` | Method | Async version of `stream_resume()`; supports `include_llm_tokens=True` (`LLMToken`/`LLMStreamEnd`) and `include_custom_events=True` (`CustomEventFrame`/`StateSnapshotFrame`) |
 | `EventGraph.resume()` | Method | Resume interrupted graph with a domain event (requires checkpointer) |
 | `EventGraph.aresume()` | Method | Async version of `resume()` |
 | `EventGraph.get_state()` | Method | Get `GraphState` for a checkpointed thread |
@@ -488,6 +494,9 @@ A supervisor handler fires on task and specialist completions, using tool-callin
 | `EventGraph.mermaid()` | Method | Return a Mermaid flowchart of event correlations |
 | `emit_custom`    | Function   | Emit a LangGraph custom stream event from a handler |
 | `aemit_custom`   | Function   | Async variant of `emit_custom` for async handlers |
+| `emit_state_snapshot` | Function | Emit a typed state snapshot stream frame from a handler |
+| `aemit_state_snapshot` | Function | Async variant of `emit_state_snapshot` for async handlers |
+| `STATE_SNAPSHOT_EVENT_NAME` | Constant | Protocol name used for snapshot custom events (`"intermediate_state"`) |
 | `EventLog`        | Class      | Immutable query container over events           |
 | `GraphState`      | NamedTuple | `(events, is_interrupted, interrupted)` from `get_state()` |
 | `Halted`          | Event      | Signal immediate graph termination              |
@@ -503,6 +512,7 @@ A supervisor handler fires on task and specialist completions, using tool-callin
 | `LLMToken`        | NamedTuple | `(run_id, content)` token delta yielded by async streams with `include_llm_tokens=True` |
 | `LLMStreamEnd`    | NamedTuple | `(run_id, message_id)` marker yielded when an LLM stream completes |
 | `CustomEventFrame` | NamedTuple | `(name, data)` custom payload yielded from LangGraph `on_custom_event` with `include_custom_events=True` |
+| `StateSnapshotFrame` | NamedTuple | `(data)` typed snapshot frame yielded when `on_custom_event` uses `STATE_SNAPSHOT_EVENT_NAME` |
 | `SystemPromptSet` | Event      | Built-in `MessageEvent` for system prompts      |
 | `langgraph_events.agui` | Subpackage | AG-UI protocol adapter (requires `[agui]` extra) |
 | `AGUIAdapter`     | Class      | Map EventGraph streams to AG-UI protocol events |
@@ -597,10 +607,9 @@ Events without `agui_dict()` are skipped with a one-time warning.
 
 `StreamFrame` reducer data is emitted outside the mapper chain as `StateSnapshot` and `MessagesSnapshot` events (when `include_reducers` is enabled).
 
-`CustomEventFrame` passthrough is also handled outside the mapper chain:
+`StateSnapshotFrame` is handled outside the mapper chain as AG-UI `StateSnapshot`.
 
-- name=`"intermediate_state"` → `StateSnapshot`
-- any other name → AG-UI `CustomEvent` with `name`/`value` copied through
+`CustomEventFrame` passthrough is also handled outside the mapper chain as AG-UI `CustomEvent` with `name`/`value` copied through.
 
 The adapter also emits lifecycle events automatically: `RunStarted` at the beginning, `RunFinished` at the end (or `RunError` on exception).
 

--- a/src/langgraph_events/__init__.py
+++ b/src/langgraph_events/__init__.py
@@ -1,6 +1,12 @@
 """langgraph-events — Opinionated event-driven abstraction for LangGraph."""
 
-from langgraph_events._custom_event import aemit_custom, emit_custom
+from langgraph_events._custom_event import (
+    STATE_SNAPSHOT_EVENT_NAME,
+    aemit_custom,
+    aemit_state_snapshot,
+    emit_custom,
+    emit_state_snapshot,
+)
 from langgraph_events._event import (
     Auditable,
     Event,
@@ -18,6 +24,7 @@ from langgraph_events._graph import (
     GraphState,
     LLMStreamEnd,
     LLMToken,
+    StateSnapshotFrame,
     StreamFrame,
 )
 from langgraph_events._handler import on
@@ -27,6 +34,7 @@ from langgraph_events._types import (
 )
 
 __all__ = [
+    "STATE_SNAPSHOT_EVENT_NAME",
     "Auditable",
     "CustomEventFrame",
     "Event",
@@ -42,10 +50,13 @@ __all__ = [
     "Resumed",
     "ScalarReducer",
     "Scatter",
+    "StateSnapshotFrame",
     "StreamFrame",
     "SystemPromptSet",
     "aemit_custom",
+    "aemit_state_snapshot",
     "emit_custom",
+    "emit_state_snapshot",
     "message_reducer",
     "on",
 ]

--- a/src/langgraph_events/_custom_event.py
+++ b/src/langgraph_events/_custom_event.py
@@ -10,6 +10,8 @@ from collections.abc import Awaitable, Callable
 from contextvars import ContextVar, Token
 from typing import Any
 
+STATE_SNAPSHOT_EVENT_NAME = "intermediate_state"
+
 _SyncEmitter = Callable[[str, Any], None]
 _AsyncEmitter = Callable[[str, Any], Awaitable[None]]
 
@@ -47,7 +49,8 @@ def _require_sync_emitter() -> _SyncEmitter:
     emitter = _SYNC_EMITTER.get()
     if emitter is None:
         raise RuntimeError(
-            "emit_custom() can only be called while an EventGraph handler is running."
+            "Custom emission helpers can only be called while an EventGraph "
+            "handler is running."
         )
     return emitter
 
@@ -56,7 +59,8 @@ def _require_async_emitter() -> _AsyncEmitter:
     emitter = _ASYNC_EMITTER.get()
     if emitter is None:
         raise RuntimeError(
-            "aemit_custom() can only be called while an EventGraph handler is running."
+            "Custom emission helpers can only be called while an EventGraph "
+            "handler is running."
         )
     return emitter
 
@@ -73,3 +77,13 @@ def emit_custom(name: str, data: Any) -> None:
 async def aemit_custom(name: str, data: Any) -> None:
     """Async variant of ``emit_custom`` for async handlers."""
     await _require_async_emitter()(name, data)
+
+
+def emit_state_snapshot(data: dict[str, Any]) -> None:
+    """Emit a typed state snapshot frame from inside a handler."""
+    _require_sync_emitter()(STATE_SNAPSHOT_EVENT_NAME, data)
+
+
+async def aemit_state_snapshot(data: dict[str, Any]) -> None:
+    """Async variant of ``emit_state_snapshot`` for async handlers."""
+    await _require_async_emitter()(STATE_SNAPSHOT_EVENT_NAME, data)

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import typing
 import warnings
-from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict
+from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict, cast
 
 from langgraph.graph import END, START, StateGraph
 
+from langgraph_events._custom_event import STATE_SNAPSHOT_EVENT_NAME
 from langgraph_events._event import Event, Interrupted, Resumed, Scatter
 from langgraph_events._event_log import EventLog
 from langgraph_events._handler import HandlerMeta, extract_handler_meta
@@ -126,6 +127,28 @@ class CustomEventFrame(NamedTuple):
 
     name: str
     data: Any
+
+
+class StateSnapshotFrame(NamedTuple):
+    """A typed state snapshot custom frame emitted from v2 stream events."""
+
+    data: dict[str, Any]
+
+
+StreamItem = (
+    Event
+    | StreamFrame
+    | LLMToken
+    | LLMStreamEnd
+    | CustomEventFrame
+    | StateSnapshotFrame
+)
+
+
+def _coerce_snapshot_data(data: Any) -> dict[str, Any]:
+    if isinstance(data, dict):
+        return cast("dict[str, Any]", data)
+    return {}
 
 
 class EventGraph:
@@ -320,7 +343,8 @@ class EventGraph:
             reducer_fields: dict[str, Any] = {"events": list[Event]}
             for name, r in self._reducers.items():
                 reducer_fields[name] = r.output_type()
-            out_schema = TypedDict("_OutputWithReducers", reducer_fields)  # type: ignore[misc,no-redef]
+            _OutputWithReducers = TypedDict("_OutputWithReducers", reducer_fields)  # type: ignore[misc]
+            out_schema = _OutputWithReducers
 
         graph: StateGraph[Any] = StateGraph(
             state_schema,
@@ -333,13 +357,13 @@ class EventGraph:
         router_node = make_router_node(self._max_rounds)
         dispatch_fn = make_dispatch(self._handler_metas)
 
-        graph.add_node("__seed__", seed_node)  # type: ignore[call-overload]
-        graph.add_node("__router__", router_node)  # type: ignore[call-overload]
+        graph.add_node("__seed__", cast("Any", seed_node))
+        graph.add_node("__router__", cast("Any", router_node))
 
         handler_names: list[str] = []
         for meta in self._handler_metas:
             handler_node = make_handler_node(meta, reducers=self._reducers)
-            graph.add_node(meta.name, handler_node)
+            graph.add_node(meta.name, cast("Any", handler_node))
             handler_names.append(meta.name)
 
         # --- edges ---
@@ -476,8 +500,9 @@ class EventGraph:
             r = self._reducers[name]
             contribution = r.collect([event])
             if r.has_contributions(contribution):
-                if hasattr(r, "reducer"):
-                    state[name] = r.reducer(state[name], contribution)
+                reducer_fn = getattr(r, "reducer", None)
+                if callable(reducer_fn):
+                    state[name] = reducer_fn(state[name], contribution)
                 else:
                     state[name] = contribution
 
@@ -539,9 +564,7 @@ class EventGraph:
         include_llm_tokens: bool,
         include_custom_events: bool,
         **kwargs: Any,
-    ) -> AsyncIterator[
-        Event | StreamFrame | LLMToken | LLMStreamEnd | CustomEventFrame
-    ]:
+    ) -> AsyncIterator[StreamItem]:
         """Stream events using LangGraph's v2 event API with LLM token support."""
         compiled = self._compile()
 
@@ -590,10 +613,15 @@ class EventGraph:
             if raw_event == "on_custom_event":
                 if not include_custom_events:
                     continue
-                yield CustomEventFrame(
-                    name=raw.get("name", ""),
-                    data=raw.get("data"),
-                )
+                if raw.get("name", "") == STATE_SNAPSHOT_EVENT_NAME:
+                    yield StateSnapshotFrame(
+                        data=_coerce_snapshot_data(raw.get("data")),
+                    )
+                else:
+                    yield CustomEventFrame(
+                        name=raw.get("name", ""),
+                        data=raw.get("data"),
+                    )
                 continue
 
             if raw_event != "on_chain_stream" or raw.get("name") != "LangGraph":
@@ -720,9 +748,7 @@ class EventGraph:
         include_llm_tokens: bool = False,
         include_custom_events: bool = False,
         **kwargs: Any,
-    ) -> AsyncIterator[
-        Event | StreamFrame | LLMToken | LLMStreamEnd | CustomEventFrame
-    ]:
+    ) -> AsyncIterator[StreamItem]:
         """Async version of ``stream_resume()``.
 
         Streaming equivalent of ``aresume()`` — accepts a domain ``Event``,
@@ -736,7 +762,8 @@ class EventGraph:
             include_llm_tokens: When True, yields ``LLMToken`` and
                 ``LLMStreamEnd`` frames for LLM token-level streaming.
             include_custom_events: When True, yields ``CustomEventFrame``
-                frames for ``on_custom_event`` payloads from LangGraph.
+                and ``StateSnapshotFrame`` frames for ``on_custom_event`` payloads
+                from LangGraph.
         """
         self._require_checkpointer("astream_resume")
         from langgraph.types import Command  # noqa: PLC0415
@@ -768,9 +795,7 @@ class EventGraph:
         include_llm_tokens: bool = False,
         include_custom_events: bool = False,
         **kwargs: Any,
-    ) -> AsyncIterator[
-        Event | StreamFrame | LLMToken | LLMStreamEnd | CustomEventFrame
-    ]:
+    ) -> AsyncIterator[StreamItem]:
         """Async version of ``stream_events()``.
 
         Args:
@@ -781,7 +806,8 @@ class EventGraph:
             include_llm_tokens: When True, yields ``LLMToken`` and
                 ``LLMStreamEnd`` frames for LLM token-level streaming.
             include_custom_events: When True, yields ``CustomEventFrame``
-                frames for ``on_custom_event`` payloads from LangGraph.
+                and ``StateSnapshotFrame`` frames for ``on_custom_event`` payloads
+                from LangGraph.
         """
         inp = self._prepare_input(seed)
         seeds = inp["events"]

--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -24,7 +24,9 @@ from langgraph_events._graph import (
     CustomEventFrame,
     LLMStreamEnd,
     LLMToken,
+    StateSnapshotFrame,
     StreamFrame,
+    StreamItem,
 )
 
 from ._context import MapperContext
@@ -54,7 +56,6 @@ if TYPE_CHECKING:
 
     from ag_ui.core import RunAgentInput
 
-    from langgraph_events._event import Event
     from langgraph_events._graph import EventGraph
 
     from ._protocols import EventMapper, ResumeFactory, SeedFactory
@@ -257,9 +258,7 @@ class AGUIAdapter:
         checkpoint_state: CheckpointState | None,
         resume_event: Any,
         config: Any,
-    ) -> AsyncIterator[
-        Event | StreamFrame | LLMToken | LLMStreamEnd | CustomEventFrame
-    ]:
+    ) -> AsyncIterator[StreamItem]:
         """Create the underlying EventGraph async event stream."""
         if resume_event is not None:
             return self._graph.astream_resume(
@@ -411,15 +410,14 @@ class AGUIAdapter:
             elif isinstance(item, LLMStreamEnd):
                 for agui_event in self._events_from_llm_stream_end(item, ctx):
                     yield agui_event
+            elif isinstance(item, StateSnapshotFrame):
+                yield build_state_snapshot(item.data)
             elif isinstance(item, CustomEventFrame):
-                if item.name == "intermediate_state":
-                    yield build_state_snapshot(item.data)
-                else:
-                    yield CustomEvent(
-                        type=EventType.CUSTOM,
-                        name=item.name,
-                        value=item.data,
-                    )
+                yield CustomEvent(
+                    type=EventType.CUSTOM,
+                    name=item.name,
+                    value=item.data,
+                )
             elif isinstance(item, StreamFrame):
                 agui_events, next_message_ids, emitted_interrupt = (
                     self._events_from_stream_frame(

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -1304,8 +1304,8 @@ def describe_config_passthrough():
 
 
 def describe_custom_event_passthrough():
-    async def it_maps_intermediate_state_to_state_snapshot(monkeypatch):
-        from langgraph_events._graph import CustomEventFrame
+    async def it_maps_state_snapshot_frame_to_state_snapshot(monkeypatch):
+        from langgraph_events._graph import StateSnapshotFrame
 
         @on(UserAsked)
         def reply(event: UserAsked) -> AgentReplied:
@@ -1336,10 +1336,7 @@ def describe_custom_event_passthrough():
                 include_custom_events,
                 config,
             )
-            yield CustomEventFrame(
-                name="intermediate_state",
-                data={"messages": [], "step": "draft"},
-            )
+            yield StateSnapshotFrame(data={"messages": [], "step": "draft"})
 
         monkeypatch.setattr(graph, "astream_events", fake_astream_events)
 
@@ -1356,6 +1353,53 @@ def describe_custom_event_passthrough():
         assert calls[0]["include_custom_events"] is True
         assert len(snapshots) == 1
         assert snapshots[0].snapshot == {"messages": [], "step": "draft"}
+
+    async def it_passes_intermediate_state_custom_event_frame_through(monkeypatch):
+        from langgraph_events._custom_event import STATE_SNAPSHOT_EVENT_NAME
+        from langgraph_events._graph import CustomEventFrame
+
+        @on(UserAsked)
+        def reply(event: UserAsked) -> AgentReplied:
+            return AgentReplied(message=AIMessage(content="ok"))
+
+        graph = EventGraph([reply])
+
+        async def fake_astream_events(
+            seed,
+            *,
+            include_reducers,
+            include_llm_tokens,
+            include_custom_events,
+            config,
+        ):
+            del (
+                seed,
+                include_reducers,
+                include_llm_tokens,
+                include_custom_events,
+                config,
+            )
+            yield CustomEventFrame(
+                name=STATE_SNAPSHOT_EVENT_NAME,
+                data={"messages": [], "step": "draft"},
+            )
+
+        monkeypatch.setattr(graph, "astream_events", fake_astream_events)
+
+        adapter = AGUIAdapter(
+            graph=graph,
+            seed_factory=lambda inp: UserAsked(question="go"),
+        )
+
+        events = await _collect(adapter, _make_input())
+        custom_events = [
+            e
+            for e in events
+            if e.type == EventType.CUSTOM and e.name == STATE_SNAPSHOT_EVENT_NAME
+        ]
+
+        assert len(custom_events) == 1
+        assert custom_events[0].value == {"messages": [], "step": "draft"}
 
     async def it_maps_custom_event_frame_to_custom_event(monkeypatch):
         from langgraph_events._graph import CustomEventFrame

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -10,6 +10,7 @@ from langchain_core.messages import (
 )
 
 from langgraph_events import (
+    STATE_SNAPSHOT_EVENT_NAME,
     Event,
     EventGraph,
     EventLog,
@@ -20,10 +21,13 @@ from langgraph_events import (
     Resumed,
     ScalarReducer,
     Scatter,
+    StateSnapshotFrame,
     StreamFrame,
     SystemPromptSet,
     aemit_custom,
+    aemit_state_snapshot,
     emit_custom,
+    emit_state_snapshot,
     message_reducer,
     on,
 )
@@ -2719,14 +2723,63 @@ def describe_EventGraph():
                 assert custom_frames[0].name == "tool.progress"
                 assert custom_frames[0].data == {"pct": 80}
 
+            @pytest.mark.asyncio
+            async def it_emits_state_snapshot_frames_from_sync_handler():
+                @on(Started)
+                def step(event: Started) -> Ended:
+                    emit_state_snapshot({"step": "draft"})
+                    return Ended(result=event.data)
+
+                graph = EventGraph([step])
+                items = [
+                    item
+                    async for item in graph.astream_events(
+                        Started(data="hello"),
+                        include_custom_events=True,
+                    )
+                ]
+
+                snapshots = [i for i in items if isinstance(i, StateSnapshotFrame)]
+                assert len(snapshots) == 1
+                assert snapshots[0].data == {"step": "draft"}
+
+            @pytest.mark.asyncio
+            async def it_emits_state_snapshot_frames_from_async_handler():
+                @on(Started)
+                async def step(event: Started) -> Ended:
+                    await aemit_state_snapshot({"step": "review"})
+                    return Ended(result=event.data)
+
+                graph = EventGraph([step])
+                items = [
+                    item
+                    async for item in graph.astream_events(
+                        Started(data="hello"),
+                        include_custom_events=True,
+                    )
+                ]
+
+                snapshots = [i for i in items if isinstance(i, StateSnapshotFrame)]
+                assert len(snapshots) == 1
+                assert snapshots[0].data == {"step": "review"}
+
             def it_raises_for_emit_custom_outside_handler():
                 with pytest.raises(RuntimeError, match="while an EventGraph handler"):
                     emit_custom("tool.progress", {"pct": 1})
+
+            def it_raises_for_emit_state_snapshot_outside_handler():
+                with pytest.raises(RuntimeError, match="while an EventGraph handler"):
+                    emit_state_snapshot({"step": "x"})
 
             @pytest.mark.asyncio
             async def it_raises_for_aemit_custom_outside_handler():
                 with pytest.raises(RuntimeError, match="while an EventGraph handler"):
                     await aemit_custom("tool.progress", {"pct": 1})
+
+            @pytest.mark.asyncio
+            async def it_raises_for_aemit_state_snapshot_outside_handler():
+                with pytest.raises(RuntimeError, match="while an EventGraph handler"):
+                    await aemit_state_snapshot({"step": "x"})
 
         @pytest.mark.asyncio
         async def it_yields_llm_token_and_stream_end_frames():
@@ -2864,7 +2917,7 @@ def describe_EventGraph():
 
         @pytest.mark.asyncio
         async def it_yields_custom_event_frames_from_v2_custom_events(monkeypatch):
-            from langgraph_events._graph import CustomEventFrame
+            from langgraph_events._graph import CustomEventFrame, StateSnapshotFrame
 
             @on(Started)
             def step(event: Started) -> Ended:
@@ -2878,6 +2931,11 @@ def describe_EventGraph():
                     "event": "on_custom_event",
                     "name": "progress",
                     "data": {"pct": 50},
+                }
+                yield {
+                    "event": "on_custom_event",
+                    "name": STATE_SNAPSHOT_EVENT_NAME,
+                    "data": {"step": "draft"},
                 }
 
             monkeypatch.setattr(graph.compiled, "astream_events", fake_astream_events)
@@ -2895,6 +2953,10 @@ def describe_EventGraph():
             assert len(custom_frames) == 1
             assert custom_frames[0].name == "progress"
             assert custom_frames[0].data == {"pct": 50}
+
+            snapshots = [i for i in items if isinstance(i, StateSnapshotFrame)]
+            assert len(snapshots) == 1
+            assert snapshots[0].data == {"step": "draft"}
 
         @pytest.mark.asyncio
         async def it_does_not_yield_custom_event_frames_by_default(monkeypatch):


### PR DESCRIPTION
## Summary
- Promotes state snapshots from a magic-string convention (`emit_custom("intermediate_state", data)`) to a typed `StateSnapshotFrame` with dedicated `emit_state_snapshot` / `aemit_state_snapshot` helpers
- AG-UI adapter now branches on frame type (`isinstance`) instead of checking `item.name == "intermediate_state"`
- Adds `StreamItem` type alias to reduce union type duplication across return annotations
- Generalizes emitter error messages so `emit_state_snapshot` outside a handler doesn't confusingly reference `emit_custom`

## Test plan
- [x] `uv run pytest tests/` — all 281 tests pass
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [ ] Verify `StateSnapshotFrame` is importable from `langgraph_events`
- [ ] Verify `emit_state_snapshot` produces `StateSnapshotFrame` in `astream_events(include_custom_events=True)`
- [ ] Verify `CustomEventFrame(name="intermediate_state", ...)` is now treated as a regular custom event in the adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)