### PR TITLE
Deduplicate AGUI snapshots using reducer deltas

### DIFF
--- a/docs/agui.md
+++ b/docs/agui.md
@@ -90,6 +90,13 @@ Events without `agui_dict()` are skipped with a one-time warning.
 
 `StreamFrame` reducer data is emitted outside the mapper chain as `StateSnapshot` and `MessagesSnapshot` events (when `include_reducers` is enabled).
 
+When reducer delta metadata is available (`StreamFrame.changed_reducers`, emitted by `EventGraph` v2 streaming), the adapter suppresses redundant snapshots:
+
+- `MessagesSnapshot` is emitted only when the `messages` reducer changed.
+- `StateSnapshot` is emitted once initially, then only when non-dedicated reducers changed.
+
+For compatibility with legacy/value-mode frames where delta metadata is unavailable, the adapter falls back to its prior message-change detection behavior.
+
 `StateSnapshotFrame` is handled outside the mapper chain as AG-UI `StateSnapshot`.
 
 `CustomEventFrame` passthrough is also handled outside the mapper chain as AG-UI `CustomEvent` with `name`/`value` copied through.

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -106,6 +106,7 @@ class StreamFrame(NamedTuple):
 
     event: Event
     reducers: dict[str, list[Any]]
+    changed_reducers: frozenset[str] | None = None
 
 
 class LLMToken(NamedTuple):
@@ -494,8 +495,9 @@ class EventGraph:
         state: dict[str, Any],
         event: Event,
         reducer_names: list[str],
-    ) -> None:
+    ) -> frozenset[str]:
         """Incrementally update reducer state with a single new event."""
+        changed: set[str] = set()
         for name in reducer_names:
             r = self._reducers[name]
             contribution = r.collect([event])
@@ -505,6 +507,8 @@ class EventGraph:
                     state[name] = reducer_fn(state[name], contribution)
                 else:
                     state[name] = contribution
+                changed.add(name)
+        return frozenset(changed)
 
     # --- High-level event streaming ---
 
@@ -552,7 +556,8 @@ class EventGraph:
             name: state.get(name, self._reducers[name].empty) for name in reducer_names
         }
         return len(all_events), [
-            StreamFrame(event=e, reducers=reducers) for e in new_events
+            StreamFrame(event=e, reducers=reducers, changed_reducers=None)
+            for e in new_events
         ]
 
     async def _astream_v2(  # noqa: PLR0912
@@ -576,7 +581,18 @@ class EventGraph:
         # Yield seed events
         for s in seeds:
             if reducer_names:
-                yield StreamFrame(event=s, reducers=dict(reducer_state))
+                changed = frozenset(
+                    name
+                    for name in reducer_names
+                    if self._reducers[name].has_contributions(
+                        self._reducers[name].collect([s])
+                    )
+                )
+                yield StreamFrame(
+                    event=s,
+                    reducers=dict(reducer_state),
+                    changed_reducers=changed,
+                )
             else:
                 yield s
 
@@ -630,8 +646,16 @@ class EventGraph:
             chunk = raw.get("data", {}).get("chunk")
             for event in self._events_from_chunk(chunk, seen):
                 if reducer_names:
-                    self._update_reducer_state(reducer_state, event, reducer_names)
-                    yield StreamFrame(event=event, reducers=dict(reducer_state))
+                    changed = self._update_reducer_state(
+                        reducer_state,
+                        event,
+                        reducer_names,
+                    )
+                    yield StreamFrame(
+                        event=event,
+                        reducers=dict(reducer_state),
+                        changed_reducers=changed,
+                    )
                 else:
                     yield event
 

--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -335,21 +335,36 @@ class AGUIAdapter:
         *,
         is_resume: bool,
         prev_message_ids: tuple[int | str, ...],
-    ) -> tuple[list[BaseEvent], tuple[int | str, ...], bool]:
+        state_snapshot_emitted: bool,
+    ) -> tuple[list[BaseEvent], tuple[int | str, ...], bool, bool]:
         event = item.event
         if is_resume and self._is_interrupt(event):
-            return [], prev_message_ids, False
+            return [], prev_message_ids, False, state_snapshot_emitted
 
-        events: list[BaseEvent] = [
-            build_state_snapshot(_strip_dedicated_keys(item.reducers))
-        ]
+        events: list[BaseEvent] = []
         messages = item.reducers.get("messages")
         next_message_ids = prev_message_ids
