### PR TITLE
docs: restructure for DX

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,47 +1,79 @@
 # API Reference
 
+## Events & Base Classes
+
 | Export            | Type       | Description                                     |
 |-------------------|------------|-------------------------------------------------|
-| `Auditable`       | Base class | Marker class for auto-logged events             |
 | `Event`           | Base class | Subclass to define events (auto-frozen)         |
+| `Auditable`       | Base class | Marker class for auto-logged events             |
+| `MessageEvent`    | Base class | Mixin for events wrapping LangChain messages    |
+| `SystemPromptSet` | Event      | Built-in `MessageEvent` for system prompts      |
+
+## Handler Subscription
+
+| Export            | Type       | Description                                     |
+|-------------------|------------|-------------------------------------------------|
+| `on`              | Decorator  | Subscribe a handler to one or more event types  |
+
+## Graph & Execution
+
+| Export            | Type       | Description                                     |
+|-------------------|------------|-------------------------------------------------|
 | `EventGraph`      | Class      | Build and run the event-driven graph            |
 | `EventGraph.invoke()` | Method | Run graph synchronously, returns `EventLog` |
 | `EventGraph.ainvoke()` | Method | Async version of `invoke()` |
-| `EventGraph.stream_events()` | Method | Yield events as produced; optional reducer snapshots via `StreamFrame` |
-| `EventGraph.astream_events()` | Method | Async version of `stream_events()`; supports `include_llm_tokens=True` (`LLMToken`/`LLMStreamEnd`) and `include_custom_events=True` (`CustomEventFrame`/`StateSnapshotFrame`) |
-| `EventGraph.stream_resume()` | Method | Yield events during resume; streaming equivalent of `resume()` |
-| `EventGraph.astream_resume()` | Method | Async version of `stream_resume()`; supports `include_llm_tokens=True` (`LLMToken`/`LLMStreamEnd`) and `include_custom_events=True` (`CustomEventFrame`/`StateSnapshotFrame`) |
 | `EventGraph.resume()` | Method | Resume interrupted graph with a domain event (requires checkpointer) |
 | `EventGraph.aresume()` | Method | Async version of `resume()` |
 | `EventGraph.get_state()` | Method | Get `GraphState` for a checkpointed thread |
 | `EventGraph.compiled` | Property | Access underlying `CompiledStateGraph` for advanced LangGraph patterns |
 | `EventGraph.reducer_names` | Property | `frozenset` of registered reducer names |
 | `EventGraph.mermaid()` | Method | Return a Mermaid flowchart of event correlations |
-| `emit_custom`    | Function   | Emit a LangGraph custom stream event from a handler |
-| `aemit_custom`   | Function   | Async variant of `emit_custom` for async handlers |
-| `emit_state_snapshot` | Function | Emit a typed state snapshot stream frame from a handler |
-| `aemit_state_snapshot` | Function | Async variant of `emit_state_snapshot` for async handlers |
-| `STATE_SNAPSHOT_EVENT_NAME` | Constant | Protocol name used for snapshot custom events (`"intermediate_state"`) |
 | `EventLog`        | Class      | Immutable query container over events           |
 | `GraphState`      | NamedTuple | `(events, is_interrupted, interrupted)` from `get_state()` |
+
+## Control Flow
+
+| Export            | Type       | Description                                     |
+|-------------------|------------|-------------------------------------------------|
 | `Halted`          | Event      | Signal immediate graph termination; subclass for domain-specific halts |
 | `MaxRoundsExceeded` | Event    | `Halted` subtype emitted when `max_rounds` is exceeded (`rounds: int`) |
 | `Cancelled`       | Event      | `Halted` subtype emitted when async handler is cancelled |
 | `Interrupted`     | Base class | Bare marker — subclass with typed fields to pause graph |
-| `MessageEvent`    | Base class | Mixin for events wrapping LangChain messages    |
-| `message_reducer` | Function   | Built-in reducer for `MessageEvent` projection  |
-| `on`              | Decorator  | Subscribe a handler to one or more event types  |
+| `Resumed`         | Event      | Created on resume with the dispatched event and `interrupted` backref |
+| `Scatter`         | Class      | Fan-out into multiple events; generic `Scatter[T]` annotates the produced type |
+
+## Reducers
+
+| Export            | Type       | Description                                     |
+|-------------------|------------|-------------------------------------------------|
 | `Reducer`         | Class      | Map events to a named LangGraph state channel   |
 | `ScalarReducer`   | Class      | Last-write-wins reducer for single values (None is a valid value) |
 | `SKIP`            | Sentinel   | Return from `ScalarReducer` fn to leave value unchanged |
-| `Resumed`         | Event      | Created on resume with the dispatched event and `interrupted` backref |
-| `Scatter`         | Class      | Fan-out into multiple events; generic `Scatter[T]` annotates the produced type |
-| `StreamFrame`     | NamedTuple | `(event, reducers)` yielded by `stream_events()` with `include_reducers` |
-| `LLMToken`        | NamedTuple | `(run_id, content)` token delta yielded by async streams with `include_llm_tokens=True` |
+| `message_reducer` | Function   | Built-in reducer for `MessageEvent` projection  |
+
+## Streaming & Frames
+
+| Export            | Type       | Description                                     |
+|-------------------|------------|-------------------------------------------------|
+| `EventGraph.stream_events()` | Method | Yield events as produced; optional reducer snapshots via `StreamFrame` |
+| `EventGraph.astream_events()` | Method | Async version of `stream_events()`; supports `include_llm_tokens` and `include_custom_events` |
+| `EventGraph.stream_resume()` | Method | Yield events during resume; streaming equivalent of `resume()` |
+| `EventGraph.astream_resume()` | Method | Async version of `stream_resume()`; supports `include_llm_tokens` and `include_custom_events` |
+| `StreamFrame`     | NamedTuple | `(event, reducers, changed_reducers)` yielded with `include_reducers`; `changed_reducers` is a `frozenset[str] \| None` indicating which reducers the event updated |
+| `LLMToken`        | NamedTuple | `(run_id, content)` token delta yielded with `include_llm_tokens=True` |
 | `LLMStreamEnd`    | NamedTuple | `(run_id, message_id)` marker yielded when an LLM stream completes |
-| `CustomEventFrame` | NamedTuple | `(name, data)` custom payload yielded from LangGraph `on_custom_event` with `include_custom_events=True` |
-| `StateSnapshotFrame` | NamedTuple | `(data)` typed snapshot frame yielded when `on_custom_event` uses `STATE_SNAPSHOT_EVENT_NAME` |
-| `SystemPromptSet` | Event      | Built-in `MessageEvent` for system prompts      |
+| `CustomEventFrame` | NamedTuple | `(name, data)` custom payload yielded with `include_custom_events=True` |
+| `StateSnapshotFrame` | NamedTuple | `(data)` typed snapshot frame from `emit_state_snapshot()` |
+| `emit_custom`    | Function   | Emit a LangGraph custom stream event from a handler |
+| `aemit_custom`   | Function   | Async variant of `emit_custom` |
+| `emit_state_snapshot` | Function | Emit a typed state snapshot stream frame from a handler |
+| `aemit_state_snapshot` | Function | Async variant of `emit_state_snapshot` |
+| `STATE_SNAPSHOT_EVENT_NAME` | Constant | Protocol name used for snapshot custom events (`"intermediate_state"`) |
+
+## Warnings
+
+| Export            | Type       | Description                                     |
+|-------------------|------------|-------------------------------------------------|
 | `OrphanedEventWarning` | Warning | Issued at graph construction when return types have no subscriber |
 
 ## AG-UI Subpackage

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -62,7 +62,7 @@ The main entry point. Pass a list of handler functions and `EventGraph` derives 
 graph = EventGraph(
     [classify, respond, audit],
     max_rounds=50,           # default: 100; prevents infinite loops
-    reducers=[my_reducer],   # optional — see Reducer section
+    reducers=[my_reducer],   # optional — see Reducers page
 )
 ```
 
@@ -142,30 +142,6 @@ def guard(event: Classified) -> Reply | ContentBlocked:
 | `MaxRoundsExceeded` | Graph exceeds `max_rounds` (has `rounds: int` field) |
 | `Cancelled` | Async handler execution was cancelled |
 
-## `Scatter`
-
-Return `Scatter([event1, event2, ...])` to fan-out into multiple events. Each becomes a separate pending event, dispatched in the next round. Use `Scatter[WorkItem]` to annotate the produced type — this renders as a dashed edge in `mermaid()` diagrams.
-
-```python
-@on(Batch)
-def split(event: Batch) -> Scatter[WorkItem]:
-    return Scatter([WorkItem(item=i) for i in event.items])
-
-
-@on(WorkItem)
-def process(event: WorkItem) -> WorkDone:
-    return WorkDone(result=f"done:{event.item}")
-
-
-@on(WorkDone)
-def gather(event: WorkDone, log: EventLog) -> BatchResult | None:
-    all_done = log.filter(WorkDone)
-    batch = log.latest(Batch)
-    if len(all_done) >= len(batch.items):
-        return BatchResult(results=tuple(e.result for e in all_done))
-    return None  # not all items done yet
-```
-
 ## `Auditable`
 
 Marker base class for events that should be auto-logged. Subclass it and subscribe a single `@on(Auditable)` handler to capture every marked event automatically. The built-in `trail()` method returns a compact summary of the event's fields.
@@ -218,149 +194,9 @@ log = graph.invoke([
 seed = SystemPromptSet(message=SystemMessage(content="You are helpful"))
 ```
 
-## Reducers
+## What's Next
 
-**When to use reducers:** Pure event-driven handlers (`log.filter()`, `log.latest()`) are the default and work for most patterns. Add a `Reducer` when you need incremental accumulation that would be expensive to recompute from the full log each round — the canonical case is `message_reducer()` for LLM conversation history. Add a `ScalarReducer` for last-write-wins configuration values injected directly into handlers. If you find yourself calling `log.filter(X)` and transforming the result the same way in multiple handlers, that's a signal a reducer would help.
-
-A `Reducer` maps events to contributions for a named LangGraph state channel. The framework maintains the channel incrementally — handlers receive the accumulated value by declaring a parameter whose name matches the reducer.
-
-```python
-from langgraph_events import Reducer, ScalarReducer, message_reducer, EventGraph, on
-
-# --- Reducer: accumulates contributions from matching events ---
-history = Reducer("history", event_type=UserMsg, fn=lambda e: [e.text], default=[])
-
-
-@on(UserMsg)
-def respond(event: UserMsg, history: list) -> Reply:
-    # history contains all projected values so far
-    ...
-
-
-graph = EventGraph([respond], reducers=[history])
-
-# --- message_reducer: built-in for LangChain message accumulation ---
-messages = message_reducer()
-graph = EventGraph([call_llm, handle_tools], reducers=[messages])
-log = graph.invoke([
-    SystemPromptSet.from_str("You are a helpful assistant."),
-    UserMessageReceived(message=HumanMessage(content="Hi")),
-])
-
-# Alternative: explicit default list
-messages = message_reducer([SystemMessage(content="You are a helpful assistant.")])
-
-# --- ScalarReducer: last-write-wins, injected as a bare value ---
-temperature = ScalarReducer(
-    "temperature", event_type=TempSet, fn=lambda e: e.value, default=0.7
-)
-```
-
-The parameter name `messages` matches the reducer name, so the framework injects the accumulated message list automatically:
-
-```python
-@on(UserMessageReceived, ToolsExecuted)
-async def call_llm(event: Event, messages: list[BaseMessage]) -> LLMResponded:
-    response = await llm.ainvoke(messages)
-    ...
-```
-
-### `SKIP`
-
-When a `ScalarReducer` function returns `SKIP`, the reducer value is left unchanged. This lets handlers opt out of updating the reducer for certain events.
-
-```python
-from langgraph_events import SKIP, ScalarReducer
-
-temperature = ScalarReducer(
-    "temperature", event_type=ConfigUpdated, fn=lambda e: e.temp if e.temp is not None else SKIP, default=0.7
-)
-```
-
-## `Interrupted` / `Resumed`
-
-`Interrupted` is a bare marker class — subclass it with domain-specific fields to pause the graph and wait for human input. Resume with `graph.resume(event)` — the event is auto-dispatched (handlers subscribed to its type fire), then the framework creates a `Resumed` event alongside it. `resume()` requires an `Event` instance; passing a plain string or dict raises `TypeError`.
-
-Requires a **checkpointer** (e.g., `MemorySaver`).
-
-```python
-from langgraph.checkpoint.memory import MemorySaver
-
-
-class OrderConfirmationRequested(Interrupted):
-    order_id: str
-    total: float
-
-
-class ApprovalSubmitted(Event):
-    approved: bool
-
-
-@on(OrderPlaced)
-def confirm(event: OrderPlaced) -> OrderConfirmationRequested:
-    return OrderConfirmationRequested(order_id=event.order_id, total=event.total)
-
-
-@on(ApprovalSubmitted)
-def handle_approval(event: ApprovalSubmitted, log: EventLog) -> OrderConfirmed | OrderCancelled:
-    confirm_event = log.latest(OrderConfirmationRequested)
-    if event.approved:
-        return OrderConfirmed(order_id=confirm_event.order_id)
-    return OrderCancelled(reason="User declined")
-
-
-graph = EventGraph([confirm, handle_approval], checkpointer=MemorySaver())
-config = {"configurable": {"thread_id": "order-1"}}
-
-# First call — pauses at the interrupt
-graph.invoke(OrderPlaced(order_id="A1", total=99.99), config=config)
-
-# Check state and resume with a typed event
-state = graph.get_state(config)
-if state.is_interrupted:
-    confirm_event = state.interrupted
-    print(f"Approve order {confirm_event.order_id} for ${confirm_event.total}?")
-log = graph.resume(ApprovalSubmitted(approved=True), config=config)
-```
-
-## Streaming
-
-All `invoke`/`stream` methods have async counterparts: `ainvoke()`, `astream_events()`, `aresume()`, `astream_resume()`.
-
-```python
-# Async stream with real-time LLM token deltas and passthrough custom frames
-from langgraph_events import (
-    CustomEventFrame,
-    LLMStreamEnd,
-    LLMToken,
-    StateSnapshotFrame,
-    emit_state_snapshot,
-    emit_custom,
-)
-
-
-@on(SeedEvent)
-def step(event: SeedEvent) -> ReplyProduced:
-    emit_state_snapshot({"messages": [], "step": "draft"})
-    emit_custom("tool.progress", {"pct": 50})
-    return ReplyProduced(...)
-
-
-async for item in graph.astream_events(
-    SeedEvent(...),
-    include_llm_tokens=True,
-    include_custom_events=True,
-):
-    if isinstance(item, LLMToken):
-        print(item.content, end="")
-    elif isinstance(item, LLMStreamEnd):
-        print("\n[done]", item.message_id)
-    elif isinstance(item, StateSnapshotFrame):
-        print("snapshot:", item.data)
-    elif isinstance(item, CustomEventFrame):
-        print("custom:", item.name, item.data)
-    else:
-        print(item)
-```
-
-Use `include_llm_tokens=True` for LLM token frames and `include_custom_events=True` for `CustomEventFrame` passthrough. Use `emit_state_snapshot(data)` / `await aemit_state_snapshot(data)` for typed snapshot frames, and `emit_custom(name, data)` / `await aemit_custom(name, data)` for all other stream-only telemetry without importing LangGraph callback APIs directly.
+- [Control Flow](control-flow.md) — `Scatter` for fan-out, `Interrupted`/`Resumed` for human-in-the-loop
+- [Reducers](reducers.md) — incremental state accumulation with `Reducer`, `ScalarReducer`, and `message_reducer()`
+- [Streaming](streaming.md) — real-time event streams, LLM token deltas, and custom telemetry
+- [Patterns](patterns.md) — complete runnable examples

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -1,0 +1,79 @@
+# Control Flow
+
+Fan-out, human-in-the-loop pauses, and other advanced dispatch patterns. Reach for these when basic event → handler → event chains aren't enough.
+
+For core graph execution and immediate halting, see [Core Concepts](concepts.md#halted).
+
+## `Scatter`
+
+Return `Scatter([event1, event2, ...])` to fan-out into multiple events. Each becomes a separate pending event, dispatched in the next round. Use `Scatter[WorkItem]` to annotate the produced type — this renders as a dashed edge in `mermaid()` diagrams.
+
+```python
+@on(Batch)
+def split(event: Batch) -> Scatter[WorkItem]:
+    return Scatter([WorkItem(item=i) for i in event.items])
+
+
+@on(WorkItem)
+def process(event: WorkItem) -> WorkDone:
+    return WorkDone(result=f"done:{event.item}")
+
+
+@on(WorkDone)
+def gather(event: WorkDone, log: EventLog) -> BatchResult | None:
+    all_done = log.filter(WorkDone)
+    batch = log.latest(Batch)
+    if len(all_done) >= len(batch.items):
+        return BatchResult(results=tuple(e.result for e in all_done))
+    return None  # not all items done yet
+```
+
+See the [Map-Reduce pattern](patterns.md#fan-out-fan-in-map-reduce) for a complete runnable example.
+
+## `Interrupted` / `Resumed`
+
+`Interrupted` is a bare marker class — subclass it with domain-specific fields to pause the graph and wait for human input. Resume with `graph.resume(event)` — the event is auto-dispatched (handlers subscribed to its type fire), then the framework creates a `Resumed` event alongside it. `resume()` requires an `Event` instance; passing a plain string or dict raises `TypeError`.
+
+Requires a **checkpointer** (e.g., `MemorySaver`).
+
+```python
+from langgraph.checkpoint.memory import MemorySaver
+
+
+class OrderConfirmationRequested(Interrupted):
+    order_id: str
+    total: float
+
+
+class ApprovalSubmitted(Event):
+    approved: bool
+
+
+@on(OrderPlaced)
+def confirm(event: OrderPlaced) -> OrderConfirmationRequested:
+    return OrderConfirmationRequested(order_id=event.order_id, total=event.total)
+
+
+@on(ApprovalSubmitted)
+def handle_approval(event: ApprovalSubmitted, log: EventLog) -> OrderConfirmed | OrderCancelled:
+    confirm_event = log.latest(OrderConfirmationRequested)
+    if event.approved:
+        return OrderConfirmed(order_id=confirm_event.order_id)
+    return OrderCancelled(reason="User declined")
+
+
+graph = EventGraph([confirm, handle_approval], checkpointer=MemorySaver())
+config = {"configurable": {"thread_id": "order-1"}}
+
+# First call — pauses at the interrupt
+graph.invoke(OrderPlaced(order_id="A1", total=99.99), config=config)
+
+# Check state and resume with a typed event
+state = graph.get_state(config)
+if state.is_interrupted:
+    confirm_event = state.interrupted
+    print(f"Approve order {confirm_event.order_id} for ${confirm_event.total}?")
+log = graph.resume(ApprovalSubmitted(approved=True), config=config)
+```
+
+See the [Human-in-the-Loop pattern](patterns.md#human-in-the-loop-approval) for a complete example, and [Checkpointer Evolution](checkpointer-evolution.md) for how graph changes affect interrupted checkpoints.

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -55,7 +55,9 @@ def confirm(event: OrderPlaced) -> OrderConfirmationRequested:
 
 
 @on(ApprovalSubmitted)
-def handle_approval(event: ApprovalSubmitted, log: EventLog) -> OrderConfirmed | OrderCancelled:
+def handle_approval(
+    event: ApprovalSubmitted, log: EventLog,
+) -> OrderConfirmed | OrderCancelled:
     confirm_event = log.latest(OrderConfirmationRequested)
     if event.approved:
         return OrderConfirmed(order_id=confirm_event.order_id)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,28 +66,40 @@ seed event
 2. The **router** collects new events, then **dispatch** matches each to subscribed handlers via `isinstance`. Matched handlers run and emit new events.
 3. The loop repeats until no handler matches or a `Halted` event appears.
 
-## Useful Operations
+## Running the Graph
 
 ```python
-# Synchronous
+# Synchronous — returns the full EventLog when the graph completes
 log = graph.invoke(MessageReceived(text="hello"))
 
-# Multiple seed events
+# Multiple seed events — useful for system prompts + user input
 log = graph.invoke([
     SystemPromptSet.from_str("You are helpful"),
     UserMessageReceived(message=HumanMessage(content="Hi")),
 ])
 
-# Async
+# Async — same API, awaitable
 log = await graph.ainvoke(MessageReceived(text="hello"))
 
-# Stream produced events
+# Stream events as they're produced — for live UI updates
 for event in graph.stream_events(MessageReceived(text="hello")):
     print(event)
 
-# Stream with reducer snapshots
+# Stream with reducer snapshots — see accumulated state each round
 for frame in graph.stream_events(MessageReceived(text="hello"), include_reducers=True):
     print(frame.event, frame.reducers["messages"])
 ```
 
-See [Concepts](concepts.md) for event log queries, reducers, interruption/resume, and fan-out.
+## Common Tasks
+
+| I want to... | Reach for... | Docs |
+|---------------|-------------|------|
+| Query past events in a handler | `EventLog` (`log.filter()`, `log.latest()`) | [Concepts](concepts.md#eventlog) |
+| Accumulate message history | `message_reducer()` | [Reducers](reducers.md#message_reducer) |
+| Fan out parallel work | `Scatter` | [Control Flow](control-flow.md#scatter) |
+| Pause for human approval | `Interrupted` + `graph.resume()` | [Control Flow](control-flow.md#interrupted-resumed) |
+| Stop the graph early | Return a `Halted` subclass | [Concepts](concepts.md#halted) |
+| Stream LLM tokens in real time | `astream_events(include_llm_tokens=True)` | [Streaming](streaming.md) |
+| Connect to an AG-UI frontend | `AGUIAdapter` | [AG-UI Adapter](agui.md) |
+
+See [Concepts](concepts.md) for the core model, then explore the topics above as needed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,8 +28,14 @@ Requires Python 3.10+ and `langgraph >= 0.2.0` (installed automatically). The `[
 
 - Start with [Getting Started](getting-started.md)
 - Learn [Core Concepts](concepts.md)
-- Browse [Patterns](patterns.md)
-- Check [API Reference](api.md)
+- Then explore as needed:
+    - [Control Flow](control-flow.md) — fan-out, human-in-the-loop
+    - [Reducers](reducers.md) — incremental state accumulation
+    - [Streaming](streaming.md) — real-time events, LLM tokens, telemetry
+- Browse [Patterns](patterns.md) for complete runnable examples
+- Check [API Reference](api.md) for the full export table
+- [AG-UI Adapter](agui.md) for frontend streaming
+- [Checkpointer Evolution](checkpointer-evolution.md) for persistence edge cases
 
 ## Status
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,45 +1,45 @@
 # Patterns
 
-These examples are runnable from `examples/`.
+Complete runnable examples in `examples/`. Each demonstrates a different combination of core concepts.
 
 ## Reflection Loop
 
-Generate -> critique -> revise with multi-subscription and revision caps.
+Generate, critique, and revise in a loop with automatic revision caps. Demonstrates **multi-subscription** (`@on(WriteRequested, CritiqueReceived)`) for revision cycles, union return types for branching, and the `Auditable` trait for automatic logging.
 
 - Code: [examples/reflection_loop.py](https://github.com/cadance-io/langgraph-events/blob/main/examples/reflection_loop.py)
 - Flow: [examples/reflection_loop.graph.md](https://github.com/cadance-io/langgraph-events/blob/main/examples/reflection_loop.graph.md)
 
 ## ReAct Agent with Message Reducer
 
-ReAct-style turns with incremental message history.
+Tool-calling agent with incremental message history. Demonstrates **[`message_reducer()`](reducers.md#message_reducer)** for automatic LangChain message accumulation, `MessageEvent` for typed message wrapping, and a multi-subscription loop (`@on(UserMessageReceived, ToolsExecuted)`) that drives the ReAct cycle.
 
 - Code: [examples/react_agent.py](https://github.com/cadance-io/langgraph-events/blob/main/examples/react_agent.py)
 - Flow: [examples/react_agent.graph.md](https://github.com/cadance-io/langgraph-events/blob/main/examples/react_agent.graph.md)
 
 ## Multi-Agent Supervisor
 
-Supervisor routes between specialists and aggregates context.
+Supervisor routes tasks to specialist agents and aggregates context. Demonstrates a **custom [`Reducer`](reducers.md#reducer)** for cross-agent context accumulation, tool-calling for structured routing decisions, and typed events for supervisor-to-specialist communication — no manual subgraph wiring.
 
 - Code: [examples/supervisor.py](https://github.com/cadance-io/langgraph-events/blob/main/examples/supervisor.py)
 - Flow: [examples/supervisor.graph.md](https://github.com/cadance-io/langgraph-events/blob/main/examples/supervisor.graph.md)
 
 ## Fan-Out / Fan-In (Map-Reduce)
 
-`Scatter` for fan-out and `EventLog.filter()` for gather completion.
+Parallel document summarization with batch splitting and completion detection. Demonstrates **[`Scatter`](control-flow.md#scatter)** for fan-out to multiple work items and `EventLog.filter()` for gather/completion detection with a duplicate-harmless pattern.
 
 - Code: [examples/map_reduce.py](https://github.com/cadance-io/langgraph-events/blob/main/examples/map_reduce.py)
 - Flow: [examples/map_reduce.graph.md](https://github.com/cadance-io/langgraph-events/blob/main/examples/map_reduce.graph.md)
 
 ## Human-in-the-Loop Approval
 
-Pause with `Interrupted`, resume with typed events.
+Pause execution for human approval and resume with typed events. Demonstrates **[`Interrupted`](control-flow.md#interrupted-resumed)** for pausing the graph, `graph.resume()` with domain events, and revision cycles driven by human feedback. Requires a checkpointer (`MemorySaver`).
 
 - Code: [examples/human_in_the_loop.py](https://github.com/cadance-io/langgraph-events/blob/main/examples/human_in_the_loop.py)
 - Flow: [examples/human_in_the_loop.graph.md](https://github.com/cadance-io/langgraph-events/blob/main/examples/human_in_the_loop.graph.md)
 
 ## Content Pipeline
 
-Safety halting with `Halted`, plus live event streaming.
+Safety gates with early termination and live event streaming. Demonstrates **[`Halted`](concepts.md#halted)** for safety-based graph termination, async **[streaming](streaming.md)** with `astream_events()`, `EventLog.has()` for existence checks, and keyword-based classification (no LLM required).
 
 - Code: [examples/content_pipeline.py](https://github.com/cadance-io/langgraph-events/blob/main/examples/content_pipeline.py)
 - Flow: [examples/content_pipeline.graph.md](https://github.com/cadance-io/langgraph-events/blob/main/examples/content_pipeline.graph.md)

--- a/docs/reducers.md
+++ b/docs/reducers.md
@@ -1,0 +1,74 @@
+# Reducers
+
+Incremental state accumulation for values that are expensive to recompute from the event log each round.
+
+**When to reach for a reducer:** Pure event-driven handlers (`log.filter()`, `log.latest()`) are the default and work for most patterns. Add a `Reducer` when you need incremental accumulation that would be expensive to recompute from the full log each round — the canonical case is `message_reducer()` for LLM conversation history. Add a `ScalarReducer` for last-write-wins configuration values injected directly into handlers. If you find yourself calling `log.filter(X)` and transforming the result the same way in multiple handlers, that's a signal a reducer would help.
+
+## `Reducer`
+
+A `Reducer` maps events to contributions for a named LangGraph state channel. The framework maintains the channel incrementally — handlers receive the accumulated value by declaring a parameter whose name matches the reducer.
+
+```python
+from langgraph_events import Reducer, ScalarReducer, message_reducer, EventGraph, on
+
+# --- Reducer: accumulates contributions from matching events ---
+history = Reducer("history", event_type=UserMsg, fn=lambda e: [e.text], default=[])
+
+
+@on(UserMsg)
+def respond(event: UserMsg, history: list) -> Reply:
+    # history contains all projected values so far
+    ...
+
+
+graph = EventGraph([respond], reducers=[history])
+```
+
+## `message_reducer`
+
+Built-in reducer for LangChain message accumulation. Projects `MessageEvent.as_messages()` into a `messages` state channel with smart deduplication via LangGraph's `add_messages`.
+
+```python
+messages = message_reducer()
+graph = EventGraph([call_llm, handle_tools], reducers=[messages])
+log = graph.invoke([
+    SystemPromptSet.from_str("You are a helpful assistant."),
+    UserMessageReceived(message=HumanMessage(content="Hi")),
+])
+
+# Alternative: explicit default list
+messages = message_reducer([SystemMessage(content="You are a helpful assistant.")])
+```
+
+The parameter name `messages` matches the reducer name, so the framework injects the accumulated message list automatically:
+
+```python
+@on(UserMessageReceived, ToolsExecuted)
+async def call_llm(event: Event, messages: list[BaseMessage]) -> LLMResponded:
+    response = await llm.ainvoke(messages)
+    ...
+```
+
+See the [ReAct Agent pattern](patterns.md#react-agent-with-message-reducer) for `message_reducer()` in action, and the [Supervisor pattern](patterns.md#multi-agent-supervisor) for a custom `Reducer`.
+
+## `ScalarReducer`
+
+Last-write-wins reducer for single values. Unlike `Reducer` (which accumulates lists), `ScalarReducer` injects a bare value — the most recent non-`SKIP` contribution wins.
+
+```python
+temperature = ScalarReducer(
+    "temperature", event_type=TempSet, fn=lambda e: e.value, default=0.7
+)
+```
+
+### `SKIP`
+
+When a `ScalarReducer` function returns `SKIP`, the reducer value is left unchanged. This distinguishes "set to `None`" from "don't update."
+
+```python
+from langgraph_events import SKIP, ScalarReducer
+
+temperature = ScalarReducer(
+    "temperature", event_type=ConfigUpdated, fn=lambda e: e.temp if e.temp is not None else SKIP, default=0.7
+)
+```

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,0 +1,68 @@
+# Streaming
+
+Real-time event streaming, LLM token deltas, and custom telemetry from handlers. Use streaming when you need live UI updates instead of waiting for the full run to complete.
+
+All `invoke`/`stream` methods have async counterparts: `ainvoke()`, `astream_events()`, `aresume()`, `astream_resume()`.
+
+```python
+# Async stream with real-time LLM token deltas and passthrough custom frames
+from langgraph_events import (
+    CustomEventFrame,
+    LLMStreamEnd,
+    LLMToken,
+    StateSnapshotFrame,
+    emit_state_snapshot,
+    emit_custom,
+)
+
+
+@on(SeedEvent)
+def step(event: SeedEvent) -> ReplyProduced:
+    emit_state_snapshot({"messages": [], "step": "draft"})
+    emit_custom("tool.progress", {"pct": 50})
+    return ReplyProduced(...)
+
+
+async for item in graph.astream_events(
+    SeedEvent(...),
+    include_llm_tokens=True,
+    include_custom_events=True,
+):
+    if isinstance(item, LLMToken):
+        print(item.content, end="")
+    elif isinstance(item, LLMStreamEnd):
+        print("\n[done]", item.message_id)
+    elif isinstance(item, StateSnapshotFrame):
+        print("snapshot:", item.data)
+    elif isinstance(item, CustomEventFrame):
+        print("custom:", item.name, item.data)
+    else:
+        print(item)
+```
+
+## Stream Options
+
+| Flag | Enables | Frame types yielded |
+|------|---------|-------------------|
+| `include_reducers=True` | Reducer snapshots alongside events | `StreamFrame(event, reducers, changed_reducers)` |
+| `include_llm_tokens=True` | Real-time LLM token deltas | `LLMToken(run_id, content)`, `LLMStreamEnd(run_id, message_id)` |
+| `include_custom_events=True` | Custom event passthrough | `CustomEventFrame(name, data)`, `StateSnapshotFrame(data)` |
+
+## Emission Helpers
+
+Emit telemetry from inside handlers without importing LangGraph callback APIs directly:
+
+| Function | Use case |
+|----------|----------|
+| `emit_custom(name, data)` | Arbitrary stream-only telemetry (sync) |
+| `aemit_custom(name, data)` | Async variant |
+| `emit_state_snapshot(data)` | Typed state snapshot for UI (sync) |
+| `aemit_state_snapshot(data)` | Async variant |
+
+These surface in `astream_events(..., include_custom_events=True)` as `CustomEventFrame` or `StateSnapshotFrame`.
+
+## Reducer Deltas
+
+When `include_reducers=True`, each `StreamFrame` includes `changed_reducers: frozenset[str] | None` — the set of reducer names that the event actually updated. Consumers can use this to skip re-emitting unchanged state. `None` means delta metadata is not available.
+
+For streaming to AG-UI frontends, see the [AG-UI Adapter](agui.md).

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -16,15 +16,15 @@ from langgraph_events import (
 )
 
 
-@on(SeedEvent)
-def step(event: SeedEvent) -> ReplyProduced:
+@on(QueryReceived)
+def step(event: QueryReceived) -> ReplyProduced:
     emit_state_snapshot({"messages": [], "step": "draft"})
     emit_custom("tool.progress", {"pct": 50})
     return ReplyProduced(...)
 
 
 async for item in graph.astream_events(
-    SeedEvent(...),
+    QueryReceived(...),
     include_llm_tokens=True,
     include_custom_events=True,
 ):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,9 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Concepts: concepts.md
+  - Control Flow: control-flow.md
+  - Reducers: reducers.md
+  - Streaming: streaming.md
   - Patterns: patterns.md
   - API Reference: api.md
   - AG-UI Adapter: agui.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-events"
-version = "0.1.1"
+version = "0.2.0"
 description = "Opinionated event-driven abstraction for LangGraph. State IS events."
 requires-python = ">=3.10"
 license = "MIT"

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -2595,6 +2595,9 @@ def describe_EventGraph():
                 task.cancel()
                 log = await task
                 assert log.latest(Cancelled) is not None
+                # First invocation's Ended is discarded — partial events
+                # within the same handler node are never committed.
+                assert not log.has(Ended)
 
     def describe_mermaid():
 

--- a/uv.lock
+++ b/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-events"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "langgraph" },


### PR DESCRIPTION
## Summary

- **Split `concepts.md`** (367 → 203 lines) into focused pages: `control-flow.md`, `reducers.md`, `streaming.md` — each with a "when you need this" intro
- **Grouped `api.md`** from a flat 45-row table into 7 categorized sections (Events, Execution, Control Flow, Reducers, Streaming, Warnings, AG-UI)
- **Enriched `patterns.md`** with 1-2 sentence descriptions per example and cross-links to relevant concept pages
- **Added "Common Tasks" table** to `getting-started.md` mapping developer goals to features/docs
- **Updated nav** across `index.md`, `mkdocs.yml`, and added cross-links between pages
- **Fixed `StreamFrame`** api.md entry to include `changed_reducers` field

## Test plan

- [x] `mkdocs build --strict` passes with no warnings
- [ ] Verify all cross-links work on the rendered site
- [ ] Spot-check that no content was lost in the split

🤖 Generated with [Claude Code](https://claude.com/claude-code)