### PR TITLE
Suppress MessageEventMapper when MESSAGES_SNAPSHOT delivers messages

### DIFF
--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -102,6 +102,10 @@ class AGUIAdapter:
             else False
         )
 
+        self._messages_in_reducers = "messages" in graph._resolve_reducer_names(
+            include_reducers
+        )
+
         # Build mapper chain: built-ins → user mappers → fallback
         chain: list[Any] = default_mappers()
         if mappers:
@@ -344,10 +348,11 @@ class AGUIAdapter:
             build_state_snapshot(_strip_dedicated_keys(item.reducers))
         ]
 
-        # Map event FIRST — registers lc_to_stream_id for mapper-emitted AI msgs
+        # Map event first. In snapshot_mode MessageEventMapper is a no-op;
+        # LLM-streamed id_overrides are already recorded by _events_from_llm_stream_end.
         mapped_events = self._map_event(event, ctx)
 
-        # THEN build messages snapshot with complete ID mappings
+        # Build messages snapshot with any LLM-stream ID overrides
         messages = item.reducers.get("messages")
         next_message_ids = prev_message_ids
         if messages is not None:
@@ -492,6 +497,7 @@ class AGUIAdapter:
             run_id=run_id,
             thread_id=thread_id,
             input_data=input_data,
+            snapshot_mode=self._messages_in_reducers,
         )
 
         yield RunStartedEvent(

--- a/src/langgraph_events/agui/_context.py
+++ b/src/langgraph_events/agui/_context.py
@@ -42,6 +42,7 @@ class MapperContext:
         default_factory=set,
         repr=False,
     )
+    snapshot_mode: bool = dataclasses.field(default=False, repr=False)
 
     def next_message_id(self) -> str:
         """Return a monotonically increasing message ID for this stream."""

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -141,9 +141,11 @@ class InterruptedMapper:
 class MessageEventMapper:
     """Map MessageEvent with AIMessage content to AG-UI text/tool events."""
 
-    def map(self, event: Event, ctx: MapperContext) -> list[BaseEvent] | None:
+    def map(self, event: Event, ctx: MapperContext) -> list[BaseEvent] | None:  # noqa: PLR0912
         if not isinstance(event, MessageEvent):
             return None
+        if ctx.snapshot_mode:
+            return []  # MESSAGES_SNAPSHOT handles message delivery
         messages = event.as_messages()
         ai_messages = [m for m in messages if m.type == "ai"]
         tool_messages = [m for m in messages if m.type == "tool"]

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -25,6 +25,7 @@ from langgraph_events import (
     message_reducer,
     on,
 )
+from langgraph_events._reducer import ScalarReducer
 from langgraph_events.agui import (
     AGUIAdapter,
     MapperContext,
@@ -581,6 +582,36 @@ def describe_AGUIAdapter():
                 last_snap = msg_snapshots[-1]
                 assert isinstance(last_snap.messages, list)
                 assert len(last_snap.messages) >= 1
+
+        def when_include_reducers_has_no_messages_reducer():
+            async def it_still_emits_text_message_events():
+                """Mapper must not be suppressed without messages reducer."""
+                counter = ScalarReducer(
+                    name="counter",
+                    event_type=AgentReplied,
+                    fn=lambda e: 1,
+                    default=0,
+                )
+
+                @on(UserAsked)
+                def reply(event: UserAsked) -> AgentReplied:
+                    return AgentReplied(message=AIMessage(content="hello"))
+
+                graph = EventGraph([reply], reducers=[counter])
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="hi"),
+                    include_reducers=True,
+                )
+                events = await _collect(adapter, _make_input())
+
+                starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+                assert len(starts) == 1
+
+                msg_snapshots = [
+                    e for e in events if e.type == EventType.MESSAGES_SNAPSHOT
+                ]
+                assert len(msg_snapshots) == 0
 
         def when_error_message_provided():
             async def it_uses_custom_error_message():
@@ -2272,11 +2303,11 @@ def describe_streaming_id_reconciliation():
 
 
 def describe_non_streamed_id_reconciliation():
-    """Snapshot IDs must match mapper-generated IDs for non-streamed AI messages."""
+    """Non-streamed AI messages are delivered only via MESSAGES_SNAPSHOT."""
 
     def when_non_streamed_ai_message():
-        async def it_reconciles_mapper_emitted_ids_in_snapshot():
-            """Non-streamed AI message ID in snapshot must match TextMessageStart ID."""
+        async def it_delivers_via_snapshot_only():
+            """No TextMessageStart for non-streamed AI; snapshot keeps LC ID."""
             ai = AIMessage(content="from history", id="lc-ai-1")
 
             @on(UserAsked)
@@ -2292,18 +2323,17 @@ def describe_non_streamed_id_reconciliation():
             events = await _collect(adapter, _make_input())
 
             starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
-            assert len(starts) == 1
-            text_msg_id = starts[0].message_id
+            assert len(starts) == 0
 
             snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
             assert len(snapshots) >= 1
             last_snap = snapshots[-1]
             ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
             assert len(ai_msgs) == 1
-            assert ai_msgs[0].id == text_msg_id
+            assert ai_msgs[0].id == "lc-ai-1"
 
     def when_multiple_non_streamed_ai_messages():
-        async def it_reconciles_all_mapper_emitted_ids():
+        async def it_delivers_all_via_snapshot_using_original_ids():
             ai1 = AIMessage(content="first", id="lc-ai-1")
             ai2 = AIMessage(content="second", id="lc-ai-2")
 
@@ -2324,14 +2354,13 @@ def describe_non_streamed_id_reconciliation():
             events = await _collect(adapter, _make_input())
 
             starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
-            assert len(starts) == 2
-            text_ids = {s.message_id for s in starts}
+            assert len(starts) == 0
 
             snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
             last_snap = snapshots[-1]
             ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
             snapshot_ids = {m.id for m in ai_msgs}
-            assert snapshot_ids == text_ids
+            assert snapshot_ids == {"lc-ai-1", "lc-ai-2"}
 
     def when_ai_message_has_no_content_or_tool_calls():
         async def it_does_not_create_orphan_id_override():


### PR DESCRIPTION
## Summary
- When `include_reducers` includes a messages reducer, `MessageEventMapper` is now suppressed — `MESSAGES_SNAPSHOT` becomes the sole channel for historical message delivery, eliminating the dual-channel conflict that caused duplicates and disappearing messages in CopilotKit
- LLM token streaming (`LLMToken`/`LLMStreamEnd`) still provides real-time `TextMessage` events with proper ID reconciliation in snapshots
- The `snapshot_mode` flag is gated on the messages reducer actually being present (not just `include_reducers` being truthy) to avoid silently dropping messages for configs like `include_reducers=["counter"]`

## Test plan
- [x] All 75 existing + new tests pass (`uv run pytest tests/test_agui.py -v`)
- [x] New regression test: `when_include_reducers_has_no_messages_reducer` verifies mapper is NOT suppressed when messages reducer is absent
- [x] Rewritten `describe_non_streamed_id_reconciliation` tests verify non-streamed AI messages are delivered only via snapshot with original LC IDs
- [x] Streaming ID reconciliation tests confirm LLM-streamed messages still get proper ID overrides in snapshots
- [x] Lint (`ruff check`) and type check (`mypy`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)