### PR TITLE
ci: add PyPI publishing with trusted publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  test-publish:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: astral-sh/setup-uv@v5
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - run: uv publish --trusted-publishing always --publish-url https://test.pypi.org/legacy/
+
+  publish:
+    name: Publish to PyPI
+    needs: test-publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: astral-sh/setup-uv@v5
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - run: uv publish --trusted-publishing always

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,15 +3,27 @@ name: Publish
 on:
   push:
     tags:
-      - v*
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   build:
-    name: Build distributions
+    name: Build and validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+      - run: uv sync --group dev
+      - name: Verify tag matches package version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          PKG=$(grep '^version' pyproject.toml | head -1 | cut -d'"' -f2)
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag v$TAG does not match pyproject.toml version $PKG"
+            exit 1
+          fi
+      - run: uv run ruff check src/ tests/
+      - run: uv run mypy src/
+      - run: uv run pytest tests/
       - run: uv build
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0]
+## [0.2.0] - 2026-04-06
 
 ### Added
 - Field-level dispatch for `@on` decorator
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `connect()` yielding no events for new threads
 - Resume interrupt detection for interrupts created during resume
 
-## [0.1.0]
+## [0.1.0] - 2026-02-20
 
 ### Added
 - Core `Event`, `EventGraph`, and `@on` decorator
@@ -42,3 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mermaid diagram generation
 - BDD-style test suite with pytest-describe
 - CI workflow (lint, typecheck, test)
+
+[Unreleased]: https://github.com/cadance-io/langgraph-events/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/cadance-io/langgraph-events/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/cadance-io/langgraph-events/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0]
+
+### Added
+- Field-level dispatch for `@on` decorator
+- AG-UI protocol adapter with `langgraph-events[agui]` optional dependency
+- Custom event emit helpers (`emit_custom`, `aemit_custom`, `emit_state_snapshot`, `aemit_state_snapshot`)
+- First-class `StateSnapshotFrame` for state snapshot streaming
+- `SKIP` sentinel for scalar reducer no-op returns
+- Graceful `Halted` subtypes (`MaxRoundsExceeded`, `Cancelled`) and `OrphanedEventWarning`
+- LLM token streaming (`LLMToken`, `LLMStreamEnd` frames)
+- MkDocs documentation site on GitHub Pages
+
+### Changed
+- Restructured docs for better DX (split concepts, grouped API reference)
+- `Interrupted` is now a bare marker class — subclass with typed fields
+
+### Fixed
+- AG-UI adapter message deduplication and ID reconciliation
+- `connect()` yielding no events for new threads
+- Resume interrupt detection for interrupts created during resume
+
+## [0.1.0]
+
+### Added
+- Core `Event`, `EventGraph`, and `@on` decorator
+- `Reducer` and `ScalarReducer` for custom state channels
+- `EventLog` with query methods (`first`, `count`, `after`, `before`, `select`)
+- Multi-subscription `@on(A, B)` and `Scatter` for fan-out
+- `Auditable` and `MessageEvent` base events
+- `SystemPromptSet` event for system prompts
+- Config and store injection for handlers
+- `Interrupted` / `Resumed` events for human-in-the-loop
+- Mermaid diagram generation
+- BDD-style test suite with pytest-describe
+- CI workflow (lint, typecheck, test)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing
+
+## Development
+
+```bash
+uv sync --group dev
+uv run pytest tests/
+uv run ruff check src/ tests/
+uv run ruff format src/ tests/
+uv run mypy src/
+```
+
+## Releasing
+
+### One-time setup
+
+Before the first release, the repo owner must:
+
+1. **Register trusted publishers on PyPI** — go to [pypi.org/manage/account/publishing](https://pypi.org/manage/account/publishing/) and add a pending trusted publisher:
+   - Project name: `langgraph-events`
+   - Owner: `cadance-io`
+   - Repository: `langgraph-events`
+   - Workflow: `publish.yml`
+   - Environment: `pypi`
+
+2. **Register trusted publishers on TestPyPI** — go to [test.pypi.org/manage/account/publishing](https://test.pypi.org/manage/account/publishing/) with the same details, except environment: `testpypi`
+
+3. **Create GitHub environments** — go to repo Settings → Environments and create `pypi` and `testpypi`
+
+### Cutting a release
+
+1. Make sure `CHANGELOG.md` has entries under `[Unreleased]`.
+
+2. Run the release script:
+
+   ```bash
+   # Preview changes
+   uv run python scripts/release.py minor --dry-run
+
+   # Cut the release (bumps version, stamps changelog, commits, tags)
+   uv run python scripts/release.py minor
+   ```
+
+   The script accepts `major`, `minor`, `patch`, or an explicit version like `1.0.0`.
+
+3. Push to trigger the publish workflow:
+
+   ```bash
+   git push origin main v0.3.0
+   ```
+
+   The workflow builds the package, publishes to TestPyPI first, then to PyPI.
+
+### What the release script does
+
+`scripts/release.py` automates:
+
+- Bumps version in `pyproject.toml`, `README.md`, `docs/index.md`
+- Stamps `[Unreleased]` in `CHANGELOG.md` with the new version and today's date
+- Updates changelog footer comparison links
+- Runs `uv lock` to sync `uv.lock`
+- Commits with message `release: vX.Y.Z`
+- Creates git tag `vX.Y.Z`
+
+Preflight checks ensure you're on `main`, working tree is clean, `[Unreleased]` has content, and the tag doesn't already exist.
+
+### Changelog
+
+We use [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Add entries under `[Unreleased]` as you work — the release script moves them to the new version section automatically.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ print(log.latest(ReplyProduced))
 ## Installation
 
 ```bash
-pip install git+https://github.com/cadance-io/langgraph-events.git
+pip install langgraph-events
 
 # With AG-UI adapter support
-pip install "langgraph-events[agui] @ git+https://github.com/cadance-io/langgraph-events.git"
+pip install "langgraph-events[agui]"
+
+# From source (development)
+pip install git+https://github.com/cadance-io/langgraph-events.git
 ```
 
 ## Documentation

--- a/docs/agui.md
+++ b/docs/agui.md
@@ -15,7 +15,7 @@ RunAgentInput -> AGUIAdapter.connect/reconnect -> checkpoint snapshots + interru
 ## Install
 
 ```bash
-pip install "langgraph-events[agui] @ git+https://github.com/cadance-io/langgraph-events.git"
+pip install "langgraph-events[agui]"
 ```
 
 You'll also need `starlette` or `fastapi` for the HTTP layer.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,13 +13,11 @@ The core principle: **state IS events.** The entire state of a run is an append-
 
 ## Installation
 
-Not published to PyPI yet. Install directly from GitHub:
-
 ```bash
-pip install git+https://github.com/cadance-io/langgraph-events.git
+pip install langgraph-events
 
 # With AG-UI adapter support (installs ag-ui-protocol)
-pip install "langgraph-events[agui] @ git+https://github.com/cadance-io/langgraph-events.git"
+pip install "langgraph-events[agui]"
 ```
 
 Requires Python 3.10+ and `langgraph >= 0.2.0` (installed automatically). The `[agui]` extra adds `ag-ui-protocol` for the [AG-UI protocol adapter](agui.md).
@@ -41,6 +39,6 @@ Requires Python 3.10+ and `langgraph >= 0.2.0` (installed automatically). The `[
 
 This is a solo experiment, not a team-backed product. Expect:
 
-- No changelog or migration guides between versions
+- No migration guides between versions
 - API surface may shrink or change significantly
 - Bug reports welcome, but no SLA on fixes

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 Opinionated event-driven abstraction for LangGraph. **State IS events.**
 
 !!! warning "Experimental (v0.2.0)"
-    This is an early-stage personal project, not a supported product. The API will change without notice or migration path. Do not depend on this for anything you can't easily rewrite. Not published to PyPI.
+    This is an early-stage personal project, not a supported product. The API will change without notice or migration path. Do not depend on this for anything you can't easily rewrite.
 
 ## What is this?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,28 @@ version = "0.2.0"
 description = "Opinionated event-driven abstraction for LangGraph. State IS events."
 requires-python = ">=3.10"
 license = "MIT"
+authors = [{name = "cadance-io"}]
+readme = "README.md"
+keywords = ["langgraph", "events", "event-driven", "state-machine"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
+]
 dependencies = [
     "langgraph>=0.2.0",
 ]
+
+[project.urls]
+Homepage = "https://cadance-io.github.io/langgraph-events/"
+Repository = "https://github.com/cadance-io/langgraph-events"
+Documentation = "https://cadance-io.github.io/langgraph-events/"
+Changelog = "https://github.com/cadance-io/langgraph-events/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 agui = ["ag-ui-protocol>=0.1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101", "PLR2004", "SIM117", "PLC0415", "PLR0915", "N802"]
 "examples/**" = ["T20", "PLR2004", "S101", "S307", "PLC0415", "E501"]
+"scripts/**" = ["S603", "S607"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["langgraph_events"]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parent.parent
 REPO_URL = "https://github.com/cadance-io/langgraph-events"
@@ -17,7 +18,7 @@ VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
 BUMP_TYPES = ("major", "minor", "patch")
 
 
-def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+def _run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         cmd, capture_output=True, text=True, check=False, cwd=ROOT, **kwargs
     )
@@ -103,8 +104,8 @@ def bump_version_strings(current: str, new: str, *, dry_run: bool) -> None:
     for path, old, new_str in replacements:
         text = path.read_text()
         if old not in text:
-            print(f"Warning: '{old}' not found in {path.name}", file=sys.stderr)
-            continue
+            print(f"Error: '{old}' not found in {path.name}", file=sys.stderr)
+            sys.exit(1)
         if dry_run:
             print(f"  {path.relative_to(ROOT)}: {old!r} → {new_str!r}", file=sys.stderr)
         else:
@@ -177,7 +178,7 @@ def sync_lockfile(*, dry_run: bool) -> None:
 
 
 def commit_and_tag(new: str) -> None:
-    _run(
+    subprocess.run(
         [
             "git",
             "add",
@@ -187,13 +188,19 @@ def commit_and_tag(new: str) -> None:
             "CHANGELOG.md",
             "uv.lock",
         ],
+        check=True,
+        cwd=ROOT,
     )
     subprocess.run(
         ["git", "commit", "-m", f"release: v{new}"],
         check=True,
         cwd=ROOT,
     )
-    _run(["git", "tag", f"v{new}"])
+    subprocess.run(
+        ["git", "tag", f"v{new}"],
+        check=True,
+        cwd=ROOT,
+    )
 
 
 def main() -> None:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Automate the release process: bump version, update changelog, commit, tag."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REPO_URL = "https://github.com/cadance-io/langgraph-events"
+
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+BUMP_TYPES = ("major", "minor", "patch")
+
+
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd, capture_output=True, text=True, check=False, cwd=ROOT, **kwargs
+    )
+
+
+def read_current_version() -> str:
+    text = (ROOT / "pyproject.toml").read_text()
+    match = re.search(r'^version = "(.+?)"', text, re.MULTILINE)
+    if not match:
+        print("Error: could not find version in pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+    return match.group(1)
+
+
+def compute_new_version(current: str, arg: str) -> str:
+    major, minor, patch = (int(x) for x in current.split("."))
+
+    if arg in BUMP_TYPES:
+        if arg == "major":
+            major, minor, patch = major + 1, 0, 0
+        elif arg == "minor":
+            minor, patch = minor + 1, 0
+        else:
+            patch += 1
+        return f"{major}.{minor}.{patch}"
+
+    if not VERSION_RE.match(arg):
+        print(f"Error: '{arg}' is not a valid bump type or version", file=sys.stderr)
+        sys.exit(1)
+
+    new_tuple = tuple(int(x) for x in arg.split("."))
+    cur_tuple = (major, minor, patch)
+    if new_tuple <= cur_tuple:
+        print(
+            f"Error: new version {arg} must be greater than current {current}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return arg
+
+
+def preflight(new_version: str) -> None:
+    errors: list[str] = []
+
+    result = _run(["git", "status", "--porcelain"])
+    if result.stdout.strip():
+        errors.append("Working tree is not clean. Commit or stash changes first.")
+
+    result = _run(["git", "branch", "--show-current"])
+    branch = result.stdout.strip()
+    if branch != "main":
+        errors.append(f"Must be on main branch (currently on '{branch}').")
+
+    changelog = (ROOT / "CHANGELOG.md").read_text()
+    unreleased_match = re.search(
+        r"## \[Unreleased\]\n(.*?)(?=\n## \[)", changelog, re.DOTALL
+    )
+    if not unreleased_match or not unreleased_match.group(1).strip():
+        errors.append("[Unreleased] section in CHANGELOG.md is empty.")
+
+    result = _run(["git", "tag", "--list", f"v{new_version}"])
+    if result.stdout.strip():
+        errors.append(f"Tag v{new_version} already exists.")
+
+    if errors:
+        for e in errors:
+            print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def bump_version_strings(current: str, new: str, *, dry_run: bool) -> None:
+    replacements = [
+        (ROOT / "pyproject.toml", f'version = "{current}"', f'version = "{new}"'),
+        (ROOT / "README.md", f"Experimental (v{current})", f"Experimental (v{new})"),
+        (
+            ROOT / "docs" / "index.md",
+            f"Experimental (v{current})",
+            f"Experimental (v{new})",
+        ),
+    ]
+
+    for path, old, new_str in replacements:
+        text = path.read_text()
+        if old not in text:
+            print(f"Warning: '{old}' not found in {path.name}", file=sys.stderr)
+            continue
+        if dry_run:
+            print(f"  {path.relative_to(ROOT)}: {old!r} → {new_str!r}", file=sys.stderr)
+        else:
+            path.write_text(text.replace(old, new_str, 1))
+
+
+def update_changelog(current: str, new: str, *, dry_run: bool) -> None:
+    path = ROOT / "CHANGELOG.md"
+    lines = path.read_text().splitlines(keepends=True)
+    today = date.today().isoformat()
+
+    # Find [Unreleased] heading and next version heading
+    unreleased_idx = None
+    next_version_idx = None
+    for i, line in enumerate(lines):
+        if line.startswith("## [Unreleased]"):
+            unreleased_idx = i
+        elif (
+            unreleased_idx is not None
+            and line.startswith("## [")
+            and i > unreleased_idx
+        ):
+            next_version_idx = i
+            break
+
+    if unreleased_idx is None or next_version_idx is None:
+        print("Error: could not parse CHANGELOG.md structure", file=sys.stderr)
+        sys.exit(1)
+
+    # Extract unreleased content (between headings)
+    unreleased_content = lines[unreleased_idx + 1 : next_version_idx]
+
+    # Rebuild file
+    result_lines = [
+        *lines[:unreleased_idx],
+        "## [Unreleased]\n",
+        "\n",
+        f"## [{new}] - {today}\n",
+        *unreleased_content,
+        *lines[next_version_idx:],
+    ]
+
+    # Update footer links
+    updated = []
+    link_inserted = False
+    for line in result_lines:
+        if line.startswith("[Unreleased]:"):
+            updated.append(f"[Unreleased]: {REPO_URL}/compare/v{new}...HEAD\n")
+            if not link_inserted:
+                updated.append(f"[{new}]: {REPO_URL}/compare/v{current}...v{new}\n")
+                link_inserted = True
+        else:
+            updated.append(line)
+
+    new_text = "".join(updated)
+
+    if dry_run:
+        print(
+            f"  CHANGELOG.md: stamp [Unreleased] as [{new}] - {today}", file=sys.stderr
+        )
+    else:
+        path.write_text(new_text)
+
+
+def sync_lockfile(*, dry_run: bool) -> None:
+    if dry_run:
+        print("  Would run: uv lock", file=sys.stderr)
+    else:
+        subprocess.run(["uv", "lock"], check=True, cwd=ROOT)
+
+
+def commit_and_tag(new: str) -> None:
+    _run(
+        [
+            "git",
+            "add",
+            "pyproject.toml",
+            "README.md",
+            "docs/index.md",
+            "CHANGELOG.md",
+            "uv.lock",
+        ],
+    )
+    subprocess.run(
+        ["git", "commit", "-m", f"release: v{new}"],
+        check=True,
+        cwd=ROOT,
+    )
+    _run(["git", "tag", f"v{new}"])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Release langgraph-events")
+    parser.add_argument(
+        "version",
+        help="Bump type (major/minor/patch) or explicit version (X.Y.Z)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without writing files",
+    )
+    args = parser.parse_args()
+
+    current = read_current_version()
+    new = compute_new_version(current, args.version)
+
+    print(f"Releasing: v{current} → v{new}", file=sys.stderr)
+    if args.dry_run:
+        print("(dry run — no files will be modified)\n", file=sys.stderr)
+
+    preflight(new)
+
+    print("\nVersion bumps:", file=sys.stderr)
+    bump_version_strings(current, new, dry_run=args.dry_run)
+
+    print("\nChangelog:", file=sys.stderr)
+    update_changelog(current, new, dry_run=args.dry_run)
+
+    print("\nLockfile:", file=sys.stderr)
+    sync_lockfile(dry_run=args.dry_run)
+
+    if not args.dry_run:
+        print("\nCommitting and tagging...", file=sys.stderr)
+        commit_and_tag(new)
+        print(
+            f"\n✅ Release v{new} is ready. Run:\n\n"
+            f"  git push origin main v{new}\n\n"
+            f"This will trigger the publish workflow (TestPyPI → PyPI).",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` — three-job workflow triggered on `v*` tags: **build → TestPyPI → PyPI** using OIDC trusted publishers (no API tokens needed)
- Build job runs lint, typecheck, and tests before publishing; validates tag matches `pyproject.toml` version
- Adds `scripts/release.py` — automates version bumping, changelog stamping, lockfile sync, commit, and tag
- Adds PyPI metadata to `pyproject.toml` (authors, readme, keywords, classifiers, project URLs)
- Adds `CHANGELOG.md` (Keep a Changelog format) with 0.1.0 and 0.2.0 entries
- Updates `README.md` install instructions to `pip install langgraph-events`
- Removes "Not published to PyPI" from docs banner

## Before first release

After merging, complete these one-time setup steps:

### 1. Register trusted publishers

**PyPI** — go to [pypi.org/manage/account/publishing](https://pypi.org/manage/account/publishing/) and add a pending trusted publisher:
- Project name: `langgraph-events`
- Owner: `cadance-io`
- Repository: `langgraph-events`
- Workflow: `publish.yml`
- Environment: `pypi`

**TestPyPI** — go to [test.pypi.org/manage/account/publishing](https://test.pypi.org/manage/account/publishing/) and add a pending trusted publisher:
- Project name: `langgraph-events`
- Owner: `cadance-io`
- Repository: `langgraph-events`
- Workflow: `publish.yml`
- Environment: `testpypi`

### 2. Create GitHub environments

Go to repo **Settings → Environments** and create two environments:
- `pypi`
- `testpypi`

Optionally add protection rules to `pypi` (e.g., required reviewers) for extra safety.

### 3. Release

```bash
# Preview what would change
uv run python scripts/release.py minor --dry-run

# Do the release (bumps version, updates changelog, commits, tags)
uv run python scripts/release.py minor   # or: patch, major, 0.3.0

# Push to trigger the publish workflow
git push origin main v0.3.0
```

The release script handles: version bump in `pyproject.toml`/`README.md`/`docs/index.md`, changelog stamping, `uv lock`, commit, and tag creation. Preflight checks ensure you're on `main`, tree is clean, `[Unreleased]` has content, and the tag doesn't exist yet.

## Test plan

- [x] `uv build` produces valid sdist + wheel locally
- [x] Wheel metadata contains all new fields (authors, classifiers, URLs)
- [x] `uv run ruff check src/` passes
- [x] Release script version parsing and validation tested
- [x] Release script preflight checks verified (dirty tree, wrong branch, empty changelog)
- [ ] After merging + setup: run `scripts/release.py` and push tag to verify full workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)