### PR TITLE
Fix ID reconciliation for non-streamed AI messages

### DIFF
--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -343,6 +343,11 @@ class AGUIAdapter:
         events: list[BaseEvent] = [
             build_state_snapshot(_strip_dedicated_keys(item.reducers))
         ]
+
+        # Map event FIRST — registers lc_to_stream_id for mapper-emitted AI msgs
+        mapped_events = self._map_event(event, ctx)
+
+        # THEN build messages snapshot with complete ID mappings
         messages = item.reducers.get("messages")
         next_message_ids = prev_message_ids
         if messages is not None:
@@ -356,7 +361,7 @@ class AGUIAdapter:
                     build_messages_snapshot(messages, id_overrides=ctx.lc_id_overrides)
                 )
 
-        events.extend(self._map_event(event, ctx))
+        events.extend(mapped_events)
         return events, next_message_ids, self._is_interrupt(event)
 
     def _events_from_bare_item(

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -213,6 +213,7 @@ class MessageEventMapper:
                     )
 
             if lc_msg_id:
+                ctx.record_lc_to_stream_id(lc_msg_id, msg_id)
                 ctx.mark_emitted_message(lc_msg_id)
 
         for msg in tool_messages:

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -153,14 +153,19 @@ class MessageEventMapper:
         result: list[BaseEvent] = []
         for msg in ai_messages:
             lc_msg_id = getattr(msg, "id", None)
-            if ctx.was_streamed_ai_message(lc_msg_id):
+            if ctx.was_streamed_ai_message(lc_msg_id) or ctx.was_emitted_message(
+                lc_msg_id
+            ):
                 continue
-            if ctx.was_emitted_message(lc_msg_id):
+
+            content = msg.content if isinstance(msg.content, str) else ""
+            tool_calls = getattr(msg, "tool_calls", None)
+            if not content and not tool_calls:
                 continue
+
             msg_id = ctx.next_message_id()
 
             # Text content
-            content = msg.content if isinstance(msg.content, str) else ""
             if content:
                 result.append(
                     TextMessageStartEvent(
@@ -184,7 +189,6 @@ class MessageEventMapper:
                 )
 
             # Tool calls
-            tool_calls = getattr(msg, "tool_calls", None)
             if tool_calls:
                 for tc in tool_calls:
                     tc_id = tc.get("id", "") if isinstance(tc, dict) else tc.id

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -2332,3 +2332,35 @@ def describe_non_streamed_id_reconciliation():
             ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
             snapshot_ids = {m.id for m in ai_msgs}
             assert snapshot_ids == text_ids
+
+    def when_ai_message_has_no_content_or_tool_calls():
+        async def it_does_not_create_orphan_id_override():
+            """Empty AI message must not register an override."""
+            empty_ai = AIMessage(content="", id="lc-empty")
+
+            @on(UserAsked)
+            def emit(event: UserAsked) -> PhaseA:
+                return PhaseA(messages=(empty_ai,))
+
+            graph = EventGraph([emit], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+                include_reducers=True,
+            )
+            events = await _collect(adapter, _make_input())
+
+            # No TextMessageStart should have been emitted
+            starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+            assert len(starts) == 0
+
+            # Snapshot should keep the original LC ID, not rewrite to an orphan msg-*
+            snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+            assert len(snapshots) >= 1
+            last_snap = snapshots[-1]
+            ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+            for m in ai_msgs:
+                assert not m.id.startswith("msg-"), (
+                    f"Orphan override: snapshot rewrote to {m.id} with no "
+                    f"corresponding TextMessageStart"
+                )

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -2269,3 +2269,66 @@ def describe_streaming_id_reconciliation():
             "TextMessageEnd (from LLMStreamEnd) must precede the first "
             "MessagesSnapshot containing the AI message"
         )
+
+
+def describe_non_streamed_id_reconciliation():
+    """Snapshot IDs must match mapper-generated IDs for non-streamed AI messages."""
+
+    def when_non_streamed_ai_message():
+        async def it_reconciles_mapper_emitted_ids_in_snapshot():
+            """Non-streamed AI message ID in snapshot must match TextMessageStart ID."""
+            ai = AIMessage(content="from history", id="lc-ai-1")
+
+            @on(UserAsked)
+            def emit(event: UserAsked) -> PhaseA:
+                return PhaseA(messages=(ai,))
+
+            graph = EventGraph([emit], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+                include_reducers=True,
+            )
+            events = await _collect(adapter, _make_input())
+
+            starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+            assert len(starts) == 1
+            text_msg_id = starts[0].message_id
+
+            snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+            assert len(snapshots) >= 1
+            last_snap = snapshots[-1]
+            ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+            assert len(ai_msgs) == 1
+            assert ai_msgs[0].id == text_msg_id
+
+    def when_multiple_non_streamed_ai_messages():
+        async def it_reconciles_all_mapper_emitted_ids():
+            ai1 = AIMessage(content="first", id="lc-ai-1")
+            ai2 = AIMessage(content="second", id="lc-ai-2")
+
+            @on(UserAsked)
+            def step1(event: UserAsked) -> PhaseA:
+                return PhaseA(messages=(ai1,))
+
+            @on(PhaseA)
+            def step2(event: PhaseA) -> PhaseB:
+                return PhaseB(messages=(ai2,))
+
+            graph = EventGraph([step1, step2], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+                include_reducers=True,
+            )
+            events = await _collect(adapter, _make_input())
+
+            starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+            assert len(starts) == 2
+            text_ids = {s.message_id for s in starts}
+
+            snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+            last_snap = snapshots[-1]
+            ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+            snapshot_ids = {m.id for m in ai_msgs}
+            assert snapshot_ids == text_ids


### PR DESCRIPTION
## Summary

- `MessageEventMapper` generated AG-UI message IDs (`msg-1`, `msg-2`) for non-streamed AI messages but never called `record_lc_to_stream_id`, so `MESSAGES_SNAPSHOT` used raw LangChain IDs while `TextMessage` events used generated IDs — CopilotKit couldn't reconcile them
- `_events_from_stream_frame` built the snapshot *before* running the mapper, so even with the registration the snapshot in the same frame used stale mappings
- Fix: register `lc_to_stream_id` in the mapper for every AI message emitted, and reorder `_events_from_stream_frame` to run the mapper before building the messages snapshot

## Test plan

- [x] `when_non_streamed_ai_message::it_reconciles_mapper_emitted_ids_in_snapshot` — single non-streamed AI message ID in snapshot matches TextMessageStart ID
- [x] `when_multiple_non_streamed_ai_messages::it_reconciles_all_mapper_emitted_ids` — two non-streamed AI messages both get correct mappings
- [x] All 73 existing tests pass, mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)