### PR TITLE
feat: graceful Halted subtypes, OrphanedEventWarning, and is_interrupted fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
       - id: pytest
         name: pytest
         language: system
-        entry: uv run pytest
+        entry: bash -c 'uv run coverage run -m pytest && uv run coverage report'
         types: [python]
         pass_filenames: false
         require_serial: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,9 @@
 | `STATE_SNAPSHOT_EVENT_NAME` | Constant | Protocol name used for snapshot custom events (`"intermediate_state"`) |
 | `EventLog`        | Class      | Immutable query container over events           |
 | `GraphState`      | NamedTuple | `(events, is_interrupted, interrupted)` from `get_state()` |
-| `Halted`          | Event      | Signal immediate graph termination              |
+| `Halted`          | Event      | Signal immediate graph termination; subclass for domain-specific halts |
+| `MaxRoundsExceeded` | Event    | `Halted` subtype emitted when `max_rounds` is exceeded (`rounds: int`) |
+| `Cancelled`       | Event      | `Halted` subtype emitted when async handler is cancelled |
 | `Interrupted`     | Base class | Bare marker — subclass with typed fields to pause graph |
 | `MessageEvent`    | Base class | Mixin for events wrapping LangChain messages    |
 | `message_reducer` | Function   | Built-in reducer for `MessageEvent` projection  |
@@ -40,6 +42,7 @@
 | `CustomEventFrame` | NamedTuple | `(name, data)` custom payload yielded from LangGraph `on_custom_event` with `include_custom_events=True` |
 | `StateSnapshotFrame` | NamedTuple | `(data)` typed snapshot frame yielded when `on_custom_event` uses `STATE_SNAPSHOT_EVENT_NAME` |
 | `SystemPromptSet` | Event      | Built-in `MessageEvent` for system prompts      |
+| `OrphanedEventWarning` | Warning | Issued at graph construction when return types have no subscriber |
 
 ## AG-UI Subpackage
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -66,7 +66,7 @@ graph = EventGraph(
 )
 ```
 
-`max_rounds` (default: 100) prevents infinite loops — the library auto-sets LangGraph's `recursion_limit` so this is the only knob you need. Override via `invoke(seed, recursion_limit=N)` if needed.
+`max_rounds` (default: 100) prevents infinite loops — the library auto-sets LangGraph's `recursion_limit` so this is the only knob you need. Exceeding the limit emits a `MaxRoundsExceeded` event (a `Halted` subclass) instead of raising, so checkpointed state stays clean and the graph can be retried.
 
 ### Visualizing the Event Flow
 
@@ -122,15 +122,25 @@ def evaluate(event: DraftProduced, log: EventLog) -> CritiqueReceived | FinalDra
 
 ## `Halted`
 
-Return a `Halted` event from any handler to immediately stop the graph. No further handlers are dispatched.
+Return a `Halted` event (or subclass) from any handler to immediately stop the graph. No further handlers are dispatched. Subclass `Halted` with domain-specific fields instead of generic payloads:
 
 ```python
+class ContentBlocked(Halted):
+    label: str
+
 @on(Classified)
-def guard(event: Classified) -> Reply | Halted:
+def guard(event: Classified) -> Reply | ContentBlocked:
     if event.label == "blocked":
-        return Halted(reason="Content policy violation")
+        return ContentBlocked(label=event.label)
     return Reply(text="OK")
 ```
+
+**Built-in subtypes:**
+
+| Subtype | Emitted when |
+|---------|-------------|
+| `MaxRoundsExceeded` | Graph exceeds `max_rounds` (has `rounds: int` field) |
+| `Cancelled` | Async handler execution was cancelled |
 
 ## `Scatter`
 

--- a/examples/content_pipeline.graph.md
+++ b/examples/content_pipeline.graph.md
@@ -6,7 +6,7 @@ graph LR
     classDef entry fill:none,stroke:none,color:none
     _e0_[ ]:::entry ==> ContentReceived
     ContentReceived -->|classify| ContentClassified
-    ContentClassified -->|gate| Halted
+    ContentClassified -->|gate| ContentBlocked
     ContentClassified -->|gate| ContentApproved
     ContentApproved -->|analyze| AnalysisProduced
 ```

--- a/examples/content_pipeline.py
+++ b/examples/content_pipeline.py
@@ -72,6 +72,10 @@ class AnalysisProduced(PipelineStage):
         return f"analyzed:{self.word_count} words"
 
 
+class ContentBlocked(Halted):
+    category: str = ""
+
+
 # ---------------------------------------------------------------------------
 # Reducer — polymorphic stage tracking
 # ---------------------------------------------------------------------------
@@ -103,13 +107,13 @@ def classify(event: ContentReceived) -> ContentClassified:
 
 
 @on(ContentClassified)
-def gate(event: ContentClassified, log: EventLog) -> Halted | ContentApproved:
+def gate(event: ContentClassified, log: EventLog) -> ContentBlocked | ContentApproved:
     """Safety gate — halts the pipeline for unsafe content.
 
     Uses ``log.latest(ContentReceived)`` to pass the original text forward.
     """
     if not event.safe:
-        return Halted(reason=f"blocked: {event.category} content")
+        return ContentBlocked(category=event.category)
     original = log.latest(ContentReceived)
     return ContentApproved(text=original.text, category=event.category)
 
@@ -158,8 +162,8 @@ async def main():
 
     print(f"  Halted in log?   {log.has(Halted)}")
     print(f"  Analysis done?   {log.has(AnalysisProduced)}")
-    halted = log.latest(Halted)
-    print(f"  Halted reason:   {halted.reason}")
+    blocked = log.latest(ContentBlocked)
+    print(f"  Blocked category: {blocked.category}")
 
     # --- Scenario 3: Bare event stream (sync) ---
     print("\n=== Scenario 3: stream_events (sync, no reducers) ===")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 describe_prefixes = ["describe_", "when_", "with_", "without_", "for_"]
 addopts = "--cov --cov-report=term-missing"
+filterwarnings = [
+    "ignore::langgraph_events.OrphanedEventWarning",
+]
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ packages = ["src/langgraph_events"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 describe_prefixes = ["describe_", "when_", "with_", "without_", "for_"]
-addopts = "--cov --cov-report=term-missing"
 filterwarnings = [
     "ignore::langgraph_events.OrphanedEventWarning",
 ]

--- a/src/langgraph_events/__init__.py
+++ b/src/langgraph_events/__init__.py
@@ -9,9 +9,11 @@ from langgraph_events._custom_event import (
 )
 from langgraph_events._event import (
     Auditable,
+    Cancelled,
     Event,
     Halted,
     Interrupted,
+    MaxRoundsExceeded,
     MessageEvent,
     Resumed,
     Scatter,
@@ -24,6 +26,7 @@ from langgraph_events._graph import (
     GraphState,
     LLMStreamEnd,
     LLMToken,
+    OrphanedEventWarning,
     StateSnapshotFrame,
     StreamFrame,
 )
@@ -37,6 +40,7 @@ __all__ = [
     "SKIP",
     "STATE_SNAPSHOT_EVENT_NAME",
     "Auditable",
+    "Cancelled",
     "CustomEventFrame",
     "Event",
     "EventGraph",
@@ -46,7 +50,9 @@ __all__ = [
     "Interrupted",
     "LLMStreamEnd",
     "LLMToken",
+    "MaxRoundsExceeded",
     "MessageEvent",
+    "OrphanedEventWarning",
     "Reducer",
     "Resumed",
     "ScalarReducer",

--- a/src/langgraph_events/_event.py
+++ b/src/langgraph_events/_event.py
@@ -115,9 +115,32 @@ class Auditable(Event):
 
 
 class Halted(Event):
-    """Special event that signals immediate graph termination."""
+    """Special event that signals immediate graph termination.
 
-    reason: str = ""
+    Subclass with domain-specific fields instead of generic payloads::
+
+        class ContentBlocked(Halted):
+            category: str
+
+        class BudgetExceeded(Halted):
+            spent: float
+            limit: float
+    """
+
+
+class MaxRoundsExceeded(Halted):
+    """Graph exceeded the configured ``max_rounds`` limit."""
+
+    rounds: int = 0
+
+
+class Cancelled(Halted):
+    """Handler execution was cancelled (e.g. task timeout).
+
+    When multiple handlers run in parallel, cancellation only discards
+    the cancelled handler's partial events — sibling handler results
+    that already committed to state will persist.
+    """
 
 
 class Interrupted(Event):

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict, cast
 from langgraph.graph import END, START, StateGraph
 
 from langgraph_events._custom_event import STATE_SNAPSHOT_EVENT_NAME
-from langgraph_events._event import Event, Interrupted, Resumed, Scatter
+from langgraph_events._event import Event, Halted, Interrupted, Resumed, Scatter
 from langgraph_events._event_log import EventLog
 from langgraph_events._handler import HandlerMeta, extract_handler_meta
 from langgraph_events._internal import (
@@ -30,6 +30,10 @@ if TYPE_CHECKING:
     from langgraph.store.base import BaseStore
 
     from langgraph_events._reducer import BaseReducer
+
+
+class OrphanedEventWarning(UserWarning):
+    """Issued when handler return types have no matching subscriber."""
 
 
 class ReturnInfo(NamedTuple):
@@ -226,6 +230,30 @@ class EventGraph:
                     f"Handler '{meta.name}' return type includes base 'Event'. "
                     f"Use specific types (e.g., TypeA | TypeB)."
                 )
+
+        # Warn about event types that are produced but never consumed
+        subscribed: set[type[Event]] = set()
+        for meta in self._handler_metas:
+            subscribed.update(meta.event_types)
+        produced: set[type[Event]] = set()
+        for info in self._return_info.values():
+            produced.update(info.event_types)
+            produced.update(info.scatter_types)
+        orphaned = {
+            t
+            for t in produced
+            if not issubclass(t, (Halted, Interrupted))
+            and not any(issubclass(t, s) for s in subscribed)
+        }
+        if orphaned:
+            names = ", ".join(sorted(t.__name__ for t in orphaned))
+            warnings.warn(
+                f"Event type(s) {names} are returned by handlers but no handler "
+                f"subscribes to them. These events will be produced but never "
+                f"processed.",
+                category=OrphanedEventWarning,
+                stacklevel=2,
+            )
 
     @staticmethod
     def _mermaid_footer_entry(
@@ -463,7 +491,11 @@ class EventGraph:
         snapshot = compiled.get_state(config)
         all_events = snapshot.values.get("events", [])
         log = EventLog(all_events)
-        is_interrupted = bool(snapshot.next)
+        # Determine interrupt status from the snapshot.
+        # snapshot.tasks[*].interrupts distinguishes real interrupts from
+        # cancelled/crashed graphs (which also have snapshot.next set).
+        has_interrupt = any(getattr(task, "interrupts", ()) for task in snapshot.tasks)
+        is_interrupted = bool(snapshot.next) and has_interrupt
         return GraphState(
             events=log,
             is_interrupted=is_interrupted,

--- a/src/langgraph_events/_internal.py
+++ b/src/langgraph_events/_internal.py
@@ -18,7 +18,14 @@ from langgraph.graph import END
 from langgraph.types import Send  # noqa: TC002
 
 from langgraph_events._custom_event import _reset_custom_emitters, _set_custom_emitters
-from langgraph_events._event import Event, Halted, Resumed, Scatter
+from langgraph_events._event import (
+    Cancelled,
+    Event,
+    Halted,
+    MaxRoundsExceeded,
+    Resumed,
+    Scatter,
+)
 from langgraph_events._event_log import EventLog
 from langgraph_events._handler import HandlerMeta  # noqa: TC001
 from langgraph_events._reducer import BaseReducer  # noqa: TC001
@@ -107,10 +114,13 @@ def make_router_node(max_rounds: int) -> Callable[[StateDict], StateDict]:
         has_resume = any(isinstance(e, Resumed) for e in new_events)
         current_round = 1 if has_resume else state.get("_round", 0) + 1
         if current_round > max_rounds:
-            raise RuntimeError(
-                f"EventGraph exceeded max_rounds={max_rounds}. "
-                f"Possible infinite loop — check your event handlers for cycles."
-            )
+            halted = MaxRoundsExceeded(rounds=max_rounds)  # type: ignore[call-arg]
+            return {
+                "_cursor": len(state["events"]),
+                "_pending": [halted],
+                "_round": current_round,
+                "events": [halted],
+            }
         return {
             "_cursor": len(state["events"]),
             "_pending": new_events,
@@ -311,6 +321,8 @@ def make_handler_node(
                 else:
                     result = meta.fn(event, **inject)
                 _collect_result(result, new_events, lg_interrupt)
+        except asyncio.CancelledError:
+            return _finalize([Cancelled()])
         finally:
             _reset_custom_emitters(tokens)
         return _finalize(new_events)

--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -83,7 +83,6 @@ class AGUIAdapter:
         mappers: list[EventMapper] | None = None,
         include_reducers: bool | list[str] = True,
         error_message: str | None = None,
-        interrupt_gate: bool = True,
     ) -> None:
         if resume_factory is not None and graph._checkpointer is None:
             raise ValueError(
@@ -94,7 +93,6 @@ class AGUIAdapter:
         self._resume_factory = resume_factory
         self._include_reducers = include_reducers
         self._error_message = error_message
-        self._interrupt_gate = interrupt_gate
         self._seed_accepts_state = self._accepts_extra_positional(seed_factory)
         self._resume_accepts_state = (
             self._accepts_extra_positional(resume_factory)
@@ -158,12 +156,13 @@ class AGUIAdapter:
     def _build_checkpoint_state(snapshot: Any) -> CheckpointState:
         """Build resume-factory state payload from a checkpoint snapshot."""
         reducers = snapshot.values if isinstance(snapshot.values, dict) else {}
+        pending = AGUIAdapter._interrupts_from_snapshot(snapshot)
         return {
             "reducers": reducers,
             "events": reducers.get("events"),
             "messages": reducers.get("messages"),
-            "pending_interrupts": AGUIAdapter._interrupts_from_snapshot(snapshot),
-            "is_interrupted": bool(snapshot.next),
+            "pending_interrupts": pending,
+            "is_interrupted": bool(pending),
             "snapshot": snapshot,
         }
 
@@ -270,7 +269,6 @@ class AGUIAdapter:
         """Whether interrupt gate should short-circuit to checkpoint replay."""
         return (
             resume_event is None
-            and self._interrupt_gate
             and checkpoint_state is not None
             and checkpoint_state["is_interrupted"]
         )
@@ -402,7 +400,7 @@ class AGUIAdapter:
         needs_checkpoint = (
             self._seed_accepts_state
             or self._resume_accepts_state
-            or self._interrupt_gate
+            or self._graph._checkpointer is not None
         )
         checkpoint_snapshot = (
             await self._aget_checkpoint_snapshot(config) if needs_checkpoint else None

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -1827,9 +1827,9 @@ def describe_seed_factory_state():
             assert received_states[0] is None
 
 
-def describe_interrupt_gate():
-    def when_gated():
-        async def it_reemits_interrupt():
+def describe_interrupt_replay():
+    def when_interrupted():
+        async def it_replays_interrupt_on_reconnect():
             call_count = {"n": 0}
 
             @on(UserAsked)
@@ -1852,7 +1852,6 @@ def describe_interrupt_gate():
             adapter = AGUIAdapter(
                 graph=graph,
                 seed_factory=lambda inp: UserAsked(question="retry"),
-                interrupt_gate=True,
             )
             events = await _collect(adapter, _make_input(thread_id="t-gate"))
 
@@ -1870,39 +1869,6 @@ def describe_interrupt_gate():
             assert len(interrupted) == 1
             assert interrupted[0].value["draft"] == "pending"
 
-    def when_gate_disabled():
-        async def it_executes_normally():
-            @on(UserAsked)
-            def ask(event: UserAsked) -> ApprovalRequested:
-                return ApprovalRequested(draft="pending")
-
-            graph = EventGraph(
-                [ask],
-                checkpointer=MemorySaver(),
-                reducers=[message_reducer()],
-            )
-            await graph.ainvoke(
-                UserAsked(question="go"),
-                config={"configurable": {"thread_id": "t-gate-off"}},
-            )
-
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="new seed"),
-                interrupt_gate=False,
-            )
-            events = await _collect(adapter, _make_input(thread_id="t-gate-off"))
-
-            assert events[0].type == EventType.RUN_STARTED
-            assert events[-1].type == EventType.RUN_FINISHED
-            # Should have executed — UserAsked custom event appears
-            custom = [
-                e
-                for e in events
-                if e.type == EventType.CUSTOM and e.name == "UserAsked"
-            ]
-            assert len(custom) >= 1
-
     def when_not_interrupted():
         async def it_executes_normally():
             @on(UserAsked)
@@ -1917,7 +1883,6 @@ def describe_interrupt_gate():
             adapter = AGUIAdapter(
                 graph=graph,
                 seed_factory=lambda inp: UserAsked(question="go"),
-                interrupt_gate=True,  # gate on, but no interrupt
             )
             events = await _collect(adapter, _make_input(thread_id="t-gate-clean"))
 

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -1,5 +1,8 @@
 """Integration tests for EventGraph — the full event-driven graph engine."""
 
+import asyncio
+import warnings
+
 import pytest
 from conftest import Completed, Ended, MessageReceived, MessageSent, Processed, Started
 from langchain_core.messages import (
@@ -11,12 +14,15 @@ from langchain_core.messages import (
 
 from langgraph_events import (
     STATE_SNAPSHOT_EVENT_NAME,
+    Cancelled,
     Event,
     EventGraph,
     EventLog,
     Halted,
     Interrupted,
+    MaxRoundsExceeded,
     MessageEvent,
+    OrphanedEventWarning,
     Reducer,
     Resumed,
     ScalarReducer,
@@ -560,7 +566,7 @@ def describe_EventGraph():
             async def it_stops_on_halt():
                 @on(Started)
                 async def halter(event: Started) -> Halted:
-                    return Halted(reason="stop")
+                    return Halted()
 
                 @on(Halted)
                 async def unreachable(event: Halted) -> Ended:
@@ -679,16 +685,20 @@ def describe_EventGraph():
 
     def describe_halt():
 
-        def it_stores_reason_and_is_Event_subclass():
-            h = Halted(reason="done")
-            assert h.reason == "done"
+        def it_is_Event_subclass():
+            h = Halted()
             assert isinstance(h, Event)
             assert isinstance(h, Halted)
+
+        def it_preserves_subtype_fields():
+            h = MaxRoundsExceeded(rounds=5)
+            assert isinstance(h, Halted)
+            assert h.rounds == 5
 
         def it_stops_execution_immediately():
             @on(Started)
             def step1(event: Started) -> Halted:
-                return Halted(reason="stopped early")
+                return Halted()
 
             @on(Halted)
             def should_not_run(event: Halted) -> Ended:
@@ -2430,8 +2440,8 @@ def describe_EventGraph():
                     return LoopDetected(n=event.n + 1)
 
                 graph = EventGraph([looper], max_rounds=5)
-                with pytest.raises(RuntimeError, match="max_rounds"):
-                    graph.invoke(LoopDetected(n=0))
+                log = graph.invoke(LoopDetected(n=0))
+                assert log.latest(MaxRoundsExceeded) is not None
 
             def it_resets_round_counter_on_resume():
                 from langgraph.checkpoint.memory import MemorySaver
@@ -2476,7 +2486,7 @@ def describe_EventGraph():
                 log = graph.resume(ResumeConfirmed(), config=config)
                 assert log.latest(Ended) is not None
 
-            def it_raises_max_rounds_not_recursion_error():
+            def it_halts_on_max_rounds_not_recursion_error():
                 """max_rounds fires before LangGraph's recursion_limit."""
 
                 class PingSent(Event):
@@ -2487,10 +2497,10 @@ def describe_EventGraph():
                     return PingSent(n=event.n + 1)
 
                 graph = EventGraph([pong], max_rounds=5)
-                with pytest.raises(RuntimeError, match="max_rounds"):
-                    graph.invoke(PingSent())
+                log = graph.invoke(PingSent())
+                assert log.latest(MaxRoundsExceeded) is not None
 
-            def it_raises_max_rounds_for_multiple_handlers():
+            def it_halts_on_max_rounds_for_multiple_handlers():
                 """recursion_limit accounts for multiple handlers per round."""
 
                 class Ticked(Event):
@@ -2508,8 +2518,83 @@ def describe_EventGraph():
                     return Ticked(n=event.n + 1)
 
                 graph = EventGraph([handle_tick, handle_tock], max_rounds=5)
-                with pytest.raises(RuntimeError, match="max_rounds"):
-                    graph.invoke(Ticked())
+                log = graph.invoke(Ticked())
+                assert log.latest(MaxRoundsExceeded) is not None
+
+            def it_saves_clean_checkpoint_on_max_rounds():
+                from langgraph.checkpoint.memory import MemorySaver
+
+                class LoopEvent(Event):
+                    n: int = 0
+
+                @on(LoopEvent)
+                def looper(event: LoopEvent) -> LoopEvent:
+                    return LoopEvent(n=event.n + 1)
+
+                graph = EventGraph([looper], max_rounds=3, checkpointer=MemorySaver())
+                config = {"configurable": {"thread_id": "max-rounds-ckpt"}}
+                log = graph.invoke(LoopEvent(n=0), config=config)
+                assert log.latest(MaxRoundsExceeded) is not None
+
+                state = graph.get_state(config)
+                assert state.events.latest(MaxRoundsExceeded) is not None
+                assert state.is_interrupted is False
+
+            def it_streams_halted_on_max_rounds():
+                class LoopEvent(Event):
+                    n: int = 0
+
+                @on(LoopEvent)
+                def looper(event: LoopEvent) -> LoopEvent:
+                    return LoopEvent(n=event.n + 1)
+
+                graph = EventGraph([looper], max_rounds=3)
+                events = list(graph.stream_events(LoopEvent(n=0)))
+                assert any(isinstance(e, MaxRoundsExceeded) for e in events)
+
+        def describe_cancellation():
+
+            async def it_halts_on_cancelled_error():
+                ready = asyncio.Event()
+
+                @on(Started)
+                async def slow(event: Started) -> Ended:
+                    ready.set()
+                    await asyncio.sleep(100)
+                    return Ended(result="done")
+
+                graph = EventGraph([slow])
+                task = asyncio.ensure_future(graph.ainvoke(Started(data="go")))
+                await ready.wait()
+                task.cancel()
+                log = await task
+                assert log.latest(Cancelled) is not None
+                assert not log.has(Ended)
+
+            async def it_discards_partial_events_on_cancel():
+                """Events collected before cancellation are not in the log."""
+                call_count = 0
+                ready = asyncio.Event()
+
+                @on(Started)
+                async def multi(event: Started) -> Scatter[Processed]:
+                    return Scatter([Processed(data="a"), Processed(data="b")])
+
+                @on(Processed)
+                async def slow(event: Processed) -> Ended:
+                    nonlocal call_count
+                    call_count += 1
+                    if call_count == 2:
+                        ready.set()
+                        await asyncio.sleep(100)
+                    return Ended(result=event.data)
+
+                graph = EventGraph([multi, slow])
+                task = asyncio.ensure_future(graph.ainvoke(Started(data="go")))
+                await ready.wait()
+                task.cancel()
+                log = await task
+                assert log.latest(Cancelled) is not None
 
     def describe_mermaid():
 
@@ -3138,3 +3223,100 @@ def describe_EventGraph():
             custom_frames = [i for i in items if isinstance(i, CustomEventFrame)]
             assert len(custom_frames) == 1
             assert custom_frames[0].name == "resume.progress"
+
+
+def describe_OrphanedEventWarning():
+
+    def when_orphaned():
+
+        def it_warns_about_orphaned_event_types():
+            class Orphan(Event):
+                pass
+
+            @on(Started)
+            def produce_orphan(event: Started) -> Orphan:
+                return Orphan()
+
+            with pytest.warns(OrphanedEventWarning, match="Orphan"):
+                EventGraph([produce_orphan])
+
+        def it_warns_for_orphaned_scatter_types():
+            class ScatterOrphan(Event):
+                pass
+
+            @on(Started)
+            def scatter_producer(event: Started) -> Scatter[ScatterOrphan]:
+                return Scatter([ScatterOrphan()])
+
+            with pytest.warns(OrphanedEventWarning, match="ScatterOrphan"):
+                EventGraph([scatter_producer])
+
+    def when_not_orphaned():
+
+        def it_does_not_warn_for_subscribed_via_inheritance():
+            class Base(Event):
+                pass
+
+            class Sub(Base):
+                pass
+
+            @on(Started)
+            def produce_sub(event: Started) -> Sub:
+                return Sub()
+
+            @on(Base)
+            def consume_base(event: Base):
+                pass
+
+            # Sub is consumed by @on(Base) via isinstance — no warning
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", OrphanedEventWarning)
+                EventGraph([produce_sub, consume_base])
+
+        def it_does_not_warn_for_halted_returns():
+            @on(Started)
+            def halter(event: Started) -> Halted:
+                return Halted()
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", OrphanedEventWarning)
+                EventGraph([halter])
+
+        def it_does_not_warn_for_interrupted_returns():
+            class AskApproval(Interrupted):
+                pass
+
+            @on(Started)
+            def asker(event: Started) -> AskApproval:
+                return AskApproval()
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", OrphanedEventWarning)
+                EventGraph([asker])
+
+        def it_does_not_warn_for_unannotated_handlers():
+            @on(Started)
+            def no_annotation(event: Started):
+                return Ended(result="ok")
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", OrphanedEventWarning)
+                EventGraph([no_annotation])
+
+        def it_does_not_warn_for_none_in_union():
+            """Optional[Event] return type should not warn about NoneType."""
+
+            class MaybeResult(Event):
+                pass
+
+            @on(Started)
+            def maybe(event: Started) -> MaybeResult | None:
+                return None
+
+            @on(MaybeResult)
+            def consumer(event: MaybeResult):
+                pass
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", OrphanedEventWarning)
+                EventGraph([maybe, consumer])


### PR DESCRIPTION
## Summary
- **Halted subtypes**: Replace `Halted(reason=...)` with typed subtypes — `MaxRoundsExceeded(rounds=N)` emitted instead of RuntimeError, `Cancelled()` emitted on async CancelledError
- **OrphanedEventWarning**: Compile-time warning when handler return types have no matching subscriber (inheritance-aware, excludes Halted/Interrupted)
- **is_interrupted fix**: Check `snapshot.tasks[*].interrupts` instead of `snapshot.next` to distinguish real interrupts from cancelled/crashed graphs
- **Remove interrupt_gate**: AGUIAdapter interrupt replay on reconnect is now always-on

### Breaking changes
- `Halted.reason` field removed — use subtypes instead
- `AGUIAdapter(interrupt_gate=...)` parameter removed

## Test plan
- [x] 312 tests pass (`uv run pytest tests/ --no-cov`)
- [x] Lint clean (`uv run ruff check src/ tests/`)
- [x] Type check clean (`uv run mypy src/`)
- [x] Mermaid graph files regenerated
- [x] Docs updated (concepts.md, api.md)
- [x] Example updated (content_pipeline.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)