### PR TITLE
Remove id_overrides for cross-run ID consistency

### DIFF
--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -323,8 +323,6 @@ class AGUIAdapter:
         closed_id = ctx.close_stream_message_id(item.run_id)
         if closed_id is None:
             return []
-        if item.message_id:
-            ctx.record_lc_to_stream_id(item.message_id, closed_id)
         return [
             TextMessageEndEvent(
                 type=EventType.TEXT_MESSAGE_END,
@@ -348,11 +346,9 @@ class AGUIAdapter:
             build_state_snapshot(_strip_dedicated_keys(item.reducers))
         ]
 
-        # Map event first. In snapshot_mode MessageEventMapper is a no-op;
-        # LLM-streamed id_overrides are already recorded by _events_from_llm_stream_end.
         mapped_events = self._map_event(event, ctx)
 
-        # Build messages snapshot with any LLM-stream ID overrides
+        # Build messages snapshot — always uses original LangChain IDs
         messages = item.reducers.get("messages")
         next_message_ids = prev_message_ids
         if messages is not None:
@@ -362,9 +358,7 @@ class AGUIAdapter:
             )
             if changed:
                 next_message_ids = tuple(getattr(m, "id", id(m)) for m in messages)
-                events.append(
-                    build_messages_snapshot(messages, id_overrides=ctx.lc_id_overrides)
-                )
+                events.append(build_messages_snapshot(messages))
 
         events.extend(mapped_events)
         return events, next_message_ids, self._is_interrupt(event)

--- a/src/langgraph_events/agui/_context.py
+++ b/src/langgraph_events/agui/_context.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 
 import dataclasses
