### PR TITLE
Fix AG-UI streaming ID mismatch and state snapshot duplication

### DIFF
--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -39,6 +39,13 @@ from ._mappers import (
 
 logger = logging.getLogger(__name__)
 
+_DEDICATED_EVENT_KEYS: frozenset[str] = frozenset({"messages"})
+
+
+def _strip_dedicated_keys(reducers: dict[str, Any]) -> dict[str, Any]:
+    """Return *reducers* without keys that have dedicated AG-UI events."""
+    return {k: v for k, v in reducers.items() if k not in _DEDICATED_EVENT_KEYS}
+
 
 class CheckpointState(TypedDict):
     """Checkpoint-derived state passed to seed/resume factories."""
@@ -228,7 +235,7 @@ class AGUIAdapter:
             return
 
         reducers = snapshot.values if isinstance(snapshot.values, dict) else {}
-        yield build_state_snapshot(reducers)
+        yield build_state_snapshot(_strip_dedicated_keys(reducers))
         yield build_messages_snapshot(reducers.get("messages") or [])
 
         for interrupted in self._interrupts_from_snapshot(snapshot):
@@ -332,7 +339,9 @@ class AGUIAdapter:
         if is_resume and self._is_interrupt(event):
             return [], prev_message_ids, False
 
-        events: list[BaseEvent] = [build_state_snapshot(item.reducers)]
+        events: list[BaseEvent] = [
+            build_state_snapshot(_strip_dedicated_keys(item.reducers))
+        ]
         messages = item.reducers.get("messages")
         next_message_ids = prev_message_ids
         if messages is not None:
@@ -389,7 +398,7 @@ class AGUIAdapter:
         # Interrupt gate: re-emit state without executing when interrupted
         if self._should_gate_with_checkpoint_replay(resume_event, checkpoint_state):
             state = cast("CheckpointState", checkpoint_state)
-            yield build_state_snapshot(state["reducers"])
+            yield build_state_snapshot(_strip_dedicated_keys(state["reducers"]))
             messages = state["messages"]
             if messages is not None:
                 yield build_messages_snapshot(messages)

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -514,8 +514,39 @@ def describe_AGUIAdapter():
 
                 snapshots = [e for e in events if e.type == EventType.STATE_SNAPSHOT]
                 assert len(snapshots) >= 1
-                # Snapshot should contain messages key
-                assert "messages" in snapshots[-1].snapshot
+                # Snapshot should not duplicate dedicated messages channel
+                assert "messages" not in snapshots[-1].snapshot
+
+            async def it_excludes_messages_from_state_snapshot():
+                @on(UserAsked)
+                def reply(event: UserAsked) -> AgentReplied:
+                    return AgentReplied(message=AIMessage(content="hello"))
+
+                graph = EventGraph(
+                    [reply],
+                    reducers=[message_reducer()],
+                )
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="hi"),
+                    include_reducers=True,
+                )
+                events = await _collect(adapter, _make_input())
+
+                state_snapshots = [
+                    e for e in events if e.type == EventType.STATE_SNAPSHOT
+                ]
+                message_snapshots = [
+                    e for e in events if e.type == EventType.MESSAGES_SNAPSHOT
+                ]
+
+                assert len(state_snapshots) >= 1
+                assert all(
+                    "messages" not in snapshot.snapshot for snapshot in state_snapshots
+                )
+                assert len(message_snapshots) >= 1
+                assert isinstance(message_snapshots[-1].messages, list)
+                assert len(message_snapshots[-1].messages) >= 1
 
         def when_messages_reducer_present():
             async def it_emits_messages_snapshot():


### PR DESCRIPTION
## Summary

- **ID reconciliation**: Streaming events used generated IDs (msg-1) while MessagesSnapshotEvent used LangChain's native AIMessage.id. Adds a LangChain-to-streaming ID mapping in MapperContext and applies it when building snapshots, so CopilotKit sees consistent IDs.
- **State snapshot deduplication**: Messages were sent twice per frame — once in StateSnapshotEvent (full reducers dict) and again in MessagesSnapshotEvent. Adds `_strip_dedicated_keys()` to remove keys that have dedicated AG-UI event types from the state snapshot, with a generic `_DEDICATED_EVENT_KEYS` frozenset for extensibility. The `StateSnapshotFrame` path (user-controlled via `emit_state_snapshot()`) is left unfiltered.

## Test plan

- [x] Existing tests pass (65 passed)
- [x] New test `it_excludes_messages_from_state_snapshot` verifies no StateSnapshotEvent contains messages
- [x] Existing `it_emits_state_snapshot` assertion flipped to confirm messages excluded
- [x] ID reconciliation tests verify streaming IDs match snapshot IDs
- [x] Ordering guard test ensures LLMStreamEnd precedes snapshot with AI message
- [x] `StateSnapshotFrame` test still asserts user-controlled data passes through unfiltered
- [x] ruff, mypy, pytest all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)