### PR TITLE
fix: init reducer state from checkpoint in _astream_v2 and make_seed_node

### DIFF
--- a/docs/reducers.md
+++ b/docs/reducers.md
@@ -82,11 +82,10 @@ The event-driven approach is always preferred: model initial state as seed event
 graph.invoke([ProposalDrafted(text="..."), ReviewRequested()])
 ```
 
-For cases where external state must be injected outside the event system (e.g., migrating from a checkpoint, or test setup that can't go through the normal invoke path), LangGraph's `update_state` on the compiled graph is supported:
+For cases where external state must be injected outside the event system (e.g., migrating from a checkpoint, or test setup that can't go through the normal invoke path), use ``pre_seed``:
 
 ```python
-compiled = graph._compile()
-compiled.update_state(config, {"my_reducer": value}, as_node="__seed__")
+graph.pre_seed(config, {"my_reducer": value})
 graph.invoke(SeedEvent(), config=config)
 ```
 
@@ -94,6 +93,5 @@ The seed node detects pre-existing channel data and preserves it rather than re-
 
 **Caveats:**
 
-- Use `as_node="__seed__"` — other node names won't populate the channel correctly.
-- Pre-seeded values bypass the event log. `log.filter()` won't reflect them; only the reducer injection will.
+- Pre-seeded values bypass the event log. `log.filter()` won't reflect them; only the reducer state will.
 - Prefer seed events for anything that should be auditable or replayable.

--- a/docs/reducers.md
+++ b/docs/reducers.md
@@ -72,3 +72,28 @@ temperature = ScalarReducer(
     "temperature", event_type=ConfigUpdated, fn=lambda e: e.temp if e.temp is not None else SKIP, default=0.7
 )
 ```
+
+## Pre-seeding reducer state
+
+The event-driven approach is always preferred: model initial state as seed events so the event log stays the single source of truth.
+
+```python
+# Preferred — state comes from events
+graph.invoke([ProposalDrafted(text="..."), ReviewRequested()])
+```
+
+For cases where external state must be injected outside the event system (e.g., migrating from a checkpoint, or test setup that can't go through the normal invoke path), LangGraph's `update_state` on the compiled graph is supported:
+
+```python
+compiled = graph._compile()
+compiled.update_state(config, {"my_reducer": value}, as_node="__seed__")
+graph.invoke(SeedEvent(), config=config)
+```
+
+The seed node detects pre-existing channel data and preserves it rather than re-initializing from defaults. Seed events that contribute to the same reducer are merged on top of the pre-seeded value.
+
+**Caveats:**
+
+- Use `as_node="__seed__"` — other node names won't populate the channel correctly.
+- Pre-seeded values bypass the event log. `log.filter()` won't reflect them; only the reducer injection will.
+- Prefer seed events for anything that should be auditable or replayable.

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -592,7 +592,7 @@ class EventGraph:
             for e in new_events
         ]
 
-    async def _astream_v2(  # noqa: PLR0912
+    async def _astream_v2(  # noqa: PLR0912, PLR0915
         self,
         inp: Any,
         seeds: list[Event],
@@ -605,10 +605,33 @@ class EventGraph:
         """Stream events using LangGraph's v2 event API with LLM token support."""
         compiled = self._compile()
 
-        # Initialize incremental reducer state from seeds
+        # Initialize incremental reducer state.  When a checkpoint exists
+        # (subsequent run / resume), start from the checkpointed values so
+        # the shadow state matches what the compiled graph already restored.
+        # Fall back to r.seed() only on the true first run.
         reducer_state: dict[str, Any] = {}
+        checkpoint_values: dict[str, Any] | None = None
+        if reducer_names and self._checkpointer is not None:
+            config = kwargs.get("config")
+            if config is not None:
+                snapshot = await compiled.aget_state(config)
+                if snapshot.values:
+                    checkpoint_values = snapshot.values
+
         for name in reducer_names:
-            reducer_state[name] = self._reducers[name].seed(seeds)
+            if checkpoint_values is not None:
+                reducer_state[name] = checkpoint_values.get(
+                    name, self._reducers[name].empty
+                )
+            else:
+                reducer_state[name] = self._reducers[name].seed(seeds)
+
+        # When resuming from a checkpoint, merge any seed contributions on
+        # top (no-op on resume since seeds=[], needed for astream_events
+        # second-run where seeds carry new events).
+        if checkpoint_values is not None:
+            for s in seeds:
+                self._update_reducer_state(reducer_state, s, reducer_names)
 
         # Yield seed events
         for s in seeds:

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -26,6 +26,7 @@ from langgraph_events._internal import (
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Iterator
 
+    from langchain_core.runnables import RunnableConfig
     from langgraph.graph.state import CompiledStateGraph
     from langgraph.store.base import BaseStore
 
@@ -462,6 +463,22 @@ class EventGraph:
         """Run the graph asynchronously with one or more seed events."""
         return await self._arun(self._prepare_input(seed), **kwargs)
 
+    def pre_seed(self, config: RunnableConfig, values: dict[str, Any]) -> None:
+        """Inject external state into reducer channels before the first run.
+
+        Use this to hydrate reducers from an external source (e.g. a database
+        migration or test fixture) when modelling the data as seed events isn't
+        practical.  Call it once before ``invoke``/``ainvoke``::
+
+            graph.pre_seed(config, {"my_reducer": existing_value})
+            graph.invoke(StartEvent(), config=config)
+
+        Requires a checkpointer.
+        """
+        self._require_checkpointer("pre_seed")
+        compiled = self._compile()
+        compiled.update_state(config, values, as_node="__seed__")
+
     def resume(self, value: Event, **kwargs: Any) -> EventLog:
         """Resume an interrupted graph with a domain event.
 
@@ -609,6 +626,8 @@ class EventGraph:
         # (subsequent run / resume), start from the checkpointed values so
         # the shadow state matches what the compiled graph already restored.
         # Fall back to r.seed() only on the true first run.
+        # NOTE: this issues an extra aget_state round-trip when reducers are
+        # present and a checkpointer is configured.
         reducer_state: dict[str, Any] = {}
         checkpoint_values: dict[str, Any] | None = None
         if reducer_names and self._checkpointer is not None:
@@ -626,9 +645,10 @@ class EventGraph:
             else:
                 reducer_state[name] = self._reducers[name].seed(seeds)
 
-        # When resuming from a checkpoint, merge any seed contributions on
-        # top (no-op on resume since seeds=[], needed for astream_events
-        # second-run where seeds carry new events).
+        # Merge seed contributions on top of checkpointed state.
+        # - On astream_resume: seeds=[] so this is a no-op.
+        # - On astream_events second-run: seeds carry new events that
+        #   should layer on top of the restored checkpoint.
         if checkpoint_values is not None:
             for s in seeds:
                 self._update_reducer_state(reducer_state, s, reducer_names)

--- a/src/langgraph_events/_internal.py
+++ b/src/langgraph_events/_internal.py
@@ -92,9 +92,19 @@ def make_seed_node(
         }
         if reds:
             if prev_cursor == 0:
-                # First run — initialize with default + seed events
                 for name, r in reds.items():
-                    result[name] = r.seed(new_events)
+                    if state.get(name):
+                        # Channel already has data (e.g., via
+                        # update_state) — only apply contributions so
+                        # the channel reducer merges them with the
+                        # existing value.
+                        collected = r.collect(new_events)
+                        if r.has_contributions(collected):
+                            result[name] = collected
+                    else:
+                        # True first run — initialize from default +
+                        # seed events.
+                        result[name] = r.seed(new_events)
             elif new_events:
                 # Subsequent run (checkpointer) — only process new events
                 for name, r in reds.items():

--- a/src/langgraph_events/_internal.py
+++ b/src/langgraph_events/_internal.py
@@ -93,11 +93,14 @@ def make_seed_node(
         if reds:
             if prev_cursor == 0:
                 for name, r in reds.items():
-                    if state.get(name):
-                        # Channel already has data (e.g., via
-                        # update_state) — only apply contributions so
-                        # the channel reducer merges them with the
-                        # existing value.
+                    existing = state.get(name)
+                    # Channel defaults: [] for list channels, None for
+                    # scalar channels.  Anything else means pre-seeded
+                    # via update_state / pre_seed().
+                    if existing is not None and existing != []:
+                        # Channel already has data — only apply seed
+                        # contributions so the channel reducer merges
+                        # them with the existing value.
                         collected = r.collect(new_events)
                         if r.has_contributions(collected):
                             result[name] = collected

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -1655,10 +1655,7 @@ def describe_EventGraph():
                     graph = EventGraph([step], reducers=[r], checkpointer=checkpointer)
                     config = {"configurable": {"thread_id": "pre-seed-list"}}
 
-                    compiled = graph._compile()
-                    compiled.update_state(
-                        config, {"texts": ["pre-seeded"]}, as_node="__seed__"
-                    )
+                    graph.pre_seed(config, {"texts": ["pre-seeded"]})
 
                     graph.invoke(Started(data="go"), config=config)
                     assert captured[0] == ["pre-seeded"]
@@ -1682,15 +1679,34 @@ def describe_EventGraph():
                     graph = EventGraph([step], reducers=[sr], checkpointer=checkpointer)
                     config = {"configurable": {"thread_id": "pre-seed-scalar"}}
 
-                    compiled = graph._compile()
-                    compiled.update_state(
-                        config,
-                        {"proposal": "my proposal text"},
-                        as_node="__seed__",
-                    )
+                    graph.pre_seed(config, {"proposal": "my proposal text"})
 
                     graph.invoke(Started(data="go"), config=config)
                     assert captured[0] == "my proposal text"
+
+                def it_preserves_pre_seeded_falsy_scalar():
+                    from langgraph.checkpoint.memory import MemorySaver
+
+                    sr = ScalarReducer(
+                        name="count",
+                        event_type=MessageReceived,
+                        fn=lambda e: int(e.text),
+                    )
+                    captured: list[object] = []
+
+                    @on(Started)
+                    def step(event: Started, count: object) -> Completed:
+                        captured.append(count)
+                        return Completed(result="ok")
+
+                    checkpointer = MemorySaver()
+                    graph = EventGraph([step], reducers=[sr], checkpointer=checkpointer)
+                    config = {"configurable": {"thread_id": "pre-seed-falsy"}}
+
+                    graph.pre_seed(config, {"count": 0})
+
+                    graph.invoke(Started(data="go"), config=config)
+                    assert captured[0] == 0
 
                 def when_seed_event_also_contributes():
 
@@ -1715,12 +1731,7 @@ def describe_EventGraph():
                         )
                         config = {"configurable": {"thread_id": "merge-list"}}
 
-                        compiled = graph._compile()
-                        compiled.update_state(
-                            config,
-                            {"texts": ["existing"]},
-                            as_node="__seed__",
-                        )
+                        graph.pre_seed(config, {"texts": ["existing"]})
 
                         graph.invoke(MessageReceived(text="new"), config=config)
                         assert captured[0] == ["existing", "new"]
@@ -1749,12 +1760,7 @@ def describe_EventGraph():
                         )
                         config = {"configurable": {"thread_id": "no-dup-default"}}
 
-                        compiled = graph._compile()
-                        compiled.update_state(
-                            config,
-                            {"texts": ["custom"]},
-                            as_node="__seed__",
-                        )
+                        graph.pre_seed(config, {"texts": ["custom"]})
 
                         graph.invoke(Started(data="go"), config=config)
                         # "init" default should NOT be re-applied on top
@@ -1780,10 +1786,7 @@ def describe_EventGraph():
                     graph = EventGraph([step], reducers=[r], checkpointer=checkpointer)
                     config = {"configurable": {"thread_id": "cursor-advance"}}
 
-                    compiled = graph._compile()
-                    compiled.update_state(
-                        config, {"texts": ["pre"]}, as_node="__seed__"
-                    )
+                    graph.pre_seed(config, {"texts": ["pre"]})
 
                     # Run 1 — pre-seeded
                     graph.invoke(MessageReceived(text="a"), config=config)
@@ -1824,11 +1827,8 @@ def describe_EventGraph():
                     )
                     config = {"configurable": {"thread_id": "mixed"}}
 
-                    compiled = graph._compile()
                     # Only pre-seed one reducer
-                    compiled.update_state(
-                        config, {"seeded": ["external"]}, as_node="__seed__"
-                    )
+                    graph.pre_seed(config, {"seeded": ["external"]})
 
                     graph.invoke(Started(data="go"), config=config)
                     # Pre-seeded reducer keeps its value

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -1636,38 +1636,45 @@ def describe_EventGraph():
 
             def when_pre_seeded_via_update_state():
 
-                def it_preserves_pre_seeded_list_reducer():
-                    from langgraph.checkpoint.memory import MemorySaver
-
-                    r = Reducer(
-                        "texts",
-                        event_type=MessageReceived,
-                        fn=lambda e: [e.text],
+                def _texts_reducer(**kw) -> Reducer:
+                    return Reducer(
+                        "texts", event_type=MessageReceived, fn=lambda e: [e.text], **kw
                     )
+
+                def _texts_handler(trigger: type) -> tuple:
                     captured: list[list] = []
 
-                    @on(Started)
-                    def step(event: Started, texts: list) -> Completed:
+                    @on(trigger)
+                    def _capture_texts(event: Event, texts: list) -> Completed:
                         captured.append(list(texts))
                         return Completed(result="ok")
 
-                    checkpointer = MemorySaver()
-                    graph = EventGraph([step], reducers=[r], checkpointer=checkpointer)
-                    config = {"configurable": {"thread_id": "pre-seed-list"}}
+                    return _capture_texts, captured
 
-                    graph.pre_seed(config, {"texts": ["pre-seeded"]})
+                def _pre_seed_graph(
+                    handlers: list, reducers: list, seed_values: dict, thread_id: str
+                ) -> tuple:
+                    from langgraph.checkpoint.memory import MemorySaver
 
+                    graph = EventGraph(
+                        handlers, reducers=reducers, checkpointer=MemorySaver()
+                    )
+                    config: dict = {"configurable": {"thread_id": thread_id}}
+                    graph.pre_seed(config, seed_values)
+                    return graph, config
+
+                def it_preserves_pre_seeded_list_reducer():
+                    handler, captured = _texts_handler(Started)
+                    graph, config = _pre_seed_graph(
+                        [handler],
+                        [_texts_reducer()],
+                        {"texts": ["pre-seeded"]},
+                        "pre-seed-list",
+                    )
                     graph.invoke(Started(data="go"), config=config)
                     assert captured[0] == ["pre-seeded"]
 
                 def it_preserves_pre_seeded_scalar_reducer():
-                    from langgraph.checkpoint.memory import MemorySaver
-
-                    sr = ScalarReducer(
-                        name="proposal",
-                        event_type=MessageReceived,
-                        fn=lambda e: e.text,
-                    )
                     captured: list[object] = []
 
                     @on(Started)
@@ -1675,23 +1682,19 @@ def describe_EventGraph():
                         captured.append(proposal)
                         return Completed(result="ok")
 
-                    checkpointer = MemorySaver()
-                    graph = EventGraph([step], reducers=[sr], checkpointer=checkpointer)
-                    config = {"configurable": {"thread_id": "pre-seed-scalar"}}
-
-                    graph.pre_seed(config, {"proposal": "my proposal text"})
-
+                    sr = ScalarReducer(
+                        name="proposal", event_type=MessageReceived, fn=lambda e: e.text
+                    )
+                    graph, config = _pre_seed_graph(
+                        [step],
+                        [sr],
+                        {"proposal": "my proposal text"},
+                        "pre-seed-scalar",
+                    )
                     graph.invoke(Started(data="go"), config=config)
                     assert captured[0] == "my proposal text"
 
                 def it_preserves_pre_seeded_falsy_scalar():
-                    from langgraph.checkpoint.memory import MemorySaver
-
-                    sr = ScalarReducer(
-                        name="count",
-                        event_type=MessageReceived,
-                        fn=lambda e: int(e.text),
-                    )
                     captured: list[object] = []
 
                     @on(Started)
@@ -1699,95 +1702,56 @@ def describe_EventGraph():
                         captured.append(count)
                         return Completed(result="ok")
 
-                    checkpointer = MemorySaver()
-                    graph = EventGraph([step], reducers=[sr], checkpointer=checkpointer)
-                    config = {"configurable": {"thread_id": "pre-seed-falsy"}}
-
-                    graph.pre_seed(config, {"count": 0})
-
+                    sr = ScalarReducer(
+                        name="count",
+                        event_type=MessageReceived,
+                        fn=lambda e: int(e.text),
+                    )
+                    graph, config = _pre_seed_graph(
+                        [step],
+                        [sr],
+                        {"count": 0},
+                        "pre-seed-falsy",
+                    )
                     graph.invoke(Started(data="go"), config=config)
                     assert captured[0] == 0
 
                 def when_seed_event_also_contributes():
 
                     def it_merges_contributions_into_pre_seeded_list():
-                        from langgraph.checkpoint.memory import MemorySaver
-
-                        r = Reducer(
-                            "texts",
-                            event_type=MessageReceived,
-                            fn=lambda e: [e.text],
+                        handler, captured = _texts_handler(MessageReceived)
+                        graph, config = _pre_seed_graph(
+                            [handler],
+                            [_texts_reducer()],
+                            {"texts": ["existing"]},
+                            "merge-list",
                         )
-                        captured: list[list] = []
-
-                        @on(MessageReceived)
-                        def step(event: MessageReceived, texts: list) -> Completed:
-                            captured.append(list(texts))
-                            return Completed(result="ok")
-
-                        checkpointer = MemorySaver()
-                        graph = EventGraph(
-                            [step], reducers=[r], checkpointer=checkpointer
-                        )
-                        config = {"configurable": {"thread_id": "merge-list"}}
-
-                        graph.pre_seed(config, {"texts": ["existing"]})
-
                         graph.invoke(MessageReceived(text="new"), config=config)
                         assert captured[0] == ["existing", "new"]
 
                 def when_reducer_has_non_empty_default():
 
                     def it_does_not_duplicate_default():
-                        from langgraph.checkpoint.memory import MemorySaver
-
-                        r = Reducer(
-                            "texts",
-                            event_type=MessageReceived,
-                            fn=lambda e: [e.text],
-                            default=["init"],
+                        handler, captured = _texts_handler(Started)
+                        graph, config = _pre_seed_graph(
+                            [handler],
+                            [_texts_reducer(default=["init"])],
+                            {"texts": ["custom"]},
+                            "no-dup-default",
                         )
-                        captured: list[list] = []
-
-                        @on(Started)
-                        def step(event: Started, texts: list) -> Completed:
-                            captured.append(list(texts))
-                            return Completed(result="ok")
-
-                        checkpointer = MemorySaver()
-                        graph = EventGraph(
-                            [step], reducers=[r], checkpointer=checkpointer
-                        )
-                        config = {"configurable": {"thread_id": "no-dup-default"}}
-
-                        graph.pre_seed(config, {"texts": ["custom"]})
-
                         graph.invoke(Started(data="go"), config=config)
                         # "init" default should NOT be re-applied on top
                         # of pre-seeded value.
                         assert captured[0] == ["custom"]
 
                 def it_advances_cursor_after_pre_seeded_run():
-                    from langgraph.checkpoint.memory import MemorySaver
-
-                    r = Reducer(
-                        "texts",
-                        event_type=MessageReceived,
-                        fn=lambda e: [e.text],
+                    handler, captured = _texts_handler(MessageReceived)
+                    graph, config = _pre_seed_graph(
+                        [handler],
+                        [_texts_reducer()],
+                        {"texts": ["pre"]},
+                        "cursor-advance",
                     )
-                    captured: list[list] = []
-
-                    @on(MessageReceived)
-                    def step(event: MessageReceived, texts: list) -> Completed:
-                        captured.append(list(texts))
-                        return Completed(result="ok")
-
-                    checkpointer = MemorySaver()
-                    graph = EventGraph([step], reducers=[r], checkpointer=checkpointer)
-                    config = {"configurable": {"thread_id": "cursor-advance"}}
-
-                    graph.pre_seed(config, {"texts": ["pre"]})
-
                     # Run 1 — pre-seeded
                     graph.invoke(MessageReceived(text="a"), config=config)
                     assert captured[0] == ["pre", "a"]
@@ -1797,19 +1761,6 @@ def describe_EventGraph():
                     assert captured[1] == ["pre", "a", "b"]
 
                 def it_handles_mixed_pre_seeded_and_normal_reducers():
-                    from langgraph.checkpoint.memory import MemorySaver
-
-                    r_seeded = Reducer(
-                        "seeded",
-                        event_type=MessageReceived,
-                        fn=lambda e: [e.text],
-                    )
-                    r_normal = Reducer(
-                        "normal",
-                        event_type=Started,
-                        fn=lambda e: [e.data],
-                        default=["init"],
-                    )
                     captured_seeded: list[list] = []
                     captured_normal: list[list] = []
 
@@ -1819,21 +1770,23 @@ def describe_EventGraph():
                         captured_normal.append(list(normal))
                         return Completed(result="ok")
 
-                    checkpointer = MemorySaver()
-                    graph = EventGraph(
-                        [step],
-                        reducers=[r_seeded, r_normal],
-                        checkpointer=checkpointer,
+                    r_seeded = Reducer(
+                        "seeded", event_type=MessageReceived, fn=lambda e: [e.text]
                     )
-                    config = {"configurable": {"thread_id": "mixed"}}
-
-                    # Only pre-seed one reducer
-                    graph.pre_seed(config, {"seeded": ["external"]})
-
+                    r_normal = Reducer(
+                        "normal",
+                        event_type=Started,
+                        fn=lambda e: [e.data],
+                        default=["init"],
+                    )
+                    graph, config = _pre_seed_graph(
+                        [step],
+                        [r_seeded, r_normal],
+                        {"seeded": ["external"]},
+                        "mixed",
+                    )
                     graph.invoke(Started(data="go"), config=config)
-                    # Pre-seeded reducer keeps its value
                     assert captured_seeded[0] == ["external"]
-                    # Normal reducer initializes from default + seed
                     assert captured_normal[0] == ["init", "go"]
 
     def describe_scalar_reducer():

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -1634,6 +1634,208 @@ def describe_EventGraph():
                     assert snapshots[0] == ["y", "z", "a"]
                     assert snapshots[1] == ["z", "a", "b"]
 
+            def when_pre_seeded_via_update_state():
+
+                def it_preserves_pre_seeded_list_reducer():
+                    from langgraph.checkpoint.memory import MemorySaver
+
+                    r = Reducer(
+                        "texts",
+                        event_type=MessageReceived,
+                        fn=lambda e: [e.text],
+                    )
+                    captured: list[list] = []
+
+                    @on(Started)
+                    def step(event: Started, texts: list) -> Completed:
+                        captured.append(list(texts))
+                        return Completed(result="ok")
+
+                    checkpointer = MemorySaver()
+                    graph = EventGraph([step], reducers=[r], checkpointer=checkpointer)
+                    config = {"configurable": {"thread_id": "pre-seed-list"}}
+
+                    compiled = graph._compile()
+                    compiled.update_state(
+                        config, {"texts": ["pre-seeded"]}, as_node="__seed__"
+                    )
+
+                    graph.invoke(Started(data="go"), config=config)
+                    assert captured[0] == ["pre-seeded"]
+
+                def it_preserves_pre_seeded_scalar_reducer():
+                    from langgraph.checkpoint.memory import MemorySaver
+
+                    sr = ScalarReducer(
+                        name="proposal",
+                        event_type=MessageReceived,
+                        fn=lambda e: e.text,
+                    )
+                    captured: list[object] = []
+
+                    @on(Started)
+                    def step(event: Started, proposal: object) -> Completed:
+                        captured.append(proposal)
+                        return Completed(result="ok")
+
+                    checkpointer = MemorySaver()
+                    graph = EventGraph([step], reducers=[sr], checkpointer=checkpointer)
+                    config = {"configurable": {"thread_id": "pre-seed-scalar"}}
+
+                    compiled = graph._compile()
+                    compiled.update_state(
+                        config,
+                        {"proposal": "my proposal text"},
+                        as_node="__seed__",
+                    )
+
+                    graph.invoke(Started(data="go"), config=config)
+                    assert captured[0] == "my proposal text"
+
+                def when_seed_event_also_contributes():
+
+                    def it_merges_contributions_into_pre_seeded_list():
+                        from langgraph.checkpoint.memory import MemorySaver
+
+                        r = Reducer(
+                            "texts",
+                            event_type=MessageReceived,
+                            fn=lambda e: [e.text],
+                        )
+                        captured: list[list] = []
+
+                        @on(MessageReceived)
+                        def step(event: MessageReceived, texts: list) -> Completed:
+                            captured.append(list(texts))
+                            return Completed(result="ok")
+
+                        checkpointer = MemorySaver()
+                        graph = EventGraph(
+                            [step], reducers=[r], checkpointer=checkpointer
+                        )
+                        config = {"configurable": {"thread_id": "merge-list"}}
+
+                        compiled = graph._compile()
+                        compiled.update_state(
+                            config,
+                            {"texts": ["existing"]},
+                            as_node="__seed__",
+                        )
+
+                        graph.invoke(MessageReceived(text="new"), config=config)
+                        assert captured[0] == ["existing", "new"]
+
+                def when_reducer_has_non_empty_default():
+
+                    def it_does_not_duplicate_default():
+                        from langgraph.checkpoint.memory import MemorySaver
+
+                        r = Reducer(
+                            "texts",
+                            event_type=MessageReceived,
+                            fn=lambda e: [e.text],
+                            default=["init"],
+                        )
+                        captured: list[list] = []
+
+                        @on(Started)
+                        def step(event: Started, texts: list) -> Completed:
+                            captured.append(list(texts))
+                            return Completed(result="ok")
+
+                        checkpointer = MemorySaver()
+                        graph = EventGraph(
+                            [step], reducers=[r], checkpointer=checkpointer
+                        )
+                        config = {"configurable": {"thread_id": "no-dup-default"}}
+
+                        compiled = graph._compile()
+                        compiled.update_state(
+                            config,
+                            {"texts": ["custom"]},
+                            as_node="__seed__",
+                        )
+
+                        graph.invoke(Started(data="go"), config=config)
+                        # "init" default should NOT be re-applied on top
+                        # of pre-seeded value.
+                        assert captured[0] == ["custom"]
+
+                def it_advances_cursor_after_pre_seeded_run():
+                    from langgraph.checkpoint.memory import MemorySaver
+
+                    r = Reducer(
+                        "texts",
+                        event_type=MessageReceived,
+                        fn=lambda e: [e.text],
+                    )
+                    captured: list[list] = []
+
+                    @on(MessageReceived)
+                    def step(event: MessageReceived, texts: list) -> Completed:
+                        captured.append(list(texts))
+                        return Completed(result="ok")
+
+                    checkpointer = MemorySaver()
+                    graph = EventGraph([step], reducers=[r], checkpointer=checkpointer)
+                    config = {"configurable": {"thread_id": "cursor-advance"}}
+
+                    compiled = graph._compile()
+                    compiled.update_state(
+                        config, {"texts": ["pre"]}, as_node="__seed__"
+                    )
+
+                    # Run 1 — pre-seeded
+                    graph.invoke(MessageReceived(text="a"), config=config)
+                    assert captured[0] == ["pre", "a"]
+
+                    # Run 2 — re-invoke, cursor now > 0, normal resume
+                    graph.invoke(MessageReceived(text="b"), config=config)
+                    assert captured[1] == ["pre", "a", "b"]
+
+                def it_handles_mixed_pre_seeded_and_normal_reducers():
+                    from langgraph.checkpoint.memory import MemorySaver
+
+                    r_seeded = Reducer(
+                        "seeded",
+                        event_type=MessageReceived,
+                        fn=lambda e: [e.text],
+                    )
+                    r_normal = Reducer(
+                        "normal",
+                        event_type=Started,
+                        fn=lambda e: [e.data],
+                        default=["init"],
+                    )
+                    captured_seeded: list[list] = []
+                    captured_normal: list[list] = []
+
+                    @on(Started)
+                    def step(event: Started, seeded: list, normal: list) -> Completed:
+                        captured_seeded.append(list(seeded))
+                        captured_normal.append(list(normal))
+                        return Completed(result="ok")
+
+                    checkpointer = MemorySaver()
+                    graph = EventGraph(
+                        [step],
+                        reducers=[r_seeded, r_normal],
+                        checkpointer=checkpointer,
+                    )
+                    config = {"configurable": {"thread_id": "mixed"}}
+
+                    compiled = graph._compile()
+                    # Only pre-seed one reducer
+                    compiled.update_state(
+                        config, {"seeded": ["external"]}, as_node="__seed__"
+                    )
+
+                    graph.invoke(Started(data="go"), config=config)
+                    # Pre-seeded reducer keeps its value
+                    assert captured_seeded[0] == ["external"]
+                    # Normal reducer initializes from default + seed
+                    assert captured_normal[0] == ["init", "go"]
+
     def describe_scalar_reducer():
 
         def when_matching_events():
@@ -2583,6 +2785,139 @@ def describe_EventGraph():
                 isinstance(v, _StepInterrupted) and v.step == 2
                 for v in interrupt_values
             )
+
+        @pytest.mark.asyncio
+        async def it_preserves_reducer_state_from_checkpoint_in_v2():
+            from langgraph.checkpoint.memory import MemorySaver
+
+            r = Reducer("texts", event_type=MessageReceived, fn=lambda e: [e.text])
+
+            @on(Started)
+            def need_input(event: Started) -> _StepInterrupted:
+                return _StepInterrupted(step=1)
+
+            @on(Completed)
+            def finish(event: Completed) -> Ended:
+                return Ended(result=event.result)
+
+            graph = EventGraph(
+                [need_input, finish],
+                checkpointer=MemorySaver(),
+                reducers=[r],
+            )
+            config = {"configurable": {"thread_id": "v2-resume-reducer"}}
+
+            # First run — seed with MessageReceived to populate reducer, then
+            # interrupt via Started → _StepInterrupted.
+            graph.invoke(
+                [MessageReceived(text="hello"), Started(data="go")], config=config
+            )
+
+            # Resume via _astream_v2 path (include_custom_events forces v2)
+            frames = [
+                item
+                async for item in graph.astream_resume(
+                    Completed(result="done"),
+                    include_reducers=True,
+                    include_custom_events=True,
+                    config=config,
+                )
+            ]
+
+            stream_frames = [f for f in frames if isinstance(f, StreamFrame)]
+            assert len(stream_frames) > 0
+            # Reducer must reflect checkpoint state ("hello" from first run)
+            assert "hello" in stream_frames[0].reducers["texts"]
+
+        @pytest.mark.asyncio
+        async def it_accumulates_reducer_across_v2_astream_events_runs():
+            from langgraph.checkpoint.memory import MemorySaver
+
+            r = Reducer("texts", event_type=MessageReceived, fn=lambda e: [e.text])
+
+            @on(MessageReceived)
+            def step(event: MessageReceived) -> Completed:
+                return Completed(result=event.text)
+
+            graph = EventGraph(
+                [step],
+                checkpointer=MemorySaver(),
+                reducers=[r],
+            )
+            config = {"configurable": {"thread_id": "v2-second-run"}}
+
+            # First run via astream_events (v2 path)
+            _ = [
+                item
+                async for item in graph.astream_events(
+                    MessageReceived(text="first"),
+                    include_reducers=True,
+                    include_custom_events=True,
+                    config=config,
+                )
+            ]
+
+            # Second run on same thread — seed contributes on top of checkpoint
+            frames = [
+                item
+                async for item in graph.astream_events(
+                    MessageReceived(text="second"),
+                    include_reducers=True,
+                    include_custom_events=True,
+                    config=config,
+                )
+            ]
+
+            stream_frames = [f for f in frames if isinstance(f, StreamFrame)]
+            assert len(stream_frames) > 0
+            texts = stream_frames[0].reducers["texts"]
+            assert "first" in texts
+            assert "second" in texts
+
+        @pytest.mark.asyncio
+        async def it_preserves_scalar_reducer_from_checkpoint_in_v2():
+            from langgraph.checkpoint.memory import MemorySaver
+
+            sr = ScalarReducer(
+                name="proposal",
+                event_type=MessageReceived,
+                fn=lambda e: e.text,
+            )
+
+            @on(Started)
+            def need_input(event: Started) -> _StepInterrupted:
+                return _StepInterrupted(step=1)
+
+            @on(Completed)
+            def finish(event: Completed) -> Ended:
+                return Ended(result=event.result)
+
+            graph = EventGraph(
+                [need_input, finish],
+                checkpointer=MemorySaver(),
+                reducers=[sr],
+            )
+            config = {"configurable": {"thread_id": "v2-scalar-resume"}}
+
+            # First run — MessageReceived populates scalar, Started interrupts
+            graph.invoke(
+                [MessageReceived(text="chosen"), Started(data="go")], config=config
+            )
+
+            # Resume via v2 path
+            frames = [
+                item
+                async for item in graph.astream_resume(
+                    Completed(result="done"),
+                    include_reducers=True,
+                    include_custom_events=True,
+                    config=config,
+                )
+            ]
+
+            stream_frames = [f for f in frames if isinstance(f, StreamFrame)]
+            assert len(stream_frames) > 0
+            assert stream_frames[0].reducers["proposal"] == "chosen"
 
     def describe_reflection_loop():
 


### PR DESCRIPTION
## Summary
- Fix reducer state initialization from checkpoints in `_astream_v2` and `make_seed_node`
- Add `EventGraph.pre_seed(config, values)` public API for injecting external state into reducer channels
- Fix bug where falsy pre-seeded values (`0`, `""`, `False`) were silently dropped due to truthiness check

## Test plan
- [x] Pre-seeded list reducer preserves value
- [x] Pre-seeded scalar reducer preserves value
- [x] Pre-seeded falsy scalar (`0`) preserves value
- [x] Seed events merge on top of pre-seeded values
- [x] Reducers with non-empty defaults don't duplicate default
- [x] Cursor advances correctly after pre-seeded run
- [x] Mixed pre-seeded and normal reducers work together
- [x] v2 stream path restores reducer state from checkpoint
- [x] v2 accumulates reducer across multiple runs
- [x] v2 scalar reducer preserved from checkpoint
- [x] 336 tests pass, mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)