-from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from ag_ui.core import RunAgentInput
 
 
@@ -32,10 +29,6 @@ class MapperContext:
     _open_stream_runs: set[str] = dataclasses.field(default_factory=set, repr=False)
     _streamed_ai_message_ids: set[str] = dataclasses.field(
         default_factory=set,
-        repr=False,
-    )
-    _lc_to_stream_id: dict[str, str] = dataclasses.field(
-        default_factory=dict,
         repr=False,
     )
     _emitted_message_ids: set[str] = dataclasses.field(
@@ -82,15 +75,6 @@ class MapperContext:
             self._stream_message_ids.pop(run_id, None)
         self._open_stream_runs.clear()
         return message_ids
-
-    def record_lc_to_stream_id(self, lc_message_id: str, stream_id: str) -> None:
-        """Map a LangChain message ID to its AG-UI streaming message ID."""
-        self._lc_to_stream_id[lc_message_id] = stream_id
-
-    @property
-    def lc_id_overrides(self) -> Mapping[str, str]:
-        """LangChain message ID -> AG-UI streaming ID overrides (read-only)."""
-        return MappingProxyType(self._lc_to_stream_id)
 
     def mark_emitted_message(self, message_id: str) -> None:
         """Remember a LangChain message id emitted by MessageEventMapper."""

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -32,8 +32,6 @@ from langgraph_events._event import (
 from ._protocols import AGUICustomEvent, AGUISerializable
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from ag_ui.core import Message
 
     from ._context import MapperContext
@@ -55,8 +53,6 @@ def _warn_missing_agui_dict(cls: type) -> None:
 
 def _langchain_to_agui_messages(
     messages: list[Any],
-    *,
-    id_overrides: Mapping[str, str] | None = None,
 ) -> list[Message]:
     """Convert LangChain BaseMessage list to AG-UI Message format."""
     from ag_ui.core import (  # noqa: PLC0415
@@ -71,8 +67,7 @@ def _langchain_to_agui_messages(
     result: list[Message] = []
     for msg in messages:
         msg_type = msg.type
-        raw_id = getattr(msg, "id", None) or ""
-        msg_id = id_overrides.get(raw_id, raw_id) if id_overrides and raw_id else raw_id
+        msg_id = getattr(msg, "id", None) or ""
         if msg_type == "human":
             result.append(UserMessage(id=msg_id, role="user", content=msg.content))
         elif msg_type == "ai":
@@ -219,7 +214,6 @@ class MessageEventMapper:
                     )
 
             if lc_msg_id:
-                ctx.record_lc_to_stream_id(lc_msg_id, msg_id)
                 ctx.mark_emitted_message(lc_msg_id)
 
         for msg in tool_messages:
@@ -282,11 +276,9 @@ def build_state_snapshot(reducers: dict[str, Any]) -> StateSnapshotEvent:
 
 def build_messages_snapshot(
     messages: list[Any],
-    *,
-    id_overrides: Mapping[str, str] | None = None,
 ) -> MessagesSnapshotEvent:
     """Build a MessagesSnapshotEvent from a LangChain message list."""
     return MessagesSnapshotEvent(
         type=EventType.MESSAGES_SNAPSHOT,
-        messages=_langchain_to_agui_messages(messages, id_overrides=id_overrides),
+        messages=_langchain_to_agui_messages(messages),
     )

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -2124,26 +2124,13 @@ def describe_MapperContext():
         assert is_new_second is True
         assert second_id == "msg-2"
 
-    def it_records_lc_to_stream_id_mapping():
-        ctx = MapperContext(
-            run_id="r1",
-            thread_id="t1",
-            input_data=_make_input(),
-        )
-        ctx.record_lc_to_stream_id("lc-run-123", "msg-1")
-        ctx.record_lc_to_stream_id("lc-run-456", "msg-2")
-        assert ctx.lc_id_overrides == {
-            "lc-run-123": "msg-1",
-            "lc-run-456": "msg-2",
-        }
 
+def describe_snapshot_uses_langchain_ids():
+    """Snapshots use original LangChain IDs for cross-run consistency."""
 
-def describe_streaming_id_reconciliation():
-    """Snapshot message IDs must match streaming event IDs."""
-
-    async def it_uses_streaming_ids_in_messages_snapshot():
-        """AI message ID in MessagesSnapshot must match TextMessageStart ID."""
-        llm = FakeListChatModel(responses=["reconcile me"], sleep=0)
+    async def it_uses_langchain_ids_not_streaming_ids():
+        """Snapshot AI message keeps its LangChain ID, not the streaming msg-N ID."""
+        llm = FakeListChatModel(responses=["hello"], sleep=0)
 
         @on(UserAsked)
         async def stream_reply(
@@ -2172,11 +2159,12 @@ def describe_streaming_id_reconciliation():
         last_snap = msg_snapshots[-1]
         ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
         assert len(ai_msgs) >= 1
-        # Key assertion: snapshot ID matches streaming ID
-        assert ai_msgs[-1].id == stream_msg_id
+        # Snapshot uses LangChain ID, NOT the streaming ID
+        assert ai_msgs[-1].id != stream_msg_id
+        assert ai_msgs[-1].id.startswith("lc_run--")
 
-    async def it_preserves_non_streamed_message_ids():
-        """Human messages in snapshot keep their LangChain IDs."""
+    async def it_preserves_all_original_ids():
+        """All messages in snapshot keep their LangChain IDs."""
         llm = FakeListChatModel(responses=["reply"], sleep=0)
 
         @on(UserSent)
@@ -2203,103 +2191,12 @@ def describe_streaming_id_reconciliation():
 
         human_msgs = [m for m in last_snap.messages if m.role == "user"]
         assert len(human_msgs) >= 1
-        # Human message keeps its original LangChain ID
         assert human_msgs[0].id == "human-1"
 
-        # AI message uses the streaming ID, not LangChain's
-        stream_msg_id = next(
-            e for e in events if e.type == EventType.TEXT_MESSAGE_START
-        ).message_id
         ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
         assert len(ai_msgs) >= 1
-        assert ai_msgs[-1].id == stream_msg_id
-
-    async def it_reconciles_ids_across_multiple_llm_calls():
-        """Each streamed AI message gets its own consistent ID mapping."""
-        llm = FakeListChatModel(responses=["first reply", "second reply"], sleep=0)
-
-        @on(UserAsked)
-        async def first_reply(
-            event: UserAsked,
-            messages: list[Any],
-        ) -> AgentReplied:
-            response = await llm.ainvoke(
-                [*messages, HumanMessage(content=event.question)]
-            )
-            return AgentReplied(message=response)
-
-        @on(AgentReplied)
-        async def second_reply(
-            event: AgentReplied,
-            messages: list[Any],
-        ) -> FollowUpReply:
-            response = await llm.ainvoke([*messages, HumanMessage(content="follow up")])
-            return FollowUpReply(message=response)
-
-        graph = EventGraph([first_reply, second_reply], reducers=[message_reducer()])
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="go"),
-            include_reducers=True,
-        )
-        events = await _collect(adapter, _make_input())
-
-        starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
-        assert len(starts) == 2
-        stream_id_1 = starts[0].message_id
-        stream_id_2 = starts[1].message_id
-
-        msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
-        assert len(msg_snapshots) >= 1
-        last_snap = msg_snapshots[-1]
-        ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
-        assert len(ai_msgs) == 2
-        assert ai_msgs[0].id == stream_id_1
-        assert ai_msgs[1].id == stream_id_2
-
-    async def it_records_mapping_before_snapshot_containing_ai_message():
-        """LLMStreamEnd must precede the StreamFrame that carries the AI message.
-
-        This guarantees the LC->stream ID mapping is recorded before the
-        snapshot is built.  If this ordering invariant ever breaks, the
-        snapshot would carry a stale LangChain ID.
-        """
-        llm = FakeListChatModel(responses=["ordering check"], sleep=0)
-
-        @on(UserAsked)
-        async def stream_reply(
-            event: UserAsked,
-            messages: list[Any],
-        ) -> AgentReplied:
-            response = await llm.ainvoke(
-                [*messages, HumanMessage(content=event.question)]
-            )
-            return AgentReplied(message=response)
-
-        graph = EventGraph([stream_reply], reducers=[message_reducer()])
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="go"),
-            include_reducers=True,
-        )
-        events = await _collect(adapter, _make_input())
-
-        # Find positions: TEXT_MESSAGE_END (emitted from LLMStreamEnd) must
-        # appear before the first MESSAGES_SNAPSHOT that contains an assistant.
-        end_idx = next(
-            i for i, e in enumerate(events) if e.type == EventType.TEXT_MESSAGE_END
-        )
-        snap_indices = [
-            i
-            for i, e in enumerate(events)
-            if e.type == EventType.MESSAGES_SNAPSHOT
-            and any(m.role == "assistant" for m in e.messages)
-        ]
-        assert snap_indices, "Expected at least one snapshot with an assistant message"
-        assert end_idx < snap_indices[0], (
-            "TextMessageEnd (from LLMStreamEnd) must precede the first "
-            "MessagesSnapshot containing the AI message"
-        )
+        # AI message uses LangChain ID, not streaming ID
+        assert not ai_msgs[-1].id.startswith("msg-")
 
 
 def describe_non_streamed_id_reconciliation():

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -2198,6 +2198,47 @@ def describe_snapshot_uses_langchain_ids():
         # AI message uses LangChain ID, not streaming ID
         assert not ai_msgs[-1].id.startswith("msg-")
 
