### PR TITLE
feat: add async apre_seed counterpart to pre_seed

### DIFF
--- a/docs/reducers.md
+++ b/docs/reducers.md
@@ -87,6 +87,10 @@ For cases where external state must be injected outside the event system (e.g., 
 ```python
 graph.pre_seed(config, {"my_reducer": value})
 graph.invoke(SeedEvent(), config=config)
+
+# Or async
+await graph.apre_seed(config, {"my_reducer": value})
+await graph.ainvoke(SeedEvent(), config=config)
 ```
 
 The seed node detects pre-existing channel data and preserves it rather than re-initializing from defaults. Seed events that contribute to the same reducer are merged on top of the pre-seeded value.

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -479,6 +479,12 @@ class EventGraph:
         compiled = self._compile()
         compiled.update_state(config, values, as_node="__seed__")
 
+    async def apre_seed(self, config: RunnableConfig, values: dict[str, Any]) -> None:
+        """Async version of :meth:`pre_seed`."""
+        self._require_checkpointer("apre_seed")
+        compiled = self._compile()
+        await compiled.aupdate_state(config, values, as_node="__seed__")
+
     def resume(self, value: Event, **kwargs: Any) -> EventLog:
         """Resume an interrupted graph with a domain event.
 

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -1789,6 +1789,21 @@ def describe_EventGraph():
                     assert captured_seeded[0] == ["external"]
                     assert captured_normal[0] == ["init", "go"]
 
+                @pytest.mark.asyncio
+                async def it_supports_async_apre_seed():
+                    from langgraph.checkpoint.memory import MemorySaver
+
+                    handler, captured = _texts_handler(Started)
+                    graph = EventGraph(
+                        [handler],
+                        reducers=[_texts_reducer()],
+                        checkpointer=MemorySaver(),
+                    )
+                    config: dict = {"configurable": {"thread_id": "pre-seed-async"}}
+                    await graph.apre_seed(config, {"texts": ["pre-seeded"]})
+                    await graph.ainvoke(Started(data="go"), config=config)
+                    assert captured[0] == ["pre-seeded"]
+
     def describe_scalar_reducer():
 
         def when_matching_events():


### PR DESCRIPTION
## Summary
- Adds `EventGraph.apre_seed()` — async counterpart to `pre_seed()` that wraps LangGraph's `aupdate_state`
- Matches the sync/async pairing pattern used throughout the API (`invoke`/`ainvoke`, `resume`/`aresume`, etc.)
- Async consumers no longer need to call the sync `pre_seed()` inside their event loop

## Test plan
- [x] New async test `it_supports_async_apre_seed` passes
- [x] All 337 existing tests still pass
- [x] `ruff check`, `ruff format`, `mypy` clean
- [x] Docs updated with async usage example

🤖 Generated with [Claude Code](https://claude.com/claude-code)