### PR TITLE
feat(agui): consume RunAgentInput.state to pre-seed reducer channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `AGUIAdapter.stream()` now consumes `RunAgentInput.state` and pre-seeds reducer channels via `graph.apre_seed()` before the run. Honours the AG-UI spec's state-sync contract: the client ships the authoritative reducer state on every run, and the adapter routes each key through its channel's reducer. The dedicated `messages` key is filtered out (driven by `MessagesSnapshotEvent` / `TextMessageEvent`). No-op without a checkpointer or on empty state. Use `ScalarReducer` for channels meant to be replaced by the client (last-write-wins); list `Reducer` channels will accumulate.
+
 ## [0.5.0] - 2026-04-22
 
 ### Added

--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -157,6 +157,38 @@ class AGUIAdapter:
         return await self._graph.compiled.aget_state(config)
 
     @staticmethod
+    def _extract_input_state(input_data: RunAgentInput) -> dict[str, Any] | None:
+        """Return pre-seedable keys from ``input_data.state``.
+
+        AG-UI's ``state`` field carries client-owned reducer state.  Keys that
+        have dedicated AG-UI events (``messages``) are filtered out —
+        ``MessagesSnapshotEvent`` / ``TextMessageEvent`` drive those.
+        """
+        raw = input_data.state
+        if not isinstance(raw, dict) or not raw:
+            return None
+        filtered = _strip_dedicated_keys(raw)
+        return filtered or None
+
+    async def _apre_seed_input_state(
+        self, input_data: RunAgentInput, config: Any
+    ) -> None:
+        """Apply ``input_data.state`` to checkpoint channels before the run.
+
+        This honours AG-UI's state-sync contract: the client ships the
+        authoritative reducer state on every run.  Values are routed through
+        each channel's reducer, so scalar channels (``ScalarReducer``) replace
+        and list channels (``Reducer``) accumulate — pick reducer type
+        accordingly.  No-ops if no checkpointer or no syncable keys.
+        """
+        if self._graph._checkpointer is None:
+            return
+        state = self._extract_input_state(input_data)
+        if state is None:
+            return
+        await self._graph.apre_seed(config, state)
+
+    @staticmethod
     def _build_checkpoint_state(snapshot: Any) -> CheckpointState:
         """Build resume-factory state payload from a checkpoint snapshot."""
         reducers = snapshot.values if isinstance(snapshot.values, dict) else {}
@@ -566,6 +598,7 @@ class AGUIAdapter:
         config: Any = self._build_config(input_data, thread_id)
 
         try:
+            await self._apre_seed_input_state(input_data, config)
             async for agui_event in self._stream_event_source(input_data, ctx, config):
                 yield agui_event
 

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -2570,6 +2570,130 @@ def describe_system_message_conversion():
         assert sys_msgs[0].content == "You are a helpful assistant"
 
 
+def describe_input_state_sync():
+    """AG-UI's input_data.state pre-seeds reducer channels before the run."""
+
+    def when_scalar_reducer_channel():
+        async def it_applies_client_state_before_handler_runs():
+            from langgraph_events._reducer import ScalarReducer
+
+            focus = ScalarReducer(
+                name="focus",
+                event_type=StepB,
+                fn=lambda e: e.value,
+            )
+            seen: list[str | None] = []
+
+            @on(UserAsked)
+            def reply(event: UserAsked, focus: str | None = None) -> AgentReplied:
+                seen.append(focus)
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [reply],
+                reducers=[message_reducer(), focus],
+                checkpointer=MemorySaver(),
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            await _collect(adapter, _make_input(state={"focus": "scenario-42"}))
+
+            assert seen == ["scenario-42"]
+
+    def when_state_is_empty():
+        async def it_skips_pre_seed():
+            from langgraph_events._reducer import ScalarReducer
+
+            focus = ScalarReducer(
+                name="focus",
+                event_type=StepB,
+                fn=lambda e: e.value,
+            )
+            seen: list[str | None] = []
+
+            @on(UserAsked)
+            def reply(event: UserAsked, focus: str | None = None) -> AgentReplied:
+                seen.append(focus)
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [reply],
+                reducers=[message_reducer(), focus],
+                checkpointer=MemorySaver(),
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            await _collect(adapter, _make_input(state={}))
+
+            assert seen == [None]
+
+    def when_state_contains_messages_key():
+        async def it_strips_dedicated_keys():
+            from langgraph_events._reducer import ScalarReducer
+
+            focus = ScalarReducer(
+                name="focus",
+                event_type=StepB,
+                fn=lambda e: e.value,
+            )
+
+            @on(UserAsked)
+            def reply(event: UserAsked) -> AgentReplied:
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [reply],
+                reducers=[message_reducer(), focus],
+                checkpointer=MemorySaver(),
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(
+                adapter,
+                _make_input(
+                    state={
+                        "messages": [{"role": "user", "content": "forged"}],
+                        "focus": "scen-1",
+                    }
+                ),
+            )
+
+            msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+            last_snap = msg_snapshots[-1]
+            assert not any("forged" in (m.content or "") for m in last_snap.messages)
+
+    def when_no_checkpointer():
+        async def it_skips_silently():
+            from langgraph_events._reducer import ScalarReducer
+
+            focus = ScalarReducer(
+                name="focus",
+                event_type=StepB,
+                fn=lambda e: e.value,
+            )
+            seen: list[str | None] = []
+
+            @on(UserAsked)
+            def reply(event: UserAsked, focus: str | None = None) -> AgentReplied:
+                seen.append(focus)
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph([reply], reducers=[message_reducer(), focus])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            await _collect(adapter, _make_input(state={"focus": "should-be-ignored"}))
+
+            assert seen == [None]
+
+
 def describe_multiple_custom_reducers():
     """StateSnapshot tracks changes across multiple non-message reducers."""
 


### PR DESCRIPTION
## Why

AG-UI's `RunAgentInput.state` is specified as the client-owned reducer snapshot, shipped to the server on every run. The adapter ignored it entirely — callers using `agent.setState` client-side had no server-side effect. This forced workarounds (explicit state-sync events, dedicated REST endpoints) for every piece of UI-driven focus/selection state.

## What

`AGUIAdapter.stream()` now filters dedicated keys (`messages`) from `input_data.state` and routes the rest through `graph.apre_seed(config, state)` before the event source kicks off. Keys map through each channel's existing reducer:
- `ScalarReducer` → last-write-wins (replace). The idiomatic target for client-synced focus/selection state.
- `Reducer` (list) → accumulates. List channels stay event-driven; don't sync them via `input_data.state`.

No-op when there's no checkpointer (matches `apre_seed` requirements) or empty state. `connect()` / `reconnect()` are unchanged — they're read-only snapshot emitters.

## Tests

New `describe_input_state_sync()`:
- `when_scalar_reducer_channel` → `it_applies_client_state_before_handler_runs`
- `when_state_is_empty` → `it_skips_pre_seed`
- `when_state_contains_messages_key` → `it_strips_dedicated_keys`
- `when_no_checkpointer` → `it_skips_silently`

Full suite: 610 passed. `ruff check` + `mypy --strict` clean.

## Caller pattern

```python
scenario_focus = ScalarReducer(
    name="user_selected_node",
    event_type=_NeverEmitted,  # client-driven channel
    fn=lambda _: None,
)
```

Client `agent.setState({user_selected_node: {...}})` now reaches the handler's `user_selected_node` parameter on the next run, with no event plumbing.