### PR TITLE
Fix streaming message ID mismatch in AG-UI MessagesSnapshot

### DIFF
--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -311,6 +311,8 @@ class AGUIAdapter:
         closed_id = ctx.close_stream_message_id(item.run_id)
         if closed_id is None:
             return []
+        if item.message_id:
+            ctx.record_lc_to_stream_id(item.message_id, closed_id)
         return [
             TextMessageEndEvent(
                 type=EventType.TEXT_MESSAGE_END,
@@ -340,7 +342,9 @@ class AGUIAdapter:
             )
             if changed:
                 next_message_ids = tuple(getattr(m, "id", id(m)) for m in messages)
-                events.append(build_messages_snapshot(messages))
+                events.append(
+                    build_messages_snapshot(messages, id_overrides=ctx.lc_id_overrides)
+                )
 
         events.extend(self._map_event(event, ctx))
         return events, next_message_ids, self._is_interrupt(event)

--- a/src/langgraph_events/agui/_context.py
+++ b/src/langgraph_events/agui/_context.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import dataclasses
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from ag_ui.core import RunAgentInput
 
 
@@ -80,9 +83,9 @@ class MapperContext:
         self._lc_to_stream_id[lc_message_id] = stream_id
 
     @property
-    def lc_id_overrides(self) -> dict[str, str]:
-        """LangChain message ID -> AG-UI streaming ID overrides."""
-        return self._lc_to_stream_id
+    def lc_id_overrides(self) -> Mapping[str, str]:
+        """LangChain message ID -> AG-UI streaming ID overrides (read-only)."""
+        return MappingProxyType(self._lc_to_stream_id)
 
     def mark_streamed_ai_message(self, message_id: str) -> None:
         """Remember a LangChain AI message id that was token-streamed."""

--- a/src/langgraph_events/agui/_context.py
+++ b/src/langgraph_events/agui/_context.py
@@ -31,6 +31,10 @@ class MapperContext:
         default_factory=set,
         repr=False,
     )
+    _lc_to_stream_id: dict[str, str] = dataclasses.field(
+        default_factory=dict,
+        repr=False,
+    )
 
     def next_message_id(self) -> str:
         """Return a monotonically increasing message ID for this stream."""
@@ -70,6 +74,15 @@ class MapperContext:
             self._stream_message_ids.pop(run_id, None)
         self._open_stream_runs.clear()
         return message_ids
+
+    def record_lc_to_stream_id(self, lc_message_id: str, stream_id: str) -> None:
+        """Map a LangChain message ID to its AG-UI streaming message ID."""
+        self._lc_to_stream_id[lc_message_id] = stream_id
+
+    @property
+    def lc_id_overrides(self) -> dict[str, str]:
+        """LangChain message ID -> AG-UI streaming ID overrides."""
+        return self._lc_to_stream_id
 
     def mark_streamed_ai_message(self, message_id: str) -> None:
         """Remember a LangChain AI message id that was token-streamed."""

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -32,6 +32,8 @@ from langgraph_events._event import (
 from ._protocols import AGUICustomEvent, AGUISerializable
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from ag_ui.core import Message
 
     from ._context import MapperContext
@@ -54,7 +56,7 @@ def _warn_missing_agui_dict(cls: type) -> None:
 def _langchain_to_agui_messages(
     messages: list[Any],
     *,
-    id_overrides: dict[str, str] | None = None,
+    id_overrides: Mapping[str, str] | None = None,
 ) -> list[Message]:
     """Convert LangChain BaseMessage list to AG-UI Message format."""
     from ag_ui.core import (  # noqa: PLC0415
@@ -263,7 +265,7 @@ def build_state_snapshot(reducers: dict[str, Any]) -> StateSnapshotEvent:
 def build_messages_snapshot(
     messages: list[Any],
     *,
-    id_overrides: dict[str, str] | None = None,
+    id_overrides: Mapping[str, str] | None = None,
 ) -> MessagesSnapshotEvent:
     """Build a MessagesSnapshotEvent from a LangChain message list."""
     return MessagesSnapshotEvent(

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -51,7 +51,11 @@ def _warn_missing_agui_dict(cls: type) -> None:
         )
 
 
-def _langchain_to_agui_messages(messages: list[Any]) -> list[Message]:
+def _langchain_to_agui_messages(
+    messages: list[Any],
+    *,
+    id_overrides: dict[str, str] | None = None,
+) -> list[Message]:
     """Convert LangChain BaseMessage list to AG-UI Message format."""
     from ag_ui.core import (  # noqa: PLC0415
         AssistantMessage,
@@ -65,7 +69,8 @@ def _langchain_to_agui_messages(messages: list[Any]) -> list[Message]:
     result: list[Message] = []
     for msg in messages:
         msg_type = msg.type
-        msg_id = getattr(msg, "id", None) or ""
+        raw_id = getattr(msg, "id", None) or ""
+        msg_id = id_overrides.get(raw_id, raw_id) if id_overrides and raw_id else raw_id
         if msg_type == "human":
             result.append(UserMessage(id=msg_id, role="user", content=msg.content))
         elif msg_type == "ai":
@@ -257,9 +262,11 @@ def build_state_snapshot(reducers: dict[str, Any]) -> StateSnapshotEvent:
 
 def build_messages_snapshot(
     messages: list[Any],
+    *,
+    id_overrides: dict[str, str] | None = None,
 ) -> MessagesSnapshotEvent:
     """Build a MessagesSnapshotEvent from a LangChain message list."""
     return MessagesSnapshotEvent(
         type=EventType.MESSAGES_SNAPSHOT,
-        messages=_langchain_to_agui_messages(messages),
+        messages=_langchain_to_agui_messages(messages, id_overrides=id_overrides),
     )

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -62,6 +62,9 @@ class AgentAndToolMessages(MessageEvent):
 class UserSent(MessageEvent):
     message: HumanMessage = None  # type: ignore[assignment]
 
+    def agui_dict(self) -> dict[str, Any]:
+        return {"content": self.message.content if self.message else ""}
+
 
 class FollowUpReply(MessageEvent):
     message: AIMessage = None  # type: ignore[assignment]
@@ -2063,3 +2066,47 @@ def describe_streaming_id_reconciliation():
         assert len(ai_msgs) == 2
         assert ai_msgs[0].id == stream_id_1
         assert ai_msgs[1].id == stream_id_2
+
+    async def it_records_mapping_before_snapshot_containing_ai_message():
+        """LLMStreamEnd must precede the StreamFrame that carries the AI message.
+
+        This guarantees the LC->stream ID mapping is recorded before the
+        snapshot is built.  If this ordering invariant ever breaks, the
+        snapshot would carry a stale LangChain ID.
+        """
+        llm = FakeListChatModel(responses=["ordering check"], sleep=0)
+
+        @on(UserAsked)
+        async def stream_reply(
+            event: UserAsked,
+            messages: list[Any],
+        ) -> AgentReplied:
+            response = await llm.ainvoke(
+                [*messages, HumanMessage(content=event.question)]
+            )
+            return AgentReplied(message=response)
+
+        graph = EventGraph([stream_reply], reducers=[message_reducer()])
+        adapter = AGUIAdapter(
+            graph=graph,
+            seed_factory=lambda inp: UserAsked(question="go"),
+            include_reducers=True,
+        )
+        events = await _collect(adapter, _make_input())
+
+        # Find positions: TEXT_MESSAGE_END (emitted from LLMStreamEnd) must
+        # appear before the first MESSAGES_SNAPSHOT that contains an assistant.
+        end_idx = next(
+            i for i, e in enumerate(events) if e.type == EventType.TEXT_MESSAGE_END
+        )
+        snap_indices = [
+            i
+            for i, e in enumerate(events)
+            if e.type == EventType.MESSAGES_SNAPSHOT
+            and any(m.role == "assistant" for m in e.messages)
+        ]
+        assert snap_indices, "Expected at least one snapshot with an assistant message"
+        assert end_idx < snap_indices[0], (
+            "TextMessageEnd (from LLMStreamEnd) must precede the first "
+            "MessagesSnapshot containing the AI message"
+        )

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -59,6 +59,14 @@ class AgentAndToolMessages(MessageEvent):
     messages: tuple[Any, ...] = ()
 
 
+class UserSent(MessageEvent):
+    message: HumanMessage = None  # type: ignore[assignment]
+
+
+class FollowUpReply(MessageEvent):
+    message: AIMessage = None  # type: ignore[assignment]
+
+
 class TaskCreated(Event):
     title: str = ""
 
@@ -1922,3 +1930,136 @@ def describe_MapperContext():
         second_id, is_new_second = ctx.ensure_stream_message_id("llm-run")
         assert is_new_second is True
         assert second_id == "msg-2"
+
+    def it_records_lc_to_stream_id_mapping():
+        ctx = MapperContext(
+            run_id="r1",
+            thread_id="t1",
+            input_data=_make_input(),
+        )
+        ctx.record_lc_to_stream_id("lc-run-123", "msg-1")
+        ctx.record_lc_to_stream_id("lc-run-456", "msg-2")
+        assert ctx.lc_id_overrides == {
+            "lc-run-123": "msg-1",
+            "lc-run-456": "msg-2",
+        }
+
+
+def describe_streaming_id_reconciliation():
+    """Snapshot message IDs must match streaming event IDs."""
+
+    async def it_uses_streaming_ids_in_messages_snapshot():
+        """AI message ID in MessagesSnapshot must match TextMessageStart ID."""
+        llm = FakeListChatModel(responses=["reconcile me"], sleep=0)
+
+        @on(UserAsked)
+        async def stream_reply(
+            event: UserAsked,
+            messages: list[Any],
+        ) -> AgentReplied:
+            response = await llm.ainvoke(
+                [*messages, HumanMessage(content=event.question)]
+            )
+            return AgentReplied(message=response)
+
+        graph = EventGraph([stream_reply], reducers=[message_reducer()])
+        adapter = AGUIAdapter(
+            graph=graph,
+            seed_factory=lambda inp: UserAsked(question="go"),
+            include_reducers=True,
+        )
+        events = await _collect(adapter, _make_input())
+
+        starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+        assert len(starts) == 1
+        stream_msg_id = starts[0].message_id
+
+        msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+        assert len(msg_snapshots) >= 1
+        last_snap = msg_snapshots[-1]
+        ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+        assert len(ai_msgs) >= 1
+        # Key assertion: snapshot ID matches streaming ID
+        assert ai_msgs[-1].id == stream_msg_id
+
+    async def it_preserves_non_streamed_message_ids():
+        """Human messages in snapshot keep their LangChain IDs."""
+        llm = FakeListChatModel(responses=["reply"], sleep=0)
+
+        @on(UserSent)
+        async def stream_reply(
+            event: UserSent,
+            messages: list[Any],
+        ) -> AgentReplied:
+            response = await llm.ainvoke(messages)
+            return AgentReplied(message=response)
+
+        graph = EventGraph([stream_reply], reducers=[message_reducer()])
+        adapter = AGUIAdapter(
+            graph=graph,
+            seed_factory=lambda inp: UserSent(
+                message=HumanMessage(content="hello", id="human-1")
+            ),
+            include_reducers=True,
+        )
+        events = await _collect(adapter, _make_input())
+
+        msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+        assert len(msg_snapshots) >= 1
+        last_snap = msg_snapshots[-1]
+
+        human_msgs = [m for m in last_snap.messages if m.role == "user"]
+        assert len(human_msgs) >= 1
+        # Human message keeps its original LangChain ID
+        assert human_msgs[0].id == "human-1"
+
+        # AI message uses the streaming ID, not LangChain's
+        stream_msg_id = next(
+            e for e in events if e.type == EventType.TEXT_MESSAGE_START
+        ).message_id
+        ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+        assert len(ai_msgs) >= 1
+        assert ai_msgs[-1].id == stream_msg_id
+
+    async def it_reconciles_ids_across_multiple_llm_calls():
+        """Each streamed AI message gets its own consistent ID mapping."""
+        llm = FakeListChatModel(responses=["first reply", "second reply"], sleep=0)
+
+        @on(UserAsked)
+        async def first_reply(
+            event: UserAsked,
+            messages: list[Any],
+        ) -> AgentReplied:
+            response = await llm.ainvoke(
+                [*messages, HumanMessage(content=event.question)]
+            )
+            return AgentReplied(message=response)
+
+        @on(AgentReplied)
+        async def second_reply(
+            event: AgentReplied,
+            messages: list[Any],
+        ) -> FollowUpReply:
+            response = await llm.ainvoke([*messages, HumanMessage(content="follow up")])
+            return FollowUpReply(message=response)
+
+        graph = EventGraph([first_reply, second_reply], reducers=[message_reducer()])
+        adapter = AGUIAdapter(
+            graph=graph,
+            seed_factory=lambda inp: UserAsked(question="go"),
+            include_reducers=True,
+        )
+        events = await _collect(adapter, _make_input())
+
+        starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+        assert len(starts) == 2
+        stream_id_1 = starts[0].message_id
+        stream_id_2 = starts[1].message_id
+
+        msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+        assert len(msg_snapshots) >= 1
+        last_snap = msg_snapshots[-1]
+        ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+        assert len(ai_msgs) == 2
+        assert ai_msgs[0].id == stream_id_1
+        assert ai_msgs[1].id == stream_id_2


### PR DESCRIPTION
## Summary

- CopilotKit showed duplicate AI messages because streaming events used generated IDs (`msg-1`) while `MessagesSnapshotEvent` used LangChain's native `AIMessage.id` (`lc_run--xxx`)
- Added a LangChain-to-streaming ID mapping in `MapperContext` — recorded when `LLMStreamEnd` fires, applied when building `MessagesSnapshotEvent`
- Non-streamed messages (human, tool, checkpoint-loaded AI) keep their original IDs

## Test plan

- [x] 4 new tests: unit test for mapping API, 3 integration tests (single message, mixed types, multiple LLM calls)
- [x] Full suite passes (287 passed)
- [x] ruff check + ruff format clean
- [x] mypy strict clean
- [x] Coverage 94.65% (above 92% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)