### PR TITLE
feat(agui): FrontendStateMutated event (0.4.x backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `AGUIAdapter` now emits a new built-in `FrontendStateMutated` event (an `Event`, exported from `langgraph_events.agui`) as the first event of each run when `RunAgentInput.state` carries non-empty client-owned state. The dedicated `messages` key is filtered out (driven by `MessagesSnapshotEvent` / `TextMessageEvent`). Reducers mirroring client-driven channels subscribe to it like any other event — e.g. `ScalarReducer(event_type=FrontendStateMutated, fn=lambda e: e.state.get("focus", SKIP))` — and handlers can optionally `@on(FrontendStateMutated)` to react. On resume, the adapter writes the filtered state directly to reducer channels via `graph.apre_seed` before calling `astream_resume` (LangGraph's `ainvoke` on a pending-interrupt thread would consume the interrupt); in the idiomatic state-key-equals-channel-name pattern the values flow through identically to the non-resume path. `FrontendStateMutated` is not echoed back to the client — its downstream reducer changes surface via the usual `StateSnapshotEvent` path. Works with or without a checkpointer on the non-resume path.
+
 ## [0.4.0] - 2026-04-20
 
 ### Added

--- a/src/langgraph_events/agui/__init__.py
+++ b/src/langgraph_events/agui/__init__.py
@@ -2,6 +2,7 @@
 
 from langgraph_events.agui._adapter import AGUIAdapter
 from langgraph_events.agui._context import MapperContext
+from langgraph_events.agui._events import FrontendStateMutated
 from langgraph_events.agui._mappers import (
     FallbackMapper,
     FrontendToolCallRequestedMapper,
@@ -30,6 +31,7 @@ __all__ = [
     "AGUISerializable",
     "EventMapper",
     "FallbackMapper",
+    "FrontendStateMutated",
     "FrontendToolCallRequestedMapper",
     "InterruptedMapper",
     "MapperContext",

--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -22,7 +22,7 @@ from ag_ui.core import (
     ToolCallStartEvent,
 )
 
-from langgraph_events._event import Interrupted
+from langgraph_events._event import Event, Interrupted
 from langgraph_events._graph import (
     CustomEventFrame,
     LLMStreamEnd,
@@ -34,6 +34,7 @@ from langgraph_events._graph import (
 )
 
 from ._context import MapperContext
+from ._events import FrontendStateMutated
 from ._mappers import (
     FallbackMapper,
     build_messages_snapshot,
@@ -277,6 +278,83 @@ class AGUIAdapter:
             and checkpoint_state["is_interrupted"]
         )
 
+    @staticmethod
+    def _extract_frontend_state(
+        input_data: RunAgentInput,
+    ) -> dict[str, Any] | None:
+        """Return the pre-filtered client state, or ``None`` if there's
+        nothing to emit.
+
+        AG-UI ships ``RunAgentInput.state`` as a snapshot.  Dedicated keys
+        (``messages``) are driven by purpose-built AG-UI events and are
+        stripped here so they don't collide.  Empty / non-dict state is
+        treated as "no update."
+        """
+        raw = input_data.state
+        if not isinstance(raw, dict) or not raw:
+            return None
+        filtered = _strip_dedicated_keys(raw)
+        return filtered or None
+
+    def _prepend_frontend_state(
+        self,
+        input_data: RunAgentInput,
+        seed: Event | list[Event],
+    ) -> list[Event]:
+        """Return a seed list with ``FrontendStateMutated`` prepended
+        when the input carries non-empty, non-dedicated state.
+
+        Used on the non-resume path; callers pass the result to
+        ``graph.astream_events(...)``.
+        """
+        seed_list: list[Event] = list(seed) if isinstance(seed, list) else [seed]
+        filtered = self._extract_frontend_state(input_data)
+        if filtered is None:
+            return seed_list
+        return [FrontendStateMutated(state=filtered), *seed_list]  # type: ignore[call-arg]
+
+    async def _apply_frontend_state_for_resume(
+        self,
+        input_data: RunAgentInput,
+        config: Any,
+    ) -> None:
+        """Write client state directly to reducer channels via ``apre_seed``.
+
+        NOTE: On resume we bypass the ``FrontendStateMutated`` dispatch
+        path.  ``ainvoke`` on a thread with a pending interrupt would
+        consume the interrupt before ``astream_resume`` runs, so we
+        write channel values directly (matching state key -> channel
+        name).  Trade-off: the reducer's ``fn`` is not invoked on
+        resume — in the idiomatic ``fn=lambda e: e.state.get(name,
+        SKIP)`` pattern the value flows through unchanged, but
+        non-identity ``fn`` logic applies only on non-resume runs.
+        No-op when the input state is empty or contains only dedicated
+        keys.
+        """
+        filtered = self._extract_frontend_state(input_data)
+        if filtered is None:
+            return
+        await self._graph.apre_seed(config, filtered)
+
+    async def _resume_event_stream(
+        self,
+        input_data: RunAgentInput,
+        resume_event: Any,
+        config: Any,
+    ) -> AsyncIterator[StreamItem]:
+        """Resume path that first commits FrontendStateMutated to the
+        checkpoint, then defers to ``astream_resume``.
+        """
+        await self._apply_frontend_state_for_resume(input_data, config)
+        async for item in self._graph.astream_resume(
+            resume_event,
+            include_reducers=self._include_reducers,
+            include_llm_tokens=True,
+            include_custom_events=True,
+            config=config,
+        ):
+            yield item
+
     def _build_event_stream(
         self,
         input_data: RunAgentInput,
@@ -286,16 +364,11 @@ class AGUIAdapter:
     ) -> AsyncIterator[StreamItem]:
         """Create the underlying EventGraph async event stream."""
         if resume_event is not None:
-            return self._graph.astream_resume(
-                resume_event,
-                include_reducers=self._include_reducers,
-                include_llm_tokens=True,
-                include_custom_events=True,
-                config=config,
-            )
+            return self._resume_event_stream(input_data, resume_event, config)
         seed = self._call_seed_factory(input_data, checkpoint_state)
+        seeds = self._prepend_frontend_state(input_data, seed)
         return self._graph.astream_events(
-            seed,
+            seeds,
             include_reducers=self._include_reducers,
             include_llm_tokens=True,
             include_custom_events=True,

--- a/src/langgraph_events/agui/_events.py
+++ b/src/langgraph_events/agui/_events.py
@@ -1,0 +1,34 @@
+"""Built-in events for the AG-UI adapter."""
+
+from __future__ import annotations
+
+from dataclasses import field
+from typing import Any
+
+from langgraph_events import Event
+
+
+class FrontendStateMutated(Event):
+    """Emitted by ``AGUIAdapter`` at the start of a run carrying
+    ``RunAgentInput.state``.
+
+    The ``state`` field is the client-owned reducer snapshot with dedicated
+    AG-UI keys (``messages``) stripped.  Reducers that mirror client-driven
+    channels subscribe to this event like any other::
+
+        from langgraph_events import ScalarReducer, SKIP
+        from langgraph_events.agui import FrontendStateMutated
+
+        focus = ScalarReducer(
+            name="focus",
+            event_type=FrontendStateMutated,
+            fn=lambda e: e.state.get("focus", SKIP),
+        )
+
+    Handlers may also subscribe via ``@on(FrontendStateMutated)`` to react
+    to client-state changes.  The adapter does not echo this event back to
+    the client; downstream reducer changes surface through the usual
+    ``StateSnapshotEvent`` path.
+    """
+
+    state: dict[str, Any] = field(default_factory=dict)

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -25,6 +25,7 @@ from langgraph_events._event import (
     SystemPromptSet,
 )
 
+from ._events import FrontendStateMutated
 from ._protocols import AGUICustomEvent, AGUISerializable
 
 if TYPE_CHECKING:
@@ -109,10 +110,16 @@ def _langchain_to_agui_messages(
 
 
 class SkipInternalMapper:
-    """Suppress framework-internal events (Resumed, SystemPromptSet)."""
+    """Suppress framework-internal events (Resumed, SystemPromptSet,
+    FrontendStateMutated).
+
+    ``FrontendStateMutated`` originates from the client — echoing it back
+    over the wire is redundant.  Its downstream reducer changes surface
+    through the usual ``StateSnapshotEvent`` path.
+    """
 
     def map(self, event: Event, ctx: MapperContext) -> list[BaseEvent] | None:
-        if isinstance(event, (Resumed, SystemPromptSet)):
+        if isinstance(event, (Resumed, SystemPromptSet, FrontendStateMutated)):
             return []
         return None
 

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -111,6 +111,13 @@ class ErrorTrigger(Event):
         return {}
 
 
+class FocusLogged(Event):
+    value: str = ""
+
+    def agui_dict(self) -> dict[str, Any]:
+        return {"value": self.value}
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -3244,3 +3251,451 @@ def describe_detect_new_tool_results():
 
             with pytest.raises(ValueError, match=r"tool_call_id"):
                 detect_new_tool_results(inp, {"messages": []})
+
+
+def describe_frontend_state_mutated_event_class():
+    """Shape checks for the new FrontendStateMutated event."""
+
+    def when_instantiated():
+        def it_is_an_event():
+            from langgraph_events.agui import FrontendStateMutated
+
+            event = FrontendStateMutated(state={"focus": "scene-1"})
+            assert isinstance(event, Event)
+            assert event.state == {"focus": "scene-1"}
+
+        def it_defaults_to_empty_state():
+            from langgraph_events.agui import FrontendStateMutated
+
+            event = FrontendStateMutated()
+            assert event.state == {}
+
+
+def describe_frontend_state_mutated():
+    """AG-UI adapter emits FrontendStateMutated before the seed event."""
+
+    def when_state_has_non_dedicated_keys():
+        async def it_applies_scalar_reducer_before_seed_handler_runs():
+            from langgraph_events import SKIP, ScalarReducer
+            from langgraph_events.agui import FrontendStateMutated
+
+            focus = ScalarReducer(
+                name="focus",
+                event_type=FrontendStateMutated,
+                fn=lambda e: e.state.get("focus", SKIP),
+            )
+            seen: list[str | None] = []
+
+            @on(UserAsked)
+            def reply(event: UserAsked, focus: str | None = None) -> AgentReplied:
+                seen.append(focus)
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [reply],
+                reducers=[message_reducer(), focus],
+                checkpointer=MemorySaver(),
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            await _collect(adapter, _make_input(state={"focus": "scene-42"}))
+
+            assert seen == ["scene-42"]
+
+        async def it_records_frontend_state_mutated_in_event_log():
+            from langgraph_events.agui import FrontendStateMutated
+
+            @on(UserAsked)
+            def reply(event: UserAsked) -> AgentReplied:
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [reply],
+                reducers=[message_reducer()],
+                checkpointer=MemorySaver(),
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            config = {"configurable": {"thread_id": "thread-fsm-1"}}
+            await _collect(
+                adapter,
+                _make_input(thread_id="thread-fsm-1", state={"focus": "scene-42"}),
+            )
+
+            log = graph.get_state(config).events
+            fsm_events = [e for e in log if isinstance(e, FrontendStateMutated)]
+            assert len(fsm_events) == 1
+            assert fsm_events[0].state == {"focus": "scene-42"}
+
+            # Ordering: FrontendStateMutated must precede UserAsked in the log.
+            indices = {type(e).__name__: i for i, e in enumerate(log)}
+            assert indices["FrontendStateMutated"] < indices["UserAsked"]
+
+    def when_state_is_empty():
+        async def it_does_not_emit_frontend_state_mutated():
+            from langgraph_events.agui import FrontendStateMutated
+
+            @on(UserAsked)
+            def reply(event: UserAsked) -> AgentReplied:
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [reply],
+                reducers=[message_reducer()],
+                checkpointer=MemorySaver(),
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            config = {"configurable": {"thread_id": "thread-fsm-empty"}}
+            await _collect(
+                adapter,
+                _make_input(thread_id="thread-fsm-empty", state={}),
+            )
+
+            log = graph.get_state(config).events
+            assert not any(isinstance(e, FrontendStateMutated) for e in log)
+
+    def when_state_is_none():
+        async def it_does_not_emit_frontend_state_mutated():
+            from langgraph_events.agui import FrontendStateMutated
+
+            @on(UserAsked)
+            def reply(event: UserAsked) -> AgentReplied:
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [reply],
+                reducers=[message_reducer()],
+                checkpointer=MemorySaver(),
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            config = {"configurable": {"thread_id": "thread-fsm-none"}}
+            await _collect(
+                adapter,
+                _make_input(thread_id="thread-fsm-none", state=None),
+            )
+
+            log = graph.get_state(config).events
+            assert not any(isinstance(e, FrontendStateMutated) for e in log)
+
+    def when_state_contains_only_dedicated_keys():
+        async def it_does_not_emit_frontend_state_mutated():
+            from langgraph_events.agui import FrontendStateMutated
+
+            @on(UserAsked)
+            def reply(event: UserAsked) -> AgentReplied:
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [reply],
+                reducers=[message_reducer()],
+                checkpointer=MemorySaver(),
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            config = {"configurable": {"thread_id": "thread-fsm-msgs-only"}}
+            await _collect(
+                adapter,
+                _make_input(
+                    thread_id="thread-fsm-msgs-only",
+                    state={"messages": [{"role": "user", "content": "forged"}]},
+                ),
+            )
+
+            log = graph.get_state(config).events
+            assert not any(isinstance(e, FrontendStateMutated) for e in log)
+
+    def when_state_has_dedicated_plus_other_keys():
+        async def it_strips_dedicated_keys_from_the_emitted_event():
+            from langgraph_events.agui import FrontendStateMutated
+
+            @on(UserAsked)
+            def reply(event: UserAsked) -> AgentReplied:
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [reply],
+                reducers=[message_reducer()],
+                checkpointer=MemorySaver(),
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            config = {"configurable": {"thread_id": "thread-fsm-mixed"}}
+            await _collect(
+                adapter,
+                _make_input(
+                    thread_id="thread-fsm-mixed",
+                    state={
+                        "messages": [{"role": "user", "content": "forged"}],
+                        "focus": "scene-7",
+                    },
+                ),
+            )
+
+            log = graph.get_state(config).events
+            fsm_events = [e for e in log if isinstance(e, FrontendStateMutated)]
+            assert len(fsm_events) == 1
+            assert fsm_events[0].state == {"focus": "scene-7"}
+            assert "messages" not in fsm_events[0].state
+
+    def when_no_checkpointer():
+        async def it_still_applies_state_within_the_run():
+            from langgraph_events import SKIP, ScalarReducer
+            from langgraph_events.agui import FrontendStateMutated
+
+            focus = ScalarReducer(
+                name="focus",
+                event_type=FrontendStateMutated,
+                fn=lambda e: e.state.get("focus", SKIP),
+            )
+            seen: list[str | None] = []
+
+            @on(UserAsked)
+            def reply(event: UserAsked, focus: str | None = None) -> AgentReplied:
+                seen.append(focus)
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [reply],
+                reducers=[message_reducer(), focus],
+                # No checkpointer — used to be a hard skip under apre_seed.
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            await _collect(adapter, _make_input(state={"focus": "no-ckpt"}))
+
+            assert seen == ["no-ckpt"]
+
+    def when_reducer_fn_transforms_the_value():
+        """Witnesses the documented resume-path asymmetry:
+
+        - non-resume: state flows through the reducer's ``fn`` via event
+          dispatch, so the channel holds the transformed value.
+        - resume: the adapter writes channel values directly via
+          ``apre_seed``, bypassing ``fn``; the channel holds the raw
+          client value.
+        """
+
+        async def it_applies_the_transformation_on_non_resume():
+            from langgraph_events import SKIP, ScalarReducer
+            from langgraph_events.agui import FrontendStateMutated
+
+            focus = ScalarReducer(
+                name="focus",
+                event_type=FrontendStateMutated,
+                fn=lambda e: e.state["focus"].upper() if "focus" in e.state else SKIP,
+            )
+            seen: list[str | None] = []
+
+            @on(UserAsked)
+            def reply(event: UserAsked, focus: str | None = None) -> AgentReplied:
+                seen.append(focus)
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [reply],
+                reducers=[message_reducer(), focus],
+                checkpointer=MemorySaver(),
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            await _collect(adapter, _make_input(state={"focus": "scene-lc"}))
+
+            assert seen == ["SCENE-LC"]
+
+        async def it_bypasses_the_transformation_on_resume():
+            from langgraph_events import SKIP, ScalarReducer
+            from langgraph_events.agui import FrontendStateMutated
+
+            focus = ScalarReducer(
+                name="focus",
+                event_type=FrontendStateMutated,
+                fn=lambda e: e.state["focus"].upper() if "focus" in e.state else SKIP,
+            )
+            seen: list[str | None] = []
+
+            @on(UserAsked)
+            def ask(event: UserAsked) -> ApprovalRequested:
+                return ApprovalRequested(draft="ship it?")
+
+            @on(ApprovalGiven)
+            def finish(
+                event: ApprovalGiven,
+                focus: str | None = None,
+            ) -> AgentReplied:
+                seen.append(focus)
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [ask, finish],
+                reducers=[message_reducer(), focus],
+                checkpointer=MemorySaver(),
+            )
+
+            thread_id = "thread-fsm-fn-bypass"
+            config = {"configurable": {"thread_id": thread_id}}
+
+            await graph.ainvoke(UserAsked(question="approve?"), config=config)
+
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="unused"),
+                resume_factory=lambda inp: ApprovalGiven(approved=True),
+            )
+            await _collect(
+                adapter,
+                _make_input(
+                    thread_id=thread_id,
+                    state={"focus": "scene-lc"},
+                ),
+            )
+
+            # Raw value — fn's `.upper()` transformation was bypassed.
+            assert seen == ["scene-lc"]
+
+    def when_handler_subscribes_to_frontend_state_mutated():
+        async def it_fires_and_its_output_event_appears_in_the_log():
+            from langgraph_events.agui import FrontendStateMutated
+
+            @on(FrontendStateMutated)
+            def log_focus(event: FrontendStateMutated) -> FocusLogged | None:
+                focus = event.state.get("focus")
+                if focus is None:
+                    return None
+                return FocusLogged(value=focus)
+
+            @on(UserAsked)
+            def reply(event: UserAsked) -> AgentReplied:
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [log_focus, reply],
+                reducers=[message_reducer()],
+                checkpointer=MemorySaver(),
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            config = {"configurable": {"thread_id": "thread-fsm-handler"}}
+            await _collect(
+                adapter,
+                _make_input(
+                    thread_id="thread-fsm-handler",
+                    state={"focus": "handler-case"},
+                ),
+            )
+
+            log = graph.get_state(config).events
+            focus_events = [e for e in log if isinstance(e, FocusLogged)]
+            assert len(focus_events) == 1
+            assert focus_events[0].value == "handler-case"
+
+    def when_resuming():
+        def with_state_change_from_client():
+            async def it_applies_state_before_resume_event_handler_runs():
+                from langgraph_events import SKIP, ScalarReducer
+                from langgraph_events.agui import FrontendStateMutated
+
+                focus = ScalarReducer(
+                    name="focus",
+                    event_type=FrontendStateMutated,
+                    fn=lambda e: e.state.get("focus", SKIP),
+                )
+                seen: list[str | None] = []
+
+                @on(UserAsked)
+                def ask(event: UserAsked) -> ApprovalRequested:
+                    return ApprovalRequested(draft="ship it?")
+
+                @on(ApprovalGiven)
+                def finish(
+                    event: ApprovalGiven,
+                    focus: str | None = None,
+                ) -> AgentReplied:
+                    seen.append(focus)
+                    return AgentReplied(message=AIMessage(content="ok"))
+
+                graph = EventGraph(
+                    [ask, finish],
+                    reducers=[message_reducer(), focus],
+                    checkpointer=MemorySaver(),
+                )
+
+                thread_id = "thread-fsm-resume"
+                config = {"configurable": {"thread_id": thread_id}}
+
+                # Drive the graph to an interrupt (bypassing the adapter —
+                # mirrors the priming pattern in
+                # `it_suppresses_resumed_events`).
+                await graph.ainvoke(UserAsked(question="approve?"), config=config)
+
+                # Now resume via the adapter, shipping client state along
+                # with the resume input.  The checkpoint's pending
+                # interrupt causes the adapter to take the resume branch.
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="unused"),
+                    resume_factory=lambda inp: ApprovalGiven(approved=True),
+                )
+                await _collect(
+                    adapter,
+                    _make_input(
+                        thread_id=thread_id,
+                        state={"focus": "resume-case"},
+                    ),
+                )
+
+                assert seen == ["resume-case"]
+
+    def when_mapping_to_agui_output():
+        async def it_does_not_warn_about_missing_agui_dict():
+            from langgraph_events.agui import FrontendStateMutated
+            from langgraph_events.agui._mappers import _warned_classes
+
+            # Ensure the warning can fire for this class in this test run.
+            _warned_classes.discard(FrontendStateMutated)
+
+            @on(UserAsked)
+            def reply(event: UserAsked) -> AgentReplied:
+                return AgentReplied(message=AIMessage(content="ok"))
+
+            graph = EventGraph(
+                [reply],
+                reducers=[message_reducer()],
+                checkpointer=MemorySaver(),
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+
+            with warnings.catch_warnings(record=True) as captured:
+                warnings.simplefilter("always")
+                events = await _collect(
+                    adapter,
+                    _make_input(state={"focus": "wire-check"}),
+                )
+
+            # No missing-agui_dict warning for FrontendStateMutated.
+            assert not any("FrontendStateMutated" in str(w.message) for w in captured)
+            # And no CustomEvent echoing the event to the client.
+            custom_names = [e.name for e in events if isinstance(e, CustomEvent)]
+            assert "FrontendStateMutated" not in custom_names


### PR DESCRIPTION
## Why

Backport of #53 onto the `0.4.x` release line. Users who can't / don't want to jump to `0.5.0`'s Namespace/Domain rename still need the AG-UI client-state sync. This PR targets `release/0.4.x` (freshly created from the `v0.4.0` tag); merge cuts a `0.4.1` patch.

## What

Same change as #53, adapted for the `v0.4.0` API surface:
- New `FrontendStateMutated(Event)` (on `v0.4.0` there's no `IntegrationEvent` — the event taxonomy was introduced in `0.5.0`; we subclass `Event` directly here, matching the `v0.4.0` pattern of `UserAsked(Event)` etc.).
- Adapter emits it as the first event of the seed list on non-resume runs.
- Resume path writes filtered `RunAgentInput.state` via `graph.apre_seed` before `astream_resume` (same rationale as #53 — `ainvoke` on a pending-interrupt thread would consume the interrupt).
- Added to `SkipInternalMapper` so it's not echoed to the client.
- Dedicated `messages` key stripped; empty / missing state → no event emitted.
- Works with or without a checkpointer on the non-resume path.

## Differences from #53 (main-targeted PR)

| Aspect | #53 (main) | This PR (0.4.x) |
|---|---|---|
| Base class | `IntegrationEvent` | `Event` |
| Stream-type imports | `langgraph_events.stream` | `langgraph_events._graph` |
| Test fixtures | Full 0.5.0 module-level event set | Only `FocusLogged` added |
| Shape test assertion | `isinstance(event, IntegrationEvent)` | `isinstance(event, Event)` |

Everything else is identical.

## Test Plan

- [x] `uv run pytest tests/` — 109 tests pass (0.4.x has a smaller suite than 0.5.x)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean

## Release

After merge, run `uv run scripts/release.py patch` on `release/0.4.x` to cut `v0.4.1`. (Or do the equivalent bumps by hand if the script is `main`-only — needs verification.)

## Supersedes / related

Closes / supersedes #53 (same change, targeting 0.4.x instead of main). If you want this *also* forward-ported to main for the next minor, that's a separate PR — happy to do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)