### PR TITLE
chore(release): support release/* branches in scripts/release.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Event-driven abstraction for LangGraph. State IS events.
 
 ## Release
 
-Use `uv run scripts/release.py {major|minor|patch|X.Y.Z}` — do not hand-edit version strings. The script bumps `pyproject.toml`/`README.md`/`docs/index.md`, stamps `[Unreleased]` in `CHANGELOG.md` with today's date, runs `uv lock`, commits as `release: vX.Y.Z`, and tags. Preflight requires a clean working tree on `main` and a non-empty `[Unreleased]` section. Add `--dry-run` to preview. After it runs: `git push origin main vX.Y.Z` triggers the TestPyPI → PyPI publish workflow.
+Use `uv run scripts/release.py {major|minor|patch|X.Y.Z}` — do not hand-edit version strings. The script bumps `pyproject.toml`/`README.md`/`docs/index.md`, stamps `[Unreleased]` in `CHANGELOG.md` with today's date, runs `uv lock`, commits as `release: vX.Y.Z`, and tags. Preflight requires a clean working tree on `main` or any `release/*` branch, plus a non-empty `[Unreleased]` section. Add `--dry-run` to preview. After it runs, the final message prints the exact `git push origin <branch> vX.Y.Z` command to run, which triggers the TestPyPI → PyPI publish workflow.
 
 ## Conventions
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -61,6 +61,11 @@ def compute_new_version(current: str, arg: str) -> str:
     return arg
 
 
+def current_branch() -> str:
+    result = _run(["git", "branch", "--show-current"])
+    return result.stdout.strip()
+
+
 def preflight(new_version: str) -> None:
     errors: list[str] = []
 
@@ -68,10 +73,11 @@ def preflight(new_version: str) -> None:
     if result.stdout.strip():
         errors.append("Working tree is not clean. Commit or stash changes first.")
 
-    result = _run(["git", "branch", "--show-current"])
-    branch = result.stdout.strip()
-    if branch != "main":
-        errors.append(f"Must be on main branch (currently on '{branch}').")
+    branch = current_branch()
+    if branch != "main" and not branch.startswith("release/"):
+        errors.append(
+            f"Must be on main or a release/* branch (currently on '{branch}')."
+        )
 
     changelog = (ROOT / "CHANGELOG.md").read_text()
     unreleased_match = re.search(
@@ -237,9 +243,10 @@ def main() -> None:
     if not args.dry_run:
         print("\nCommitting and tagging...", file=sys.stderr)
         commit_and_tag(new)
+        branch = current_branch()
         print(
             f"\n✅ Release v{new} is ready. Run:\n\n"
-            f"  git push origin main v{new}\n\n"
+            f"  git push origin {branch} v{new}\n\n"
             f"This will trigger the publish workflow (TestPyPI → PyPI).",
             file=sys.stderr,
         )


### PR DESCRIPTION
## Why

`scripts/release.py` hard-fails on any branch except `main`:

```
Error: Must be on main branch (currently on 'release/0.4.x').
```

That blocks backport-patch releases like `v0.4.1` cut from `release/0.4.x`. Hand-editing version strings is explicitly forbidden by CLAUDE.md, so without this change we'd be stuck.

## What

Two changes, both in `scripts/release.py`:

1. **Preflight branch check** now accepts `main` OR any `release/*` branch. Error message updated accordingly.
2. **Final push instruction** uses the current branch instead of hardcoding `main` — so cutting `v0.4.1` on `release/0.4.x` prints `git push origin release/0.4.x v0.4.1`.

Small helper `current_branch()` extracted since it's now called in two places.

`CLAUDE.md`'s Release section updated to reflect the new rule.

## Test Plan

- [x] `uv run scripts/release.py patch --dry-run` on `chore/release-script-support-release-branches` correctly errors with `"Must be on main or a release/* branch (currently on 'chore/...')."` — preflight logic verified.
- [x] `uv run ruff check scripts/` + `uv run ruff format --check scripts/` — clean.
- [ ] (Reviewer) Confirm `current_branch()` placement is OK; alternative would be inlining.

## Follows / unblocks

- Required before cutting `v0.4.1` via the script on `release/0.4.x` (backport PR #54).

🤖 Generated with [Claude Code](https://claude.com/claude-code)