-        if messages is not None:
-            changed = len(messages) != len(prev_message_ids) or any(
-                getattr(m, "id", id(m)) != pid
-                for m, pid in zip(messages, prev_message_ids, strict=True)
+        changed_reducers = item.changed_reducers
+        should_emit_state_snapshot = not state_snapshot_emitted
+        if changed_reducers is None:
+            should_emit_state_snapshot = True
+        else:
+            should_emit_state_snapshot = should_emit_state_snapshot or any(
+                name not in _DEDICATED_EVENT_KEYS for name in changed_reducers
             )
+
+        if should_emit_state_snapshot:
+            events.append(build_state_snapshot(_strip_dedicated_keys(item.reducers)))
+            state_snapshot_emitted = True
+
+        if messages is not None:
+            if changed_reducers is None:
+                changed = len(messages) != len(prev_message_ids) or any(
+                    getattr(m, "id", id(m)) != pid
+                    for m, pid in zip(messages, prev_message_ids, strict=True)
+                )
+            else:
+                changed = "messages" in changed_reducers
             if changed:
                 next_message_ids = tuple(getattr(m, "id", id(m)) for m in messages)
                 events.append(
@@ -357,7 +372,12 @@ class AGUIAdapter:
                 )
 
         events.extend(self._map_event(event, ctx))
-        return events, next_message_ids, self._is_interrupt(event)
+        return (
+            events,
+            next_message_ids,
+            self._is_interrupt(event),
+            state_snapshot_emitted,
+        )
 
     def _events_from_bare_item(
         self,
@@ -395,6 +415,7 @@ class AGUIAdapter:
         is_resume = resume_event is not None
         prev_message_ids: tuple[int | str, ...] = ()
         emitted_interrupt_in_stream = False
+        emitted_state_snapshot = False
 
         # Interrupt gate: re-emit state without executing when interrupted
         if self._should_gate_with_checkpoint_replay(resume_event, checkpoint_state):
@@ -431,13 +452,17 @@ class AGUIAdapter:
                     value=item.data,
                 )
             elif isinstance(item, StreamFrame):
-                agui_events, next_message_ids, emitted_interrupt = (
-                    self._events_from_stream_frame(
-                        item,
-                        ctx,
-                        is_resume=is_resume,
-                        prev_message_ids=prev_message_ids,
-                    )
+                (
+                    agui_events,
+                    next_message_ids,
+                    emitted_interrupt,
+                    emitted_state_snapshot,
+                ) = self._events_from_stream_frame(
+                    item,
+                    ctx,
+                    is_resume=is_resume,
+                    prev_message_ids=prev_message_ids,
+                    state_snapshot_emitted=emitted_state_snapshot,
                 )
                 prev_message_ids = next_message_ids
                 emitted_interrupt_in_stream = (

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -629,7 +629,10 @@ def describe_AGUIAdapter():
                 msg_count = sum(
                     1 for e in events if e.type == EventType.MESSAGES_SNAPSHOT
                 )
-                assert state_count > msg_count
+                # With StreamFrame.changed_reducers, state snapshots are only
+                # emitted initially (or when non-dedicated reducers change).
+                assert state_count == 1
+                assert msg_count == 1
 
             async def it_detects_message_content_changes():
                 """MessagesSnapshot emits when add_messages replaces in-place."""

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -2046,6 +2046,8 @@ def describe_EventGraph():
                     )
                 )
                 assert all(isinstance(f, StreamFrame) for f in frames)
+                # values-mode frames (sync API) do not track reducer deltas
+                assert all(f.changed_reducers is None for f in frames)
                 types = [type(f.event).__name__ for f in frames]
                 assert "Started" in types
                 assert "Processed" in types
@@ -2918,6 +2920,38 @@ def describe_EventGraph():
             assert len(tokens) >= 1
             # Frames should have reducer data
             assert all("messages" in f.reducers for f in frames)
+            # v2 reducer frames track which reducers changed per event
+            assert all(f.changed_reducers is not None for f in frames)
+            assert "messages" in frames[0].changed_reducers
+            assert "messages" in frames[-1].changed_reducers
+
+        @pytest.mark.asyncio
+        async def it_reports_empty_changed_reducers_for_non_matching_events():
+            reducer = _data_reducer()
+
+            @on(Started)
+            def step1(event: Started) -> Processed:
+                return Processed(data=f"mid:{event.data}")
+
+            @on(Processed)
+            def step2(event: Processed) -> Ended:
+                return Ended(result=event.data)
+
+            graph = EventGraph([step1, step2], reducers=[reducer])
+            items = [
+                item
+                async for item in graph.astream_events(
+                    Started(data="x"),
+                    include_reducers=True,
+                    include_llm_tokens=True,
+                )
+            ]
+
+            frames = [i for i in items if isinstance(i, StreamFrame)]
+            assert len(frames) >= 3
+            assert frames[0].changed_reducers == frozenset({"data_items"})
+            # Processed/Ended are not Started events, so reducer is unchanged.
+            assert all(f.changed_reducers == frozenset() for f in frames[1:])
 
         @pytest.mark.asyncio
         async def it_omits_tokens_by_default():


### PR DESCRIPTION
## Summary
- add optional `changed_reducers` metadata to `StreamFrame` and populate it in EventGraph v2 streaming paths
- use reducer-delta metadata in `AGUIAdapter` to emit `MessagesSnapshot` only when `messages` changes and `StateSnapshot` only initially or when non-dedicated reducers change
- keep compatibility fallback for legacy/value-mode frames, update docs, and extend AGUI/EventGraph tests for delta semantics and dedup behavior

## Why
AGUI snapshot emission previously relied on repeated list/id scans and emitted redundant snapshots, especially when reducers were unchanged. This change lets the adapter consume reducer change signals directly from the stream source, reducing redundant loops and snapshot churn while preserving behavior for older frame shapes.

## Validation
- `uv run pytest tests/`