+    async def it_uses_langchain_ids_across_multiple_llm_calls():
+        """Both AI messages keep LangChain IDs after two LLM streams."""
+        llm = FakeListChatModel(responses=["first reply", "second reply"], sleep=0)
+
+        @on(UserAsked)
+        async def first_reply(
+            event: UserAsked,
+            messages: list[Any],
+        ) -> AgentReplied:
+            response = await llm.ainvoke(
+                [*messages, HumanMessage(content=event.question)]
+            )
+            return AgentReplied(message=response)
+
+        @on(AgentReplied)
+        async def second_reply(
+            event: AgentReplied,
+            messages: list[Any],
+        ) -> FollowUpReply:
+            response = await llm.ainvoke([*messages, HumanMessage(content="follow up")])
+            return FollowUpReply(message=response)
+
+        graph = EventGraph([first_reply, second_reply], reducers=[message_reducer()])
+        adapter = AGUIAdapter(
+            graph=graph,
+            seed_factory=lambda inp: UserAsked(question="go"),
+            include_reducers=True,
+        )
+        events = await _collect(adapter, _make_input())
+
+        starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+        assert len(starts) == 2
+
+        msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+        last_snap = msg_snapshots[-1]
+        ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+        assert len(ai_msgs) == 2
+        for m in ai_msgs:
+            assert m.id.startswith("lc_run--"), f"Expected LangChain ID, got {m.id}"
+            assert not m.id.startswith("msg-")
+
 
 def describe_non_streamed_id_reconciliation():
     """Non-streamed AI messages are delivered only via MESSAGES_SNAPSHOT."""


### PR DESCRIPTION
## Summary
- Removes the `id_overrides` mechanism that rewrote LangChain IDs to streaming IDs in `MESSAGES_SNAPSHOT`, which caused cross-run message duplication (checkpoint stores LangChain IDs, CopilotKit stored streaming IDs, `add_messages` couldn't match them on the next run)
- `MESSAGES_SNAPSHOT` now always uses original LangChain IDs — checkpoint and frontend stay consistent across runs
- LLM streaming still uses `msg-N` IDs for real-time display; the final snapshot replaces everything with correct LangChain IDs
- Deletes `record_lc_to_stream_id`, `lc_id_overrides`, `_lc_to_stream_id` from `MapperContext` and `id_overrides` params from `build_messages_snapshot` / `_langchain_to_agui_messages`

## Test plan
- [x] 72 tests pass (`uv run pytest tests/test_agui.py -v`)
- [x] Replaced `describe_streaming_id_reconciliation` with `describe_snapshot_uses_langchain_ids` — verifies snapshots use LangChain IDs, not streaming IDs
- [x] Removed `it_records_lc_to_stream_id_mapping` unit test (dead API)
- [x] Lint and type check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)