### PR TITLE
Fix duplicate message emission across multiple MessageEvents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,4 +21,4 @@ Event-driven abstraction for LangGraph. State IS events.
 - Use `uv` to run all tooling (not bare `python` or `pytest`)
 - Ruff for linting and formatting (config in pyproject.toml)
 - mypy strict mode
-- Tests: `describe_` groups by API surface, `when_` mirrors code branches, `it_` names the assertion. Test each behavior once at the API boundary where it's consumed. Shared event classes in `conftest.py`; scenario-specific events inline.
+- Tests: `describe_` groups by API surface, `when_` mirrors code branches, `it_` names the assertion. Test each behavior once at the API boundary where it's consumed. Shared event classes in `conftest.py`; scenario-specific events inline. Event classes used as handler type annotations must be defined at module level (not inside `describe_`/`when_` blocks) so Python can resolve forward references at runtime.

--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -315,6 +315,7 @@ class AGUIAdapter:
     ) -> list[BaseEvent]:
         if item.message_id:
             ctx.mark_streamed_ai_message(item.message_id)
+            ctx.mark_emitted_message(item.message_id)
         closed_id = ctx.close_stream_message_id(item.run_id)
         if closed_id is None:
             return []

--- a/src/langgraph_events/agui/_context.py
+++ b/src/langgraph_events/agui/_context.py
@@ -38,6 +38,10 @@ class MapperContext:
         default_factory=dict,
         repr=False,
     )
+    _emitted_message_ids: set[str] = dataclasses.field(
+        default_factory=set,
+        repr=False,
+    )
 
     def next_message_id(self) -> str:
         """Return a monotonically increasing message ID for this stream."""
@@ -86,6 +90,16 @@ class MapperContext:
     def lc_id_overrides(self) -> Mapping[str, str]:
         """LangChain message ID -> AG-UI streaming ID overrides (read-only)."""
         return MappingProxyType(self._lc_to_stream_id)
+
+    def mark_emitted_message(self, message_id: str) -> None:
+        """Remember a LangChain message id emitted by MessageEventMapper."""
+        self._emitted_message_ids.add(message_id)
+
+    def was_emitted_message(self, message_id: str | None) -> bool:
+        """Whether this LangChain message id was already emitted by a mapper."""
+        if not message_id:
+            return False
+        return message_id in self._emitted_message_ids
 
     def mark_streamed_ai_message(self, message_id: str) -> None:
         """Remember a LangChain AI message id that was token-streamed."""

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -152,7 +152,10 @@ class MessageEventMapper:
 
         result: list[BaseEvent] = []
         for msg in ai_messages:
-            if ctx.was_streamed_ai_message(getattr(msg, "id", None)):
+            lc_msg_id = getattr(msg, "id", None)
+            if ctx.was_streamed_ai_message(lc_msg_id):
+                continue
+            if ctx.was_emitted_message(lc_msg_id):
                 continue
             msg_id = ctx.next_message_id()
 
@@ -209,7 +212,13 @@ class MessageEventMapper:
                         )
                     )
 
+            if lc_msg_id:
+                ctx.mark_emitted_message(lc_msg_id)
+
         for msg in tool_messages:
+            lc_msg_id = getattr(msg, "id", None)
+            if ctx.was_emitted_message(lc_msg_id):
+                continue
             result.append(
                 ToolCallResultEvent(
                     type=EventType.TOOL_CALL_RESULT,
@@ -219,6 +228,8 @@ class MessageEventMapper:
                     role="tool",
                 )
             )
+            if lc_msg_id:
+                ctx.mark_emitted_message(lc_msg_id)
 
         return result
 

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -91,6 +91,14 @@ class ApprovalGiven(Event):
         return {"approved": self.approved}
 
 
+class PhaseA(MessageEvent):
+    messages: tuple[Any, ...] = ()
+
+
+class PhaseB(MessageEvent):
+    messages: tuple[Any, ...] = ()
+
+
 class ErrorTrigger(Event):
     def agui_dict(self) -> dict[str, Any]:
         return {}
@@ -1893,6 +1901,126 @@ def describe_ai_message_dedup():
         starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
         # Exactly one start — from streaming, not doubled by mapper
         assert len(starts) == 1
+
+
+def describe_message_event_dedup():
+    """Multiple MessageEvents carrying the same AI message must not duplicate."""
+
+    def when_same_ai_id_across_events():
+        async def it_emits_text_message_start_once():
+            shared_ai = AIMessage(content="hello", id="ai-shared")
+
+            @on(UserAsked)
+            def step1(event: UserAsked) -> PhaseA:
+                return PhaseA(messages=(shared_ai,))
+
+            @on(PhaseA)
+            def step2(event: PhaseA) -> PhaseB:
+                return PhaseB(messages=(shared_ai,))
+
+            graph = EventGraph([step1, step2])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+            assert len(starts) == 1
+
+    def when_streamed_ai_reappears_via_message_event():
+        async def it_does_not_reemit():
+            llm = FakeListChatModel(responses=["streamed"], sleep=0)
+
+            @on(UserAsked)
+            async def stream_then_wrap(
+                event: UserAsked,
+                messages: list[Any],
+            ) -> PhaseA:
+                response = await llm.ainvoke(
+                    [*messages, HumanMessage(content=event.question)]
+                )
+                return PhaseA(messages=(response,))
+
+            graph = EventGraph([stream_then_wrap], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+                include_reducers=True,
+            )
+            events = await _collect(adapter, _make_input())
+
+            starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+            assert len(starts) == 1
+
+    def without_message_ids():
+        async def it_emits_both_because_dedup_cannot_apply():
+            no_id = AIMessage(content="no id", id=None)
+
+            @on(UserAsked)
+            def step1(event: UserAsked) -> PhaseA:
+                return PhaseA(messages=(no_id,))
+
+            @on(PhaseA)
+            def step2(event: PhaseA) -> PhaseB:
+                return PhaseB(messages=(no_id,))
+
+            graph = EventGraph([step1, step2])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+            assert len(starts) == 2
+
+    def when_distinct_ai_ids_across_events():
+        async def it_emits_both():
+            ai1 = AIMessage(content="first", id="ai-1")
+            ai2 = AIMessage(content="second", id="ai-2")
+
+            @on(UserAsked)
+            def step1(event: UserAsked) -> PhaseA:
+                return PhaseA(messages=(ai1,))
+
+            @on(PhaseA)
+            def step2(event: PhaseA) -> PhaseB:
+                return PhaseB(messages=(ai2,))
+
+            graph = EventGraph([step1, step2])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+            assert len(starts) == 2
+
+    def when_same_tool_message_id_across_events():
+        async def it_emits_tool_call_result_once():
+            shared_tool = ToolMessage(
+                content="result", tool_call_id="tc-1", id="tool-shared"
+            )
+
+            @on(UserAsked)
+            def step1(event: UserAsked) -> PhaseA:
+                return PhaseA(messages=(shared_tool,))
+
+            @on(PhaseA)
+            def step2(event: PhaseA) -> PhaseB:
+                return PhaseB(messages=(shared_tool,))
+
+            graph = EventGraph([step1, step2])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            results = [e for e in events if e.type == EventType.TOOL_CALL_RESULT]
+            assert len(results) == 1
 
 
 def describe_llm_streaming_on_resume():


### PR DESCRIPTION
## Summary

- When multiple `MessageEvent` subclasses fire in the same AG-UI stream carrying the same AI or tool message (e.g. checkpoint-loaded history on resume), `MessageEventMapper` emitted duplicate `TextMessage`/`ToolCallResult` events
- Adds a unified `_emitted_message_ids` registry in `MapperContext` that tracks all LangChain message IDs emitted by the mapper, preventing re-emission for both AI text and tool messages
- Streamed AI messages are also registered in the emitted set at stream end, ensuring they aren't re-emitted if they later reappear via a `MessageEvent`

## Test plan

- [x] `when_same_ai_id_across_events` — same AI message ID from two events emits once
- [x] `when_streamed_ai_reappears_via_message_event` — token-streamed AI not re-emitted
- [x] `without_message_ids` — messages with no ID still emit (no false dedup)
- [x] `when_distinct_ai_ids_across_events` — different IDs both emit
- [x] `when_same_tool_message_id_across_events` — same tool message ID from two events emits once
- [x] All 71 existing tests pass, mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)