### PR TITLE
feat: field-level dispatch for @on decorator

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -13,7 +13,7 @@
 
 | Export            | Type       | Description                                     |
 |-------------------|------------|-------------------------------------------------|
-| `on`              | Decorator  | Subscribe a handler to one or more event types  |
+| `on`              | Decorator  | Subscribe a handler to one or more event types; supports `**field_matchers` kwargs for [field-level dispatch](control-flow.md#field-matchers--type-safe-resume-dispatch) |
 
 ## Graph & Execution
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,7 +13,7 @@
 
 | Export            | Type       | Description                                     |
 |-------------------|------------|-------------------------------------------------|
-| `on`              | Decorator  | Subscribe a handler to one or more event types; supports `**field_matchers` kwargs for [field-level dispatch](control-flow.md#field-matchers--type-safe-resume-dispatch) |
+| `on`              | Decorator  | Subscribe a handler to one or more event types; supports `**field_matchers` kwargs for [field-level dispatch](control-flow.md#field-matchers--narrow-dispatch-by-field-type) |
 
 ## Graph & Execution
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -54,7 +54,7 @@ def call_llm(event: Event, log: EventLog) -> AssistantMessage:
     ...
 ```
 
-**Field matchers** — narrow dispatch by requiring a field to be a specific type. The matched field is injected as a typed parameter:
+**Field matchers** — narrow dispatch by requiring a field to be a specific **type**. The handler only fires when the named field is an instance of the given type. If the handler signature includes a matching parameter, the value is injected automatically:
 
 ```python
 @on(Resumed, interrupted=ApprovalRequested)
@@ -62,7 +62,7 @@ def on_approval(event: Resumed, interrupted: ApprovalRequested) -> Confirmed:
     ...  # only fires when interrupted is an ApprovalRequested
 ```
 
-See [Control Flow — Field Matchers](control-flow.md#field-matchers--type-safe-resume-dispatch) for details.
+See [Control Flow — Field Matchers](control-flow.md#field-matchers--narrow-dispatch-by-field-type) for details.
 
 ## `EventGraph`
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -54,6 +54,16 @@ def call_llm(event: Event, log: EventLog) -> AssistantMessage:
     ...
 ```
 
+**Field matchers** — narrow dispatch by requiring a field to be a specific type. The matched field is injected as a typed parameter:
+
+```python
+@on(Resumed, interrupted=ApprovalRequested)
+def on_approval(event: Resumed, interrupted: ApprovalRequested) -> Confirmed:
+    ...  # only fires when interrupted is an ApprovalRequested
+```
+
+See [Control Flow — Field Matchers](control-flow.md#field-matchers--type-safe-resume-dispatch) for details.
+
 ## `EventGraph`
 
 The main entry point. Pass a list of handler functions and `EventGraph` derives the topology.

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -78,4 +78,31 @@ if state.is_interrupted:
 log = graph.resume(ApprovalSubmitted(approved=True), config=config)
 ```
 
+### Field Matchers — Type-Safe Resume Dispatch
+
+When multiple interrupt types exist, a plain `@on(Resumed)` handler must manually `isinstance`-check the `interrupted` field. **Field matchers** narrow dispatch at the decorator level and inject the matched field as a typed parameter:
+
+```python
+@on(Resumed, interrupted=OrderConfirmationRequested)
+def handle_order_confirmation(
+    event: Resumed, interrupted: OrderConfirmationRequested,
+) -> OrderConfirmed | OrderCancelled:
+    # `interrupted` is guaranteed to be OrderConfirmationRequested —
+    # the handler only fires when the field matches.
+    print(f"Order {interrupted.order_id}: ${interrupted.total}")
+    ...
+```
+
+Field matchers work on any event field typed as `Event`, not just `interrupted`. If the named field is `None` or doesn't match the given type, the handler is silently skipped. The field name is validated at graph construction — typos raise `TypeError` immediately.
+
+If the handler signature omits the field parameter, the matcher still filters dispatch but no injection occurs:
+
+```python
+@on(Resumed, interrupted=OrderConfirmationRequested)
+def handle_order_confirmation(event: Resumed) -> OrderConfirmed:
+    # Still only fires for OrderConfirmationRequested interrupts,
+    # but you'd access event.interrupted directly.
+    ...
+```
+
 See the [Human-in-the-Loop pattern](patterns.md#human-in-the-loop-approval) for a complete example, and [Checkpointer Evolution](checkpointer-evolution.md) for how graph changes affect interrupted checkpoints.

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -78,9 +78,9 @@ if state.is_interrupted:
 log = graph.resume(ApprovalSubmitted(approved=True), config=config)
 ```
 
-### Field Matchers — Type-Safe Resume Dispatch
+### Field Matchers — Narrow Dispatch by Field Type
 
-When multiple interrupt types exist, a plain `@on(Resumed)` handler must manually `isinstance`-check the `interrupted` field. **Field matchers** narrow dispatch at the decorator level and inject the matched field as a typed parameter:
+**Field matchers** narrow dispatch by requiring a field on the event to be a specific type. Pass `field_name=EventType` as a keyword argument to `@on()` — the handler only fires when that field is an instance of the given type. If the handler signature includes a parameter with the same name, the matched value is injected automatically:
 
 ```python
 @on(Resumed, interrupted=OrderConfirmationRequested)

--- a/src/langgraph_events/_handler.py
+++ b/src/langgraph_events/_handler.py
@@ -61,9 +61,10 @@ def on(*event_types: type[Event], **field_matchers: type[Event]) -> Callable[[F]
             field_name in getattr(et, "__dataclass_fields__", {}) for et in event_types
         )
         if not has_field:
+            type_names = ", ".join(t.__name__ for t in event_types)
             raise TypeError(
                 f"@on() field matcher references {field_name!r}, but "
-                f"no field {field_name!r} exists on {event_types!r}"
+                f"no field {field_name!r} exists on ({type_names})"
             )
 
     def decorator(fn: F) -> F:
@@ -89,6 +90,12 @@ class HandlerMeta:
     store_param: str | None = None
     field_matchers: tuple[tuple[str, type[Event]], ...] = ()
     field_inject_params: frozenset[str] = frozenset()
+
+    def matches(self, event: Event) -> bool:
+        """Check whether *event* satisfies this handler's type + field matchers."""
+        return isinstance(event, self.event_types) and all(
+            isinstance(getattr(event, fn, None), ft) for fn, ft in self.field_matchers
+        )
 
     @property
     def wants_log(self) -> bool:

--- a/src/langgraph_events/_handler.py
+++ b/src/langgraph_events/_handler.py
@@ -20,10 +20,17 @@ if TYPE_CHECKING:
     from langgraph_events._types import F, HandlerReturn
 
 
-def on(*event_types: type[Event]) -> Callable[[F], F]:
+def on(*event_types: type[Event], **field_matchers: type[Event]) -> Callable[[F], F]:
     """Decorator that subscribes a handler to one or more event types.
 
     Multi-subscription: the handler fires when ANY of the listed types arrive.
+
+    Field matchers narrow dispatch further — the handler only fires when the
+    named field is an instance of the given type::
+
+        @on(Resumed, interrupted=ApprovalRequested)
+        def handle(event: Resumed, interrupted: ApprovalRequested):
+            interrupted.draft  # type-safe, framework-guaranteed
 
     Examples::
 
@@ -42,8 +49,27 @@ def on(*event_types: type[Event]) -> Callable[[F], F]:
         if not (isinstance(et, type) and issubclass(et, Event)):
             raise TypeError(f"@on() requires Event subclasses, got {et!r}")
 
+    # Validate field matchers
+    for field_name, field_type in field_matchers.items():
+        if not (isinstance(field_type, type) and issubclass(field_type, Event)):
+            raise TypeError(
+                f"@on() field matcher values must be Event subclasses, "
+                f"got {field_type!r} for field {field_name!r}"
+            )
+        # Check that at least one event type declares this field
+        has_field = any(
+            field_name in getattr(et, "__dataclass_fields__", {}) for et in event_types
+        )
+        if not has_field:
+            raise TypeError(
+                f"@on() field matcher references {field_name!r}, but "
+                f"no field {field_name!r} exists on {event_types!r}"
+            )
+
     def decorator(fn: F) -> F:
         fn._event_types = event_types  # type: ignore[attr-defined]
+        if field_matchers:
+            fn._field_matchers = dict(field_matchers)  # type: ignore[attr-defined]
         return fn
 
     return decorator
@@ -61,6 +87,8 @@ class HandlerMeta:
     reducer_params: tuple[str, ...] = ()
     config_param: str | None = None
     store_param: str | None = None
+    field_matchers: tuple[tuple[str, type[Event]], ...] = ()
+    field_inject_params: frozenset[str] = frozenset()
 
     @property
     def wants_log(self) -> bool:
@@ -112,6 +140,13 @@ def extract_handler_meta(
     sig = inspect.signature(fn)
     reducer_params = tuple(name for name in sig.parameters if name in reducer_names)
 
+    # Extract field matchers
+    raw_field_matchers: dict[str, type[Event]] = getattr(fn, "_field_matchers", {})
+    field_matchers = tuple(raw_field_matchers.items())
+    field_inject_params = frozenset(
+        name for name in sig.parameters if name in raw_field_matchers
+    )
+
     # Warn about handler params that don't match any known injection source
     if reducer_names:
         first_param = next(iter(sig.parameters), None)
@@ -123,6 +158,7 @@ def extract_handler_meta(
         if store_param:
             known_params.add(store_param)
         known_params.update(reducer_names)
+        known_params.update(raw_field_matchers.keys())
         unknown = [
             name
             for name in sig.parameters
@@ -145,4 +181,6 @@ def extract_handler_meta(
         reducer_params=reducer_params,
         config_param=config_param,
         store_param=store_param,
+        field_matchers=field_matchers,
+        field_inject_params=field_inject_params,
     )

--- a/src/langgraph_events/_internal.py
+++ b/src/langgraph_events/_internal.py
@@ -154,14 +154,7 @@ def make_dispatch(
         matched: list[str] = []
         seen: set[str] = set()
         for meta in handler_metas:
-            if meta.name not in seen and any(
-                isinstance(e, meta.event_types)
-                and all(
-                    isinstance(getattr(e, fn, None), ft)
-                    for fn, ft in meta.field_matchers
-                )
-                for e in pending
-            ):
+            if meta.name not in seen and any(meta.matches(e) for e in pending):
                 seen.add(meta.name)
                 matched.append(meta.name)
 
@@ -264,14 +257,7 @@ def make_handler_node(
     def _prepare(
         state: StateDict, config: RunnableConfig
     ) -> tuple[list[Event], dict[str, Any]]:
-        matching = [
-            e
-            for e in state["_pending"]
-            if isinstance(e, meta.event_types)
-            and all(
-                isinstance(getattr(e, fn, None), ft) for fn, ft in meta.field_matchers
-            )
-        ]
+        matching = [e for e in state["_pending"] if meta.matches(e)]
         inject = _build_inject(meta, state, reds, config)
         return matching, inject
 

--- a/src/langgraph_events/_internal.py
+++ b/src/langgraph_events/_internal.py
@@ -155,7 +155,12 @@ def make_dispatch(
         seen: set[str] = set()
         for meta in handler_metas:
             if meta.name not in seen and any(
-                isinstance(e, meta.event_types) for e in pending
+                isinstance(e, meta.event_types)
+                and all(
+                    isinstance(getattr(e, fn, None), ft)
+                    for fn, ft in meta.field_matchers
+                )
+                for e in pending
             ):
                 seen.add(meta.name)
                 matched.append(meta.name)
@@ -218,6 +223,20 @@ def _apply_reducers(
     return updates
 
 
+def _inject_fields(
+    meta: HandlerMeta,
+    event: Event,
+    inject: dict[str, Any],
+) -> dict[str, Any]:
+    """Add field-matcher values to the injection dict for a single event."""
+    if not meta.field_inject_params:
+        return inject
+    merged = dict(inject)
+    for field_name in meta.field_inject_params:
+        merged[field_name] = getattr(event, field_name)
+    return merged
+
+
 def make_handler_node(
     meta: HandlerMeta,
     reducers: dict[str, BaseReducer] | None = None,
@@ -245,7 +264,14 @@ def make_handler_node(
     def _prepare(
         state: StateDict, config: RunnableConfig
     ) -> tuple[list[Event], dict[str, Any]]:
-        matching = [e for e in state["_pending"] if isinstance(e, meta.event_types)]
+        matching = [
+            e
+            for e in state["_pending"]
+            if isinstance(e, meta.event_types)
+            and all(
+                isinstance(getattr(e, fn, None), ft) for fn, ft in meta.field_matchers
+            )
+        ]
         inject = _build_inject(meta, state, reds, config)
         return matching, inject
 
@@ -272,6 +298,7 @@ def make_handler_node(
         )
         try:
             for event in matching:
+                call_inject = _inject_fields(meta, event, inject)
                 if meta.is_async:
                     try:
                         asyncio.get_running_loop()
@@ -279,7 +306,7 @@ def make_handler_node(
                         # No running loop — safe to use asyncio.run().
                         coro = cast(
                             "Coroutine[Any, Any, HandlerReturn]",
-                            meta.fn(event, **inject),
+                            meta.fn(event, **call_inject),
                         )
                         result = asyncio.run(coro)
                     else:
@@ -290,7 +317,7 @@ def make_handler_node(
                             f"Use ainvoke() instead."
                         )
                 else:
-                    result = meta.fn(event, **inject)
+                    result = meta.fn(event, **call_inject)
                 _collect_result(result, new_events, lg_interrupt)
         finally:
             _reset_custom_emitters(tokens)
@@ -313,13 +340,15 @@ def make_handler_node(
         )
         try:
             for event in matching:
+                call_inject = _inject_fields(meta, event, inject)
                 if meta.is_async:
                     coro = cast(
-                        "Coroutine[Any, Any, HandlerReturn]", meta.fn(event, **inject)
+                        "Coroutine[Any, Any, HandlerReturn]",
+                        meta.fn(event, **call_inject),
                     )
                     result = await coro
                 else:
-                    result = meta.fn(event, **inject)
+                    result = meta.fn(event, **call_inject)
                 _collect_result(result, new_events, lg_interrupt)
         except asyncio.CancelledError:
             return _finalize([Cancelled()])

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -960,25 +960,43 @@ def describe_EventGraph():
         def when_field_is_none():
 
             def it_skips_the_handler():
-                """Resumed with interrupted=None should not match a field matcher."""
+                """A None field value does not match a field matcher."""
+                from langgraph.checkpoint.memory import MemorySaver
 
                 class ApprovalRequested(Interrupted):
                     draft: str = ""
 
+                class OtherInterrupted(Interrupted):
+                    reason: str = ""
+
+                class Acknowledge(Event):
+                    pass
+
                 captured = []
 
+                @on(Started)
+                def need_input(event: Started) -> OtherInterrupted:
+                    return OtherInterrupted(reason="test")
+
                 @on(Resumed, interrupted=ApprovalRequested)
-                def handler(event: Resumed) -> Ended:
-                    captured.append("fired")
-                    return Ended(result="matched")
+                def approval_handler(event: Resumed) -> Ended:
+                    captured.append("should not fire")
+                    return Ended(result="approval")
 
-                # Manually create a Resumed with interrupted=None
-                r = Resumed()
-                assert r.interrupted is None
+                @on(Acknowledge)
+                def fallback(event: Acknowledge) -> Ended:
+                    return Ended(result="fallback")
 
-                # The handler should not match — verified via dispatch predicate
-                # isinstance(None, ApprovalRequested) is False — dispatch skips
-                assert not isinstance(r.interrupted, ApprovalRequested)
+                graph = EventGraph(
+                    [need_input, approval_handler, fallback],
+                    checkpointer=MemorySaver(),
+                )
+                config = {"configurable": {"thread_id": "field-none-test"}}
+                graph.invoke(Started(data="test"), config=config)
+                log = graph.resume(Acknowledge(), config=config)
+
+                assert len(captured) == 0
+                assert log.latest(Ended) == Ended(result="fallback")
 
         def when_handler_requests_field_injection():
 
@@ -1016,6 +1034,86 @@ def describe_EventGraph():
                 assert len(injected_values) == 1
                 assert isinstance(injected_values[0], ApprovalRequested)
                 assert injected_values[0].draft == "my draft"
+
+        def when_multiple_field_matchers():
+
+            def it_requires_all_fields_to_match():
+                from langgraph.checkpoint.memory import MemorySaver
+
+                class ApprovalRequested(Interrupted):
+                    draft: str = ""
+
+                class ReviewApproved(Event):
+                    pass
+
+                captured = []
+
+                @on(Started)
+                def need_input(event: Started) -> ApprovalRequested:
+                    return ApprovalRequested(draft="hello")
+
+                @on(Resumed, interrupted=ApprovalRequested, value=ReviewApproved)
+                def strict_handler(
+                    event: Resumed,
+                    interrupted: ApprovalRequested,
+                    value: ReviewApproved,
+                ) -> Ended:
+                    captured.append((interrupted, value))
+                    return Ended(result="strict")
+
+                graph = EventGraph(
+                    [need_input, strict_handler],
+                    checkpointer=MemorySaver(),
+                )
+                config = {"configurable": {"thread_id": "multi-field-test"}}
+                graph.invoke(Started(data="test"), config=config)
+                log = graph.resume(ReviewApproved(), config=config)
+
+                assert log.latest(Ended) == Ended(result="strict")
+                assert len(captured) == 1
+                assert isinstance(captured[0][0], ApprovalRequested)
+                assert isinstance(captured[0][1], ReviewApproved)
+
+            def when_one_field_does_not_match():
+
+                def it_skips_the_handler():
+                    from langgraph.checkpoint.memory import MemorySaver
+
+                    class ApprovalRequested(Interrupted):
+                        draft: str = ""
+
+                    class ReviewApproved(Event):
+                        pass
+
+                    class OtherEvent(Event):
+                        pass
+
+                    captured = []
+
+                    @on(Started)
+                    def need_input(event: Started) -> ApprovalRequested:
+                        return ApprovalRequested(draft="hello")
+
+                    # value=OtherEvent won't match ReviewApproved
+                    @on(Resumed, interrupted=ApprovalRequested, value=OtherEvent)
+                    def strict_handler(event: Resumed) -> Ended:
+                        captured.append("should not fire")
+                        return Ended(result="strict")
+
+                    @on(ReviewApproved)
+                    def fallback(event: ReviewApproved) -> Ended:
+                        return Ended(result="fallback")
+
+                    graph = EventGraph(
+                        [need_input, strict_handler, fallback],
+                        checkpointer=MemorySaver(),
+                    )
+                    config = {"configurable": {"thread_id": "multi-field-skip"}}
+                    graph.invoke(Started(data="test"), config=config)
+                    log = graph.resume(ReviewApproved(), config=config)
+
+                    assert len(captured) == 0
+                    assert log.latest(Ended) == Ended(result="fallback")
 
     def describe_scatter():
 

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -881,6 +881,142 @@ def describe_EventGraph():
             )
             assert log.latest(Ended) == Ended(result="done")
 
+    def describe_field_matchers():
+
+        def when_field_matches():
+
+            def it_dispatches_the_handler():
+                from langgraph.checkpoint.memory import MemorySaver
+
+                class ApprovalRequested(Interrupted):
+                    draft: str = ""
+
+                class ReviewApproved(Event):
+                    pass
+
+                captured = []
+
+                @on(Started)
+                def need_input(event: Started) -> ApprovalRequested:
+                    return ApprovalRequested(draft="hello")
+
+                @on(Resumed, interrupted=ApprovalRequested)
+                def handle_approval(event: Resumed) -> Ended:
+                    captured.append(event.interrupted)
+                    return Ended(result="approved")
+
+                graph = EventGraph(
+                    [need_input, handle_approval],
+                    checkpointer=MemorySaver(),
+                )
+                config = {"configurable": {"thread_id": "field-match-test"}}
+                graph.invoke(Started(data="test"), config=config)
+                log = graph.resume(ReviewApproved(), config=config)
+
+                assert log.latest(Ended) == Ended(result="approved")
+                assert len(captured) == 1
+                assert isinstance(captured[0], ApprovalRequested)
+
+        def when_field_does_not_match():
+
+            def it_skips_the_handler():
+                from langgraph.checkpoint.memory import MemorySaver
+
+                class ApprovalRequested(Interrupted):
+                    draft: str = ""
+
+                class OtherInterrupted(Interrupted):
+                    reason: str = ""
+
+                class ReviewApproved(Event):
+                    pass
+
+                captured = []
+
+                @on(Started)
+                def need_input(event: Started) -> OtherInterrupted:
+                    return OtherInterrupted(reason="different")
+
+                @on(Resumed, interrupted=ApprovalRequested)
+                def handle_approval(event: Resumed) -> Ended:
+                    captured.append("should not fire")
+                    return Ended(result="approved")
+
+                @on(ReviewApproved)
+                def fallback(event: ReviewApproved) -> Ended:
+                    return Ended(result="fallback")
+
+                graph = EventGraph(
+                    [need_input, handle_approval, fallback],
+                    checkpointer=MemorySaver(),
+                )
+                config = {"configurable": {"thread_id": "field-no-match-test"}}
+                graph.invoke(Started(data="test"), config=config)
+                log = graph.resume(ReviewApproved(), config=config)
+
+                assert len(captured) == 0
+                assert log.latest(Ended) == Ended(result="fallback")
+
+        def when_field_is_none():
+
+            def it_skips_the_handler():
+                """Resumed with interrupted=None should not match a field matcher."""
+
+                class ApprovalRequested(Interrupted):
+                    draft: str = ""
+
+                captured = []
+
+                @on(Resumed, interrupted=ApprovalRequested)
+                def handler(event: Resumed) -> Ended:
+                    captured.append("fired")
+                    return Ended(result="matched")
+
+                # Manually create a Resumed with interrupted=None
+                r = Resumed()
+                assert r.interrupted is None
+
+                # The handler should not match — verified via dispatch predicate
+                # isinstance(None, ApprovalRequested) is False — dispatch skips
+                assert not isinstance(r.interrupted, ApprovalRequested)
+
+        def when_handler_requests_field_injection():
+
+            def it_injects_the_narrowed_field():
+                from langgraph.checkpoint.memory import MemorySaver
+
+                class ApprovalRequested(Interrupted):
+                    draft: str = ""
+
+                class ReviewApproved(Event):
+                    pass
+
+                injected_values = []
+
+                @on(Started)
+                def need_input(event: Started) -> ApprovalRequested:
+                    return ApprovalRequested(draft="my draft")
+
+                @on(Resumed, interrupted=ApprovalRequested)
+                def handle_approval(
+                    event: Resumed, interrupted: ApprovalRequested
+                ) -> Ended:
+                    injected_values.append(interrupted)
+                    return Ended(result=interrupted.draft)
+
+                graph = EventGraph(
+                    [need_input, handle_approval],
+                    checkpointer=MemorySaver(),
+                )
+                config = {"configurable": {"thread_id": "field-inject-test"}}
+                graph.invoke(Started(data="test"), config=config)
+                log = graph.resume(ReviewApproved(), config=config)
+
+                assert log.latest(Ended) == Ended(result="my draft")
+                assert len(injected_values) == 1
+                assert isinstance(injected_values[0], ApprovalRequested)
+                assert injected_values[0].draft == "my draft"
+
     def describe_scatter():
 
         class BatchReceived(Event):

--- a/tests/test_on_decorator.py
+++ b/tests/test_on_decorator.py
@@ -5,6 +5,7 @@ import warnings
 import pytest
 
 from langgraph_events import Event, EventGraph, EventLog, on
+from langgraph_events._event import Interrupted, Resumed
 from langgraph_events._handler import extract_handler_meta
 
 
@@ -18,6 +19,14 @@ class EventA(Event):
 
 class EventB(Event):
     b: str = ""
+
+
+class ApprovalRequested(Interrupted):
+    draft: str = ""
+
+
+class OtherInterrupted(Interrupted):
+    reason: str = ""
 
 
 def describe_on_decorator():
@@ -65,6 +74,40 @@ def describe_on_decorator():
 
                 @on(EventA, str)  # type: ignore
                 async def handler(event):
+                    pass
+
+    def when_field_matcher_provided():
+
+        def it_attaches_field_matchers():
+            @on(Resumed, interrupted=ApprovalRequested)
+            def handler(event: Resumed, interrupted: ApprovalRequested):
+                pass
+
+            assert handler._field_matchers == {"interrupted": ApprovalRequested}
+
+        def it_attaches_event_types_alongside():
+            @on(Resumed, interrupted=ApprovalRequested)
+            def handler(event: Resumed, interrupted: ApprovalRequested):
+                pass
+
+            assert handler._event_types == (Resumed,)
+
+    def when_field_matcher_references_nonexistent_field():
+
+        def it_raises_type_error():
+            with pytest.raises(TypeError, match=r"no field.*bogus"):
+
+                @on(Resumed, bogus=ApprovalRequested)
+                def handler(event: Resumed):
+                    pass
+
+    def when_field_matcher_value_is_not_event_subclass():
+
+        def it_raises_type_error():
+            with pytest.raises(TypeError, match="Event subclass"):
+
+                @on(Resumed, interrupted=str)  # type: ignore
+                def handler(event: Resumed):
                     pass
 
 
@@ -196,6 +239,46 @@ def describe_extract_handler_meta():
             meta = extract_handler_meta(handler)
             assert meta.event_types == (EventA, EventB)
             assert meta.wants_log is True
+
+    def when_field_matchers_in_meta():
+
+        def it_extracts_field_matchers():
+            @on(Resumed, interrupted=ApprovalRequested)
+            def handler(event: Resumed, interrupted: ApprovalRequested):
+                pass
+
+            meta = extract_handler_meta(handler)
+            assert meta.field_matchers == (("interrupted", ApprovalRequested),)
+
+        def it_identifies_field_inject_params_from_signature():
+            @on(Resumed, interrupted=ApprovalRequested)
+            def handler(event: Resumed, interrupted: ApprovalRequested):
+                pass
+
+            meta = extract_handler_meta(handler)
+            assert meta.field_inject_params == frozenset({"interrupted"})
+
+        def when_field_param_not_in_signature():
+
+            def it_omits_field_inject():
+                @on(Resumed, interrupted=ApprovalRequested)
+                def handler(event: Resumed):
+                    pass
+
+                meta = extract_handler_meta(handler)
+                assert meta.field_inject_params == frozenset()
+
+        def it_does_not_warn_about_field_inject_params():
+            @on(Resumed, interrupted=ApprovalRequested)
+            def handler(event: Resumed, interrupted: ApprovalRequested):
+                pass
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                extract_handler_meta(handler, reducer_names=frozenset({"messages"}))
+
+            typo_warnings = [x for x in w if "Typo?" in str(x.message)]
+            assert len(typo_warnings) == 0
 
     def when_type_hints_cannot_be_resolved():
 


### PR DESCRIPTION
## Summary

- Add `**field_matchers` kwargs to `@on()` decorator for type-safe field-level dispatch: `@on(Resumed, interrupted=ApprovalRequested)`
- Handler only fires when the named field is an instance of the given type; matched field is injected as a typed parameter when present in the handler signature
- Validated at decoration time — typos in field names or non-Event matcher types raise `TypeError` immediately
- Zero breaking changes — existing `@on(EventType)` usage is unaffected

## Files changed

- `src/langgraph_events/_handler.py` — `on()` kwargs, `HandlerMeta` fields, `extract_handler_meta`
- `src/langgraph_events/_internal.py` — dispatch predicate, handler filtering, per-event field injection
- `tests/test_on_decorator.py` — 7 unit tests for decorator and metadata extraction
- `tests/test_event_graph.py` — 4 integration tests (dispatch match/skip, None handling, injection)
- `docs/control-flow.md`, `docs/concepts.md`, `docs/api.md` — document new feature

## Test plan

- [x] `uv run pytest tests/` — 324 passed, 0 failures
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] Pre-commit hooks (ruff format, validate tests, mypy, jscpd, pytest) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)