### PR TITLE
ci: add security scanning (pre-commit + daily audit)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,37 @@
+name: Security Audit
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'pyproject.toml'
+      - 'uv.lock'
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Audit dependencies
+        run: |
+          uv export --no-hashes --no-dev --format requirements-txt -o requirements-audit.txt
+          uv run --with pip-audit pip-audit -r requirements-audit.txt
+
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Scan for secrets
+        run: |
+          uv run --with detect-secrets detect-secrets scan --baseline .secrets.baseline
+          diff <(jq -S '.results' .secrets.baseline) \
+               <(git show HEAD:.secrets.baseline | jq -S '.results') \
+            || { echo "::error::New secrets detected — update .secrets.baseline"; exit 1; }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,21 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: '^(\.secrets\.baseline|\.worktrees/|\.claude/)'
+
   - repo: local
     hooks:
+      - id: pip-audit
+        name: pip-audit
+        language: system
+        entry: bash -c 'uv export --no-hashes --no-dev --format requirements-txt | uv run --with pip-audit pip-audit -r /dev/stdin'
+        pass_filenames: false
+        files: ^(pyproject\.toml|uv\.lock)$
       - id: validate-tests
         name: validate tests
         entry: bash -c "uv run python scripts/validate_tests.py"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,183 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "(^|/)(\\.worktrees|\\.claude)/"
+      ]
+    }
+  ],
+  "results": {
+    "examples/human_in_the_loop.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/human_in_the_loop.py",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
+    "examples/map_reduce.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/map_reduce.py",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
+    "examples/react_agent.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/react_agent.py",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "examples/reflection_loop.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/reflection_loop.py",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "examples/supervisor.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/supervisor.py",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ]
+  },
+  "generated_at": "2026-04-14T10:18:46Z"
+}


### PR DESCRIPTION
## Summary
- Adds **detect-secrets** (upstream hook, `v1.5.0`) with `.secrets.baseline` to pre-commit. Baseline captures 5 existing `sk-...` placeholder strings in example docstrings.
- Adds **pip-audit** as a local pre-commit hook scoped to `pyproject.toml` / `uv.lock` changes; exports `uv.lock` and scans via `uv run --with pip-audit`.
- Adds **`.github/workflows/security.yml`**: runs both scans daily at 06:00 UTC, on `workflow_dispatch`, and on pushes to `main` that touch dependency files. Declares `permissions: contents: read`.
- Bandit intentionally not added — ruff's `S` (flake8-bandit) ruleset is already enabled in `pyproject.toml`.

## Notes
- `pip-audit` currently reports 3 CVEs in existing deps (`langgraph 1.0.9`, `langchain-core 1.2.14`, `requests 2.32.5`). These are **not fixed in this PR** — tracked separately.
- The `detect-secrets` CI step diffs only `.results` (not the full baseline) to avoid spurious failures from the `generated_at` timestamp bump.

## Test plan
- [x] `pre-commit run detect-secrets --all-files` passes locally
- [x] `pre-commit run pip-audit --all-files` runs and surfaces CVEs
- [x] CI scan-and-diff logic verified locally (no spurious diff on unchanged repo)
- [ ] Confirm `Security Audit` workflow runs successfully once merged (first cron or manual dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)