### PR TITLE
fix(agui): port PR #56 (state projection + resume FSM dispatch) to main / 0.5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **agui**: `AGUIAdapter(include_reducers=...)` validation — malformed values (anything other than `bool | list[str]`) now raise `TypeError` at construction instead of silently producing empty snapshots at runtime.
+
+### Fixed
+- **agui**: `AGUIAdapter.connect()` and the streaming `StateSnapshotEvent` path no longer leak the EventGraph-internal `events` audit log to clients. The audit log is graph-internal and was causing O(history) wire bloat on every client `Send` via `RunAgentInput.state` round-trip. The strip set is now derived from `_internal._BASE_FIELDS` (single source of truth across all four projection sites) rather than hardcoded; future internal channels propagate automatically. `_extract_frontend_state` also strips internal keys as defense-in-depth against stale-client echo.
+- **agui**: Resume-time frontend state now flows through `FrontendStateMutated` instead of bypassing dispatch via `apre_seed(raw_state)`. The adapter computes per-reducer contributions from the FSM event (preserving `fn` semantics — transformations, `SKIP`) and writes them to channels via `apre_seed` *before* the resume's domain dispatch, then injects FSM as a seed to `astream_resume` so it appears in the output stream and the persisted audit log. Reducers that subscribe to `FrontendStateMutated` see the same contract on resume as on the non-resume path; reducers that subscribe to backend domain events are no longer clobbered by stale frontend snapshot keys. `@on(FrontendStateMutated)` *handlers* still do not fire on resume — `Command(resume=...)` carries one value and seeds dispatch out-of-graph; use `@on(Resumed)` for resume-time side effects.
+
+### Changed
+- **agui**: `AGUIAdapter.__init__` validates the `messages` reducer eagerly (raises `ValueError` immediately, before any other setup).
+- **EventGraph**: `stream_resume` and `astream_resume` now accept a `seeds: list[Event] | None = None` kwarg. Seeds are dispatched alongside the resume in the same step — used by `AGUIAdapter` to route `FrontendStateMutated` through reducers on resume. Power users can plumb their own resume-time companion events through this hook.
+
 ## [0.5.1] - 2026-04-24
 
 ### Added

--- a/docs/agui.md
+++ b/docs/agui.md
@@ -93,6 +93,28 @@ Outside the mapper chain, the adapter also emits:
 - `StateSnapshot` for `StateSnapshotFrame`; `CustomEvent` for `CustomEventFrame` (name/value passthrough).
 - Lifecycle: `RunStarted`, `RunFinished`, or `RunError` on exception.
 
+### Shaping client-facing state
+
+`AGUIAdapter(include_reducers=...)` controls what reducer state crosses the wire. It accepts:
+
+- `True` (default) — ship every user reducer.
+- `list[str]` — allow-list (e.g. `["focus", "scene"]`).
+- `False` — ship no user reducers (the dedicated `messages` snapshot still ships via `MessagesSnapshotEvent`).
+
+The same value is applied symmetrically to outbound `StateSnapshotEvent` and inbound `RunAgentInput.state` echo (so a stale or untrusted client can't inject keys you've decided are internal). Framework-internal channels (`events`, `_cursor`, `_pending`, `_round`) and dedicated AG-UI keys (`messages`) are always stripped first.
+
+Allow-list keepers when you want to hide a few internal reducers:
+
+```python
+adapter = AGUIAdapter(
+    graph=graph,
+    seed_factory=lambda inp: UserAsked(question=...),
+    include_reducers=["focus", "scene", "user", "context"],  # debug_count, scratch hidden
+)
+```
+
+The list-form drives both projection (what the snapshot contains) and activation (which reducers EventGraph computes during streaming). If you need redaction or value transformation, write a custom `EventMapper` — that's the supported extension point for shaping AG-UI output.
+
 Messages are delivered via two channels — authoritative `MessagesSnapshot` from the reducer, plus real-time `TextMessageStart` / `Content` / `End` tokens. AG-UI clients reconcile them.
 
 ## Connect / Reconnect
@@ -192,6 +214,19 @@ adapter = AGUIAdapter(
 ```
 
 Returning an `Event` triggers `graph.astream_resume()`; `None` starts a fresh run via `seed_factory`. The `checkpoint_state` argument is optional — one-argument factories still work.
+
+### Frontend state on resume
+
+When `RunAgentInput.state` is populated alongside a resume, the adapter routes it through `FrontendStateMutated` exactly like the non-resume path:
+
+1. The state dict is projected via `include_reducers` (framework internals + dedicated keys stripped, then your projector if any).
+2. A `FrontendStateMutated(state=projected)` event is built.
+3. For each reducer subscribing to `FrontendStateMutated`, the adapter computes its contribution and writes it to the channel via `apre_seed` *before* the resume's domain dispatch — so the reducer's `fn` runs (transformations, `SKIP`) and any handler reading **reducer state via parameter injection** (e.g. `def my_handler(event: ApprovalGiven, focus: str | None = None)`) sees the updated value during the resume step.
+4. FSM is also injected as a seed to `astream_resume` so it appears in the output stream and the persisted audit log.
+
+**Reducers driven by backend domain events are not affected by FSM dispatch** — their channels stay intact regardless of what the client echoes. The resume's domain event flows through normal dispatch and wins for shared keys.
+
+**`@on(FrontendStateMutated)` *handler* callbacks do not fire on resume.** This is distinct from the parameter-injection pattern above: a function decorated with `@on(FrontendStateMutated)` will not be invoked, because LangGraph's `Command(resume=...)` carries one value and seeds dispatch out-of-graph. The reducer pipeline still runs (#3 above); it's only the dispatched-handler entry point that's unavailable on resume. Use `@on(Resumed)` or `@on(Resumed, interrupted=...)` for resume-time side effects.
 
 ## Frontend Tools
 

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -919,6 +919,7 @@ class EventGraph:
     ) -> AsyncIterator[StreamItem]:
         """Stream events using LangGraph's v2 event API with LLM token support."""
         compiled = self._compile()
+        is_resume = isinstance(inp, LGCommand)
 
         # Initialize incremental reducer state.  When a checkpoint exists
         # (subsequent run / resume), start from the checkpointed values so
@@ -944,10 +945,20 @@ class EventGraph:
                 reducer_state[name] = self._reducers[name].seed(seeds)
 
         # Merge seed contributions on top of checkpointed state.
-        # - On astream_resume: seeds=[] so this is a no-op.
-        # - On astream_events second-run: seeds carry new events that
-        #   should layer on top of the restored checkpoint.
-        if checkpoint_values is not None:
+        # - On astream_events second-run: seeds carry new events whose
+        #   contributions need to layer on top of the restored checkpoint
+        #   (LangGraph's seed_node will copy them into state["events"], but
+        #   the in-adapter reducer_state shadow needs the contribution
+        #   computed here so the StreamFrame yielded just below reflects it).
+        # - On astream_resume (is_resume=True): skipped — the caller
+        #   (e.g. AGUIAdapter) is responsible for pre-seeding contributions
+        #   via apre_seed before calling astream_resume, because
+        #   Command(resume=...) doesn't route seeds through the seed_node.
+        #   Re-applying contributions here would double-count for
+        #   accumulator reducers (operator.add channel reducers concatenate
+        #   the contribution twice).  See
+        #   `AGUIAdapter._resume_event_stream` for the canonical pattern.
+        if checkpoint_values is not None and not is_resume:
             for s in seeds:
                 self._update_reducer_state(reducer_state, s, reducer_names)
 
@@ -1134,6 +1145,7 @@ class EventGraph:
         self,
         value: Event,
         *,
+        seeds: list[Event] | None = None,
         include_reducers: bool | list[str] = False,
         **kwargs: Any,
     ) -> Iterator[Event | StreamFrame]:
@@ -1145,6 +1157,12 @@ class EventGraph:
 
         Args:
             value: The domain event to resume with.
+            seeds: Optional events to dispatch alongside the resume in the
+                same step.  Their reducer contributions layer onto the
+                checkpointed state *before* the resume's downstream events
+                run, so resume-handler outputs win for shared keys.  Used
+                by ``AGUIAdapter`` to route ``FrontendStateMutated`` through
+                the dispatch chain on resume.
             include_reducers: When truthy, yields ``StreamFrame`` tuples
                 instead of bare events.  Pass ``True`` for all reducers or
                 a list of reducer names for selective inclusion.
@@ -1153,7 +1171,7 @@ class EventGraph:
         kwargs.pop("stream_mode", None)
         reducer_names = self._resolve_reducer_names(include_reducers)
         yield from self._stream_sync(
-            LGCommand(resume=value), [], reducer_names, **kwargs
+            LGCommand(resume=value), seeds or [], reducer_names, **kwargs
         )
 
     async def _astream_entry(
@@ -1188,6 +1206,7 @@ class EventGraph:
         self,
         value: Event,
         *,
+        seeds: list[Event] | None = None,
         include_reducers: bool | list[str] = False,
         include_llm_tokens: bool = False,
         include_custom_events: bool = False,
@@ -1200,6 +1219,12 @@ class EventGraph:
 
         Args:
             value: The domain event to resume with.
+            seeds: Optional events to dispatch alongside the resume in the
+                same step.  Their reducer contributions layer onto the
+                checkpointed state *before* the resume's downstream events
+                run, so resume-handler outputs win for shared keys.  Used
+                by ``AGUIAdapter`` to route ``FrontendStateMutated`` through
+                the dispatch chain on resume.
             include_reducers: When truthy, yields ``StreamFrame`` tuples
                 instead of bare events.  Pass ``True`` for all reducers or
                 a list of reducer names for selective inclusion.
@@ -1212,7 +1237,7 @@ class EventGraph:
         self._require_checkpointer("astream_resume")
         async for item in self._astream_entry(
             LGCommand(resume=value),
-            [],
+            seeds or [],
             include_reducers=include_reducers,
             include_llm_tokens=include_llm_tokens,
             include_custom_events=include_custom_events,

--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -41,15 +41,9 @@ from ._mappers import (
     build_state_snapshot,
     default_mappers,
 )
+from ._state import _DEDICATED_EVENT_KEYS, _default_state_projection
 
 logger = logging.getLogger(__name__)
-
-_DEDICATED_EVENT_KEYS: frozenset[str] = frozenset({"messages"})
-
-
-def _strip_dedicated_keys(reducers: dict[str, Any]) -> dict[str, Any]:
-    """Return *reducers* without keys that have dedicated AG-UI events."""
-    return {k: v for k, v in reducers.items() if k not in _DEDICATED_EVENT_KEYS}
 
 
 class CheckpointState(TypedDict):
@@ -93,10 +87,25 @@ class AGUIAdapter:
             raise ValueError(
                 "AGUIAdapter resume_factory requires a checkpointer on the EventGraph"
             )
+        if "messages" not in graph._reducers:
+            raise ValueError(
+                "AGUIAdapter requires a message_reducer() on the EventGraph. "
+                "Add reducers=[message_reducer()] when constructing your "
+                "EventGraph."
+            )
+
+        # Validate input shape early.  Bools and lists are the only
+        # supported forms — fail loudly on garbage instead of silently
+        # producing an empty snapshot at runtime.
+        if not isinstance(include_reducers, (bool, list)):
+            raise TypeError(
+                f"include_reducers must be bool | list[str], "
+                f"got {type(include_reducers).__name__}"
+            )
+
         self._graph = graph
         self._seed_factory = seed_factory
         self._resume_factory = resume_factory
-        self._include_reducers = include_reducers
         self._error_message = error_message
         self._seed_accepts_state = self._accepts_extra_positional(seed_factory)
         self._resume_accepts_state = (
@@ -105,23 +114,25 @@ class AGUIAdapter:
             else False
         )
 
-        # Ensure message_reducer is present and included
+        # Force-include "messages" in the activation set so message-driven
+        # AG-UI events can read reducer state.  Layer 2 of
+        # default_state_projection then strips it from the snapshot.
+        # Note: `False` resolves to activation=["messages"] (so
+        # MessagesSnapshot still works) while the projection returns `{}` —
+        # empty StateSnapshot, populated MessagesSnapshot.  Intentional.
         resolved = graph._resolve_reducer_names(include_reducers)
         if "messages" not in resolved:
-            if "messages" in graph._reducers:
-                # User excluded "messages" — force-include it
-                if isinstance(include_reducers, list):
-                    include_reducers = [*include_reducers, "messages"]
-                else:
-                    include_reducers = ["messages"]
-                self._include_reducers = include_reducers
-            else:
-                raise ValueError(
-                    "AGUIAdapter requires a message_reducer() on the "
-                    "EventGraph. "
-                    "Add reducers=[message_reducer()] when constructing "
-                    "your EventGraph."
-                )
+            include_reducers = (
+                [*include_reducers, "messages"]
+                if isinstance(include_reducers, list)
+                else ["messages"]
+            )
+        self._activation: bool | list[str] = include_reducers
+        # Pre-compute the allow-list set for fast filtering.  None for
+        # bool=True (no filter beyond the framework strip).
+        self._allowed_keys: frozenset[str] | None = (
+            frozenset(include_reducers) if isinstance(include_reducers, list) else None
+        )
 
         # Build mapper chain: built-ins → user mappers → fallback
         chain: list[Any] = default_mappers()
@@ -129,6 +140,20 @@ class AGUIAdapter:
             chain.extend(mappers)
         chain.append(FallbackMapper())
         self._mappers: list[EventMapper] = chain
+
+    def _project_state(self, reducers: dict[str, Any]) -> dict[str, Any]:
+        """Project raw reducer state to client-facing state.
+
+        Strips framework-internal channels (``events``, ``_cursor``, …) and
+        dedicated AG-UI keys (``messages``), then applies the
+        ``include_reducers`` allow-list (if any).  Used symmetrically in
+        both directions: outbound ``StateSnapshotEvent`` and inbound
+        ``RunAgentInput.state`` echo into ``FrontendStateMutated``.
+        """
+        base = _default_state_projection(reducers)
+        if self._allowed_keys is None:
+            return base
+        return {k: v for k, v in base.items() if k in self._allowed_keys}
 
     def _map_event(self, event: Any, ctx: MapperContext) -> list[BaseEvent]:
         """Run event through the mapper chain. First non-None wins."""
@@ -257,7 +282,7 @@ class AGUIAdapter:
             return
 
         reducers = snapshot.values if isinstance(snapshot.values, dict) else {}
-        yield build_state_snapshot(_strip_dedicated_keys(reducers))
+        yield build_state_snapshot(self._project_state(reducers))
         yield build_messages_snapshot(reducers.get("messages") or [])
 
         for interrupted in self._interrupts_from_snapshot(snapshot):
@@ -278,22 +303,23 @@ class AGUIAdapter:
             and checkpoint_state["is_interrupted"]
         )
 
-    @staticmethod
     def _extract_frontend_state(
+        self,
         input_data: RunAgentInput,
     ) -> dict[str, Any] | None:
-        """Return the pre-filtered client state, or ``None`` if there's
+        """Return the projected client state, or ``None`` if there's
         nothing to emit.
 
-        AG-UI ships ``RunAgentInput.state`` as a snapshot.  Dedicated keys
-        (``messages``) are driven by purpose-built AG-UI events and are
-        stripped here so they don't collide.  Empty / non-dict state is
-        treated as "no update."
+        AG-UI ships ``RunAgentInput.state`` as a snapshot.  We apply the
+        same projection used outbound (framework internals stripped,
+        dedicated keys stripped, then the user's ``include_reducers``) so
+        a stale or untrusted client can't echo back keys the dev decided
+        are internal.  Empty / non-dict state is treated as "no update."
         """
         raw = input_data.state
         if not isinstance(raw, dict) or not raw:
             return None
-        filtered = _strip_dedicated_keys(raw)
+        filtered = self._project_state(raw)
         return filtered or None
 
     def _prepend_frontend_state(
@@ -313,47 +339,92 @@ class AGUIAdapter:
             return seed_list
         return [FrontendStateMutated(state=filtered), *seed_list]  # type: ignore[call-arg]
 
-    async def _apply_frontend_state_for_resume(
-        self,
-        input_data: RunAgentInput,
-        config: Any,
-    ) -> None:
-        """Write client state directly to reducer channels via ``apre_seed``.
-
-        NOTE: On resume we bypass the ``FrontendStateMutated`` dispatch
-        path.  ``ainvoke`` on a thread with a pending interrupt would
-        consume the interrupt before ``astream_resume`` runs, so we
-        write channel values directly (matching state key -> channel
-        name).  Trade-off: the reducer's ``fn`` is not invoked on
-        resume — in the idiomatic ``fn=lambda e: e.state.get(name,
-        SKIP)`` pattern the value flows through unchanged, but
-        non-identity ``fn`` logic applies only on non-resume runs.
-        No-op when the input state is empty or contains only dedicated
-        keys.
-        """
-        filtered = self._extract_frontend_state(input_data)
-        if filtered is None:
-            return
-        await self._graph.apre_seed(config, filtered)
-
     async def _resume_event_stream(
         self,
         input_data: RunAgentInput,
         resume_event: Any,
         config: Any,
     ) -> AsyncIterator[StreamItem]:
-        """Resume path that first commits FrontendStateMutated to the
-        checkpoint, then defers to ``astream_resume``.
+        """Resume path that routes ``FrontendStateMutated`` through both
+        reducer dispatch and the LangGraph channel state.
+
+        For each reducer subscribing to ``FrontendStateMutated``, compute the
+        contribution and ``apre_seed`` it to the channel so handlers reading
+        reducer state via parameter injection on the resumed step see the
+        update.  This preserves reducer ``fn`` semantics (transformations,
+        ``SKIP``) — unlike the old ``apre_seed(raw_state)`` bypass that wrote
+        client values directly and could clobber backend-authoritative
+        channels with stale snapshot keys.
+
+        Then pass FSM as a seed to ``astream_resume`` so it appears in the
+        output stream and audit log alongside the resume event.
+
+        **Limitation**: ``@on(FrontendStateMutated)`` handlers do not fire on
+        resume — LangGraph's ``Command(resume=...)`` carries one value and
+        seeds are dispatched out-of-graph.  Use ``@on(Resumed)`` for
+        resume-time side effects.
         """
-        await self._apply_frontend_state_for_resume(input_data, config)
+        fsm = self._build_resume_frontend_state_event(input_data)
+        if fsm is not None:
+            await self._commit_resume_frontend_state(fsm, config)
         async for item in self._graph.astream_resume(
             resume_event,
-            include_reducers=self._include_reducers,
+            seeds=[fsm] if fsm is not None else [],
+            include_reducers=self._activation,
             include_llm_tokens=True,
             include_custom_events=True,
             config=config,
         ):
             yield item
+
+    def _build_resume_frontend_state_event(
+        self, input_data: RunAgentInput
+    ) -> FrontendStateMutated | None:
+        """Build a ``FrontendStateMutated`` from the projected client state,
+        or ``None`` when there's nothing to apply on resume.
+        """
+        filtered = self._extract_frontend_state(input_data)
+        if filtered is None:
+            return None
+        return FrontendStateMutated(state=filtered)  # type: ignore[call-arg]
+
+    async def _commit_resume_frontend_state(
+        self, fsm: FrontendStateMutated, config: Any
+    ) -> None:
+        """Persist FSM into the audit log AND apply reducer contributions
+        to user channels — both before the resume's domain dispatch runs.
+
+        Channel reducers merge the writes (``operator.add`` for ``events``,
+        scalar / accumulator for user reducers).  We do NOT emit FSM via
+        the seed_node here: ``Command(resume=...)`` carries one value and
+        doesn't route seeds through ``inp["events"]``, so this ``apre_seed``
+        is the sole path that lands FSM in the persisted ``events``
+        channel.  ``_astream_v2`` yields seeds into the output stream but
+        deliberately skips re-applying seed contributions on resume to
+        avoid double-counting accumulator reducers.
+
+        If a future refactor unifies seed dispatch through ``inp["events"]``,
+        drop the ``{"events": [fsm]}`` entry to avoid duplication.
+        """
+        updates: dict[str, Any] = {"events": [fsm]}
+        updates.update(self._reducer_updates_for([fsm]))
+        await self._graph.apre_seed(config, updates)
+
+    def _reducer_updates_for(self, events: list[Event]) -> dict[str, Any]:
+        """Compute per-channel reducer contributions for *events*.
+
+        Runs each registered reducer's ``collect`` against *events* and
+        returns the dict of channel updates (only including channels with
+        actual contributions).  Used on the resume path to materialise FSM
+        reducer effects into LangGraph channel state so subsequent handlers
+        see them via parameter injection.
+        """
+        updates: dict[str, Any] = {}
+        for name, reducer in self._graph._reducers.items():
+            contribution = reducer.collect(events)
+            if reducer.has_contributions(contribution):
+                updates[name] = contribution
+        return updates
 
     def _build_event_stream(
         self,
@@ -369,7 +440,7 @@ class AGUIAdapter:
         seeds = self._prepend_frontend_state(input_data, seed)
         return self._graph.astream_events(
             seeds,
-            include_reducers=self._include_reducers,
+            include_reducers=self._activation,
             include_llm_tokens=True,
             include_custom_events=True,
             config=config,
@@ -473,7 +544,7 @@ class AGUIAdapter:
             )
 
         if should_emit_state_snapshot:
-            events.append(build_state_snapshot(_strip_dedicated_keys(item.reducers)))
+            events.append(build_state_snapshot(self._project_state(item.reducers)))
             state_snapshot_emitted = True
 
         messages = item.reducers.get("messages")
@@ -531,7 +602,7 @@ class AGUIAdapter:
         # Interrupt gate: re-emit state without executing when interrupted
         if self._should_gate_with_checkpoint_replay(resume_event, checkpoint_state):
             state = cast("CheckpointState", checkpoint_state)
-            yield build_state_snapshot(_strip_dedicated_keys(state["reducers"]))
+            yield build_state_snapshot(self._project_state(state["reducers"]))
             messages = state["messages"]
             if messages is not None:
                 yield build_messages_snapshot(messages)

--- a/src/langgraph_events/agui/_events.py
+++ b/src/langgraph_events/agui/_events.py
@@ -29,6 +29,17 @@ class FrontendStateMutated(IntegrationEvent):
     to client-state changes.  The adapter does not echo this event back to
     the client; downstream reducer changes surface through the usual
     ``StateSnapshotEvent`` path.
+
+    **Resume-path semantics.**  On resume (``RunAgentInput`` carrying both
+    ``state`` and a resume signal), reducers subscribed to
+    ``FrontendStateMutated`` *do* fire — the adapter computes their
+    contributions and writes them to channels via ``apre_seed`` before the
+    resume's domain dispatch, so handlers reading reducer state via
+    parameter injection see the updated values.  However,
+    ``@on(FrontendStateMutated)`` *handlers* do not fire on resume — the
+    LangGraph ``Command(resume=...)`` carries a single value and seeds are
+    dispatched out-of-graph.  Use ``@on(Resumed)`` for resume-time side
+    effects.
     """
 
     state: dict[str, Any] = field(default_factory=dict)

--- a/src/langgraph_events/agui/_state.py
+++ b/src/langgraph_events/agui/_state.py
@@ -1,0 +1,34 @@
+"""State projection: deciding which reducer state crosses the AG-UI boundary.
+
+Two layers of stripping always run on every snapshot, in both directions:
+
+1. **Framework internals** — channels managed by EventGraph itself
+   (``events``, ``_cursor``, ``_pending``, ``_round``).  Never visible to
+   clients.  Derived from :data:`langgraph_events._internal._BASE_FIELDS`
+   so adding a new internal channel propagates automatically.
+2. **Dedicated AG-UI keys** — reducer keys driven by purpose-built AG-UI
+   events (e.g. ``messages`` ships via MESSAGES_SNAPSHOT, not in
+   STATE_SNAPSHOT).
+
+User-facing control is via ``AGUIAdapter(include_reducers=...)`` which
+accepts ``bool | list[str]``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph_events._internal import _BASE_FIELDS
+
+_FRAMEWORK_INTERNAL_KEYS: frozenset[str] = frozenset(_BASE_FIELDS)
+_DEDICATED_EVENT_KEYS: frozenset[str] = frozenset({"messages"})
+_RESERVED_KEYS: frozenset[str] = _FRAMEWORK_INTERNAL_KEYS | _DEDICATED_EVENT_KEYS
+
+
+def _default_state_projection(reducers: dict[str, Any]) -> dict[str, Any]:
+    """Strip framework-internal channels and dedicated AG-UI keys.
+
+    Always applied before any user-supplied ``include_reducers`` filter.
+    Module-internal: devs interact via ``include_reducers``.
+    """
+    return {k: v for k, v in reducers.items() if k not in _RESERVED_KEYS}

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -185,6 +185,16 @@ class FocusLogged(IntegrationEvent):
         return {"value": self.value}
 
 
+class FocusEcho(IntegrationEvent):
+    """Module-level for handler-annotation type resolution (per CLAUDE.md).
+
+    Used by the C1 regression test that primes an accumulator reducer
+    before a resume.
+    """
+
+    value: str = ""
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -218,6 +228,52 @@ def _types(events: list[BaseEvent]) -> list[EventType]:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+def describe_default_state_projection():
+    """Direct coverage of the framework-strip layer.
+
+    Module-internal but load-bearing: every snapshot (outbound + inbound)
+    flows through it.  A regression here would silently leak framework
+    channels (``events``, ``_cursor``, …) or dedicated AG-UI keys
+    (``messages``) to clients — so we test it directly, independent of
+    the AGUIAdapter integration that also exercises it.
+    """
+
+    def when_input_has_framework_keys():
+        def it_strips_them():
+            from langgraph_events.agui._state import _default_state_projection
+
+            result = _default_state_projection(
+                {
+                    "events": ["audit-log"],
+                    "_cursor": 7,
+                    "_pending": [],
+                    "_round": 3,
+                    "focus": "scene-1",
+                }
+            )
+            assert result == {"focus": "scene-1"}
+
+    def when_input_has_messages_key():
+        def it_strips_the_dedicated_channel():
+            from langgraph_events.agui._state import _default_state_projection
+
+            result = _default_state_projection({"messages": ["m1"], "focus": "scene-2"})
+            assert result == {"focus": "scene-2"}
+
+    def when_input_has_only_user_keys():
+        def it_passes_them_through_unchanged():
+            from langgraph_events.agui._state import _default_state_projection
+
+            payload = {"focus": "scene-3", "scene": "@scene-3", "count": 7}
+            assert _default_state_projection(payload) == payload
+
+    def when_input_is_empty():
+        def it_returns_empty():
+            from langgraph_events.agui._state import _default_state_projection
+
+            assert _default_state_projection({}) == {}
 
 
 def describe_AGUIAdapter():
@@ -1247,6 +1303,39 @@ def describe_AGUIAdapter():
                 snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
                 assert len(snapshots) >= 1
 
+        def when_include_reducers_is_malformed():
+            def it_raises_typeerror_at_construction():
+                """Garbage values (int, dict, callable, etc.) fail loudly at
+                init, not silently as empty snapshots at runtime."""
+
+                @on(UserAsked)
+                def reply(event: UserAsked) -> AgentReplied:
+                    return AgentReplied(message=AIMessage(content="ok"))
+
+                graph = EventGraph([reply], reducers=[message_reducer()])
+                with pytest.raises(TypeError, match="include_reducers"):
+                    AGUIAdapter(
+                        graph=graph,
+                        seed_factory=lambda inp: UserAsked(question="hi"),
+                        include_reducers=42,  # type: ignore[arg-type]
+                    )
+
+            def it_rejects_a_callable():
+                """Bare callables aren't a supported include_reducers shape —
+                use the list[str] allow-list form."""
+
+                @on(UserAsked)
+                def reply(event: UserAsked) -> AgentReplied:
+                    return AgentReplied(message=AIMessage(content="ok"))
+
+                graph = EventGraph([reply], reducers=[message_reducer()])
+                with pytest.raises(TypeError, match="include_reducers"):
+                    AGUIAdapter(
+                        graph=graph,
+                        seed_factory=lambda inp: UserAsked(question="hi"),
+                        include_reducers=lambda r: r,  # type: ignore[arg-type]
+                    )
+
     def describe_seed_factory():
         async def it_passes_input_to_factory():
             received_inputs: list[Any] = []
@@ -1515,6 +1604,61 @@ def describe_connect():
             assert captured[0]["configurable"]["tenant_id"] == "acme"
             assert captured[0]["configurable"]["thread_id"] == "t-connect-config"
             assert any(e.type == EventType.STATE_SNAPSHOT for e in events)
+
+    def when_internal_audit_log_present():
+        async def it_strips_events_audit_log_from_state_snapshot():
+            """`events` is graph-internal and must not leak into client state.
+
+            The EventGraph auto-injects an `events` reducer for the cumulative
+            audit log.  AG-UI clients echo any `state.*` key back via
+            `RunAgentInput.state` on every Send — round-tripping the entire
+            audit log every run is O(history) wire bloat and the log itself is
+            never a client concern.
+            """
+            from langgraph_events import SKIP, ScalarReducer
+
+            focus = ScalarReducer(
+                name="focus",
+                event_type=UserAsked,
+                fn=lambda e: e.question or SKIP,
+            )
+
+            @on(UserAsked)
+            def reply(event: UserAsked) -> AgentReplied:
+                return AgentReplied(message=AIMessage(content="hi"))
+
+            graph = EventGraph(
+                [reply],
+                checkpointer=MemorySaver(),
+                reducers=[message_reducer(), focus],
+            )
+            config = {"configurable": {"thread_id": "t-connect-no-events-leak"}}
+            await graph.ainvoke(UserAsked(question="scene-7"), config=config)
+
+            # Sanity: the checkpoint really does carry a non-empty audit log.
+            checkpoint_events = graph.get_state(config).events
+            assert len(checkpoint_events) >= 1
+
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="unused"),
+            )
+            events = [
+                event
+                async for event in adapter.connect(
+                    _make_input(thread_id="t-connect-no-events-leak")
+                )
+            ]
+
+            state_snapshots = [e for e in events if e.type == EventType.STATE_SNAPSHOT]
+            assert len(state_snapshots) == 1
+            snapshot = state_snapshots[0].snapshot
+            # The internal audit log must NOT leak to the client.
+            assert "events" not in snapshot
+            # Dedicated channels remain stripped.
+            assert "messages" not in snapshot
+            # User-defined reducers must STILL be present (no over-filtering).
+            assert snapshot.get("focus") == "scene-7"
 
 
 def describe_config_passthrough():
@@ -3466,6 +3610,77 @@ def describe_frontend_state_mutated():
             assert fsm_events[0].state == {"focus": "scene-7"}
             assert "messages" not in fsm_events[0].state
 
+    def when_state_echoes_internal_events():
+        def when_state_also_has_user_keys():
+            async def it_strips_internal_keys_from_the_emitted_event():
+                """Defense-in-depth: a stale client echoing `state.events` must
+                never inject the EventGraph audit log back into the graph.
+                """
+                from langgraph_events.agui import FrontendStateMutated
+
+                @on(UserAsked)
+                def reply(event: UserAsked) -> AgentReplied:
+                    return AgentReplied(message=AIMessage(content="ok"))
+
+                graph = EventGraph(
+                    [reply],
+                    reducers=[message_reducer()],
+                    checkpointer=MemorySaver(),
+                )
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="go"),
+                )
+                config = {"configurable": {"thread_id": "thread-fsm-events-echo"}}
+                await _collect(
+                    adapter,
+                    _make_input(
+                        thread_id="thread-fsm-events-echo",
+                        state={
+                            "events": [
+                                {"type": "stale", "payload": "from-client"},
+                            ],
+                            "user_key": "v",
+                        },
+                    ),
+                )
+
+                log = graph.get_state(config).events
+                fsm_events = [e for e in log if isinstance(e, FrontendStateMutated)]
+                assert len(fsm_events) == 1
+                assert fsm_events[0].state == {"user_key": "v"}
+                assert "events" not in fsm_events[0].state
+
+        def when_state_only_has_internal_keys():
+            async def it_drops_the_event_entirely():
+                """If the only key is the internal `events`, no FSM event fires."""
+                from langgraph_events.agui import FrontendStateMutated
+
+                @on(UserAsked)
+                def reply(event: UserAsked) -> AgentReplied:
+                    return AgentReplied(message=AIMessage(content="ok"))
+
+                graph = EventGraph(
+                    [reply],
+                    reducers=[message_reducer()],
+                    checkpointer=MemorySaver(),
+                )
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="go"),
+                )
+                config = {"configurable": {"thread_id": "thread-fsm-events-only"}}
+                await _collect(
+                    adapter,
+                    _make_input(
+                        thread_id="thread-fsm-events-only",
+                        state={"events": [{"type": "stale"}]},
+                    ),
+                )
+
+                log = graph.get_state(config).events
+                assert not any(isinstance(e, FrontendStateMutated) for e in log)
+
     def when_no_checkpointer():
         async def it_still_applies_state_within_the_run():
             from langgraph_events import SKIP, ScalarReducer
@@ -3497,13 +3712,13 @@ def describe_frontend_state_mutated():
             assert seen == ["no-ckpt"]
 
     def when_reducer_fn_transforms_the_value():
-        """Witnesses the documented resume-path asymmetry:
+        """The reducer's ``fn`` runs on both the non-resume and resume paths.
 
-        - non-resume: state flows through the reducer's ``fn`` via event
-          dispatch, so the channel holds the transformed value.
-        - resume: the adapter writes channel values directly via
-          ``apre_seed``, bypassing ``fn``; the channel holds the raw
-          client value.
+        On resume the adapter computes per-reducer contributions from the
+        ``FrontendStateMutated`` event and writes them to channels via
+        ``apre_seed`` *before* the resume's domain dispatch — preserving
+        ``fn`` semantics (transformations, ``SKIP``) symmetrically with the
+        non-resume path.
         """
 
         async def it_applies_the_transformation_on_non_resume():
@@ -3535,7 +3750,7 @@ def describe_frontend_state_mutated():
 
             assert seen == ["SCENE-LC"]
 
-        async def it_bypasses_the_transformation_on_resume():
+        async def it_applies_the_transformation_on_resume():
             from langgraph_events import SKIP, ScalarReducer
             from langgraph_events.agui import FrontendStateMutated
 
@@ -3564,7 +3779,7 @@ def describe_frontend_state_mutated():
                 checkpointer=MemorySaver(),
             )
 
-            thread_id = "thread-fsm-fn-bypass"
+            thread_id = "thread-fsm-fn-resume"
             config = {"configurable": {"thread_id": thread_id}}
 
             await graph.ainvoke(UserAsked(question="approve?"), config=config)
@@ -3582,8 +3797,8 @@ def describe_frontend_state_mutated():
                 ),
             )
 
-            # Raw value — fn's `.upper()` transformation was bypassed.
-            assert seen == ["scene-lc"]
+            # Transformed value — fn's `.upper()` ran on resume too.
+            assert seen == ["SCENE-LC"]
 
     def when_handler_subscribes_to_frontend_state_mutated():
         async def it_fires_and_its_output_event_appears_in_the_log():
@@ -3679,6 +3894,309 @@ def describe_frontend_state_mutated():
                 )
 
                 assert seen == ["resume-case"]
+
+        def with_backend_authoritative_channel():
+            async def it_lets_the_resume_domain_event_win():
+                """Cadance reproduction (`d1b7d7cf-…`, `560203cc-…`).
+
+                A channel driven by a backend domain event must not be
+                overwritten by a stale frontend snapshot key on resume.
+                The reducer subscribes to the backend event only — FSM
+                dispatch is a no-op for that channel, so the resume's
+                domain dispatch wins.
+                """
+                from langgraph_events import ScalarReducer
+
+                # Backend-authoritative: channel only updates from the
+                # domain event, NOT from FrontendStateMutated.
+                strategy = ScalarReducer(
+                    name="walkthrough_strategy",
+                    event_type=ApprovalGiven,
+                    fn=lambda e: "guided" if e.approved else "skipped",
+                )
+                # Backend reads strategy after resume.
+                seen_strategy: list[str | None] = []
+
+                @on(UserAsked)
+                def ask(event: UserAsked) -> ApprovalRequested:
+                    return ApprovalRequested(draft="proceed?")
+
+                @on(ApprovalGiven)
+                def finish(
+                    event: ApprovalGiven,
+                    walkthrough_strategy: str | None = None,
+                ) -> AgentReplied:
+                    seen_strategy.append(walkthrough_strategy)
+                    return AgentReplied(message=AIMessage(content="ok"))
+
+                graph = EventGraph(
+                    [ask, finish],
+                    reducers=[message_reducer(), strategy],
+                    checkpointer=MemorySaver(),
+                )
+
+                thread_id = "thread-backend-authoritative"
+                config = {"configurable": {"thread_id": thread_id}}
+                await graph.ainvoke(UserAsked(question="?"), config=config)
+
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="unused"),
+                    resume_factory=lambda inp: ApprovalGiven(approved=True),
+                )
+                # Stale frontend snapshot tries to inject a NULL strategy.
+                # Under the old apre_seed bypass this would clobber the
+                # channel; under FSM dispatch the reducer doesn't subscribe
+                # to FSM, so it's a no-op and the domain event wins.
+                await _collect(
+                    adapter,
+                    _make_input(
+                        thread_id=thread_id,
+                        state={"walkthrough_strategy": None},
+                    ),
+                )
+
+                assert seen_strategy == ["guided"]
+
+        def with_accumulator_reducer_subscribed_to_fsm():
+            async def it_does_not_double_count_the_contribution():
+                """Regression for C1 (PR #56 final review): an
+                ``operator.add``-style accumulator reducer wired to
+                ``FrontendStateMutated`` must not have its FSM contribution
+                applied twice on the resume path — once via the adapter's
+                ``apre_seed`` (which writes the channel), then a second time
+                via ``_astream_v2``'s seed-merge loop on top of the
+                already-written checkpoint state.
+
+                Symptom (pre-fix): the streamed STATE_SNAPSHOT shows the
+                FSM contribution doubled (``["X", "X"]``) while the
+                persisted checkpoint correctly shows ``["X"]``.
+                """
+                import operator
+
+                from langgraph_events import Reducer
+                from langgraph_events.agui import FrontendStateMutated
+
+                # Append-style reducer: each FSM event contributes
+                # [state["focus"]], merged via operator.add on the channel.
+                focus_log = Reducer(
+                    name="focus_log",
+                    event_type=FrontendStateMutated,
+                    fn=lambda e: [e.state["focus"]] if "focus" in e.state else [],
+                    reducer=operator.add,
+                )
+
+                @on(UserAsked)
+                def ask(event: UserAsked) -> ApprovalRequested:
+                    return ApprovalRequested(draft="ok?")
+
+                @on(ApprovalGiven)
+                def finish(event: ApprovalGiven) -> AgentReplied:
+                    return AgentReplied(message=AIMessage(content="done"))
+
+                graph = EventGraph(
+                    [ask, finish],
+                    reducers=[message_reducer(), focus_log],
+                    checkpointer=MemorySaver(),
+                )
+
+                thread_id = "thread-fsm-no-double-count"
+                config = {"configurable": {"thread_id": thread_id}}
+                await graph.ainvoke(UserAsked(question="?"), config=config)
+
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="unused"),
+                    resume_factory=lambda inp: ApprovalGiven(approved=True),
+                )
+                events = await _collect(
+                    adapter,
+                    _make_input(
+                        thread_id=thread_id,
+                        state={"focus": "X"},
+                    ),
+                )
+
+                # Persisted checkpoint: single contribution (correct).
+                checkpoint_values = (await graph.compiled.aget_state(config)).values
+                assert checkpoint_values.get("focus_log") == ["X"]
+
+                # Streamed STATE_SNAPSHOT: must also be single contribution.
+                snapshots = [e for e in events if e.type == EventType.STATE_SNAPSHOT]
+                assert snapshots, "expected at least one STATE_SNAPSHOT"
+                last = snapshots[-1].snapshot
+                assert last.get("focus_log") == ["X"], (
+                    f"expected ['X'], got {last.get('focus_log')!r} — FSM "
+                    "contribution was double-counted in the streamed snapshot"
+                )
+
+            async def it_layers_one_new_entry_onto_existing_accumulator_state():
+                """Stronger C1 regression: when the channel already holds
+                accumulated values from a prior run, the resume's FSM
+                contribution must add exactly one new entry, not two."""
+                import operator
+
+                from langgraph_events import Reducer
+                from langgraph_events.agui import FrontendStateMutated
+
+                # Reducer accumulates from BOTH a domain event (priming) and
+                # FSM (resume payload), so we can prime with real prior
+                # state then layer the FSM contribution on top.  FocusEcho
+                # is defined at module level so handler annotations resolve.
+                focus_log = Reducer(
+                    name="focus_log",
+                    event_type=(FocusEcho, FrontendStateMutated),
+                    fn=lambda e: (
+                        [e.value]
+                        if isinstance(e, FocusEcho)
+                        else ([e.state["focus"]] if "focus" in e.state else [])
+                    ),
+                    reducer=operator.add,
+                )
+
+                @on(FocusEcho)
+                def prime(event: FocusEcho) -> ApprovalRequested:
+                    return ApprovalRequested(draft="ok?")
+
+                @on(ApprovalGiven)
+                def finish(event: ApprovalGiven) -> AgentReplied:
+                    return AgentReplied(message=AIMessage(content="done"))
+
+                graph = EventGraph(
+                    [prime, finish],
+                    reducers=[message_reducer(), focus_log],
+                    checkpointer=MemorySaver(),
+                )
+
+                thread_id = "thread-fsm-layered"
+                config = {"configurable": {"thread_id": thread_id}}
+                # Prime the channel: two prior FocusEcho events accumulate
+                # ["a", "b"] before the interrupt.
+                await graph.ainvoke(
+                    [FocusEcho(value="a"), FocusEcho(value="b")], config=config
+                )
+                checkpoint_before = (await graph.compiled.aget_state(config)).values
+                assert checkpoint_before.get("focus_log") == ["a", "b"]
+
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: FocusEcho(value="unused"),
+                    resume_factory=lambda inp: ApprovalGiven(approved=True),
+                )
+                events = await _collect(
+                    adapter,
+                    _make_input(
+                        thread_id=thread_id,
+                        state={"focus": "X"},
+                    ),
+                )
+
+                # Persisted checkpoint: exactly one new entry layered on top.
+                checkpoint_after = (await graph.compiled.aget_state(config)).values
+                assert checkpoint_after.get("focus_log") == ["a", "b", "X"]
+
+                # Streamed STATE_SNAPSHOT: same — no double-count regression.
+                snapshots = [e for e in events if e.type == EventType.STATE_SNAPSHOT]
+                assert snapshots, "expected at least one STATE_SNAPSHOT"
+                last = snapshots[-1].snapshot
+                assert last.get("focus_log") == ["a", "b", "X"], (
+                    f"expected ['a', 'b', 'X'], got {last.get('focus_log')!r}"
+                    " — FSM contribution was double-counted on top of "
+                    "pre-existing accumulator state"
+                )
+
+        def with_state_yielded_in_output_stream():
+            async def it_emits_a_frontend_state_mutated_event_on_resume():
+                """FSM appears in the audit log on the resume path,
+                exactly like the non-resume path."""
+                from langgraph_events.agui import FrontendStateMutated
+
+                @on(UserAsked)
+                def ask(event: UserAsked) -> ApprovalRequested:
+                    return ApprovalRequested(draft="ok?")
+
+                @on(ApprovalGiven)
+                def finish(event: ApprovalGiven) -> AgentReplied:
+                    return AgentReplied(message=AIMessage(content="done"))
+
+                graph = EventGraph(
+                    [ask, finish],
+                    reducers=[message_reducer()],
+                    checkpointer=MemorySaver(),
+                )
+
+                thread_id = "thread-fsm-resume-audit"
+                config = {"configurable": {"thread_id": thread_id}}
+                await graph.ainvoke(UserAsked(question="?"), config=config)
+
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="unused"),
+                    resume_factory=lambda inp: ApprovalGiven(approved=True),
+                )
+                await _collect(
+                    adapter,
+                    _make_input(
+                        thread_id=thread_id,
+                        state={"focus": "resume-audit"},
+                    ),
+                )
+
+                log = graph.get_state(config).events
+                fsm_events = [e for e in log if isinstance(e, FrontendStateMutated)]
+                assert len(fsm_events) == 1
+                assert fsm_events[0].state == {"focus": "resume-audit"}
+
+        def with_dispatch_ordering():
+            async def it_records_fsm_before_the_resume_domain_event():
+                """Plan acceptance criterion 4(a): FSM lands in the audit log
+                before the resume's domain event, so reducers/observers see
+                client-state contributions first and the resume handler's
+                output reduces on top."""
+                from langgraph_events.agui import FrontendStateMutated
+
+                @on(UserAsked)
+                def ask(event: UserAsked) -> ApprovalRequested:
+                    return ApprovalRequested(draft="ok?")
+
+                @on(ApprovalGiven)
+                def finish(event: ApprovalGiven) -> AgentReplied:
+                    return AgentReplied(message=AIMessage(content="done"))
+
+                graph = EventGraph(
+                    [ask, finish],
+                    reducers=[message_reducer()],
+                    checkpointer=MemorySaver(),
+                )
+
+                thread_id = "thread-fsm-resume-order"
+                config = {"configurable": {"thread_id": thread_id}}
+                await graph.ainvoke(UserAsked(question="?"), config=config)
+
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="unused"),
+                    resume_factory=lambda inp: ApprovalGiven(approved=True),
+                )
+                await _collect(
+                    adapter,
+                    _make_input(
+                        thread_id=thread_id,
+                        state={"focus": "ordering"},
+                    ),
+                )
+
+                log = list(graph.get_state(config).events)
+                idx_fsm = next(
+                    i for i, e in enumerate(log) if isinstance(e, FrontendStateMutated)
+                )
+                idx_resume_event = next(
+                    i for i, e in enumerate(log) if isinstance(e, ApprovalGiven)
+                )
+                assert idx_fsm < idx_resume_event, (
+                    f"FSM must precede the resume domain event "
+                    f"(idx_fsm={idx_fsm}, idx_resume={idx_resume_event})"
+                )
 
     def when_mapping_to_agui_output():
         async def it_does_not_warn_about_missing_agui_dict():


### PR DESCRIPTION
## Summary

Port of [PR #56](https://github.com/cadance-io/langgraph-events/pull/56) (released as v0.4.2) to `main` for the upcoming v0.5.2.

Combines the leak fix, projection unification, resume-time `FrontendStateMutated` dispatch, and the C1 double-count fix that all shipped in v0.4.2 — adapted to main's event-taxonomy idioms (`IntegrationEvent`, `LGCommand` alias).

### What's in this port

- **Fixed:** `events` audit log no longer leaks into outbound state snapshots (O(history) wire bloat closed). Strip set derived from `_internal._BASE_FIELDS` — single source of truth.
- **Fixed:** Resume-time frontend state now flows through `FrontendStateMutated` instead of bypassing dispatch via `apre_seed(raw_state)`. The adapter computes per-reducer contributions, writes them via `apre_seed` *before* the resume's domain dispatch (preserving `fn` semantics — transformations, `SKIP`), and injects FSM as a seed to `astream_resume` for output-stream visibility.
- **Fixed:** C1 — accumulator-style reducers (`Reducer(reducer=operator.add)`) subscribed to FSM no longer double-count their contribution on resume. `_astream_v2` now skips the seed-merge when input is `Command(resume=...)` since the caller is responsible for pre-seeding via `apre_seed`.
- **Changed:** `EventGraph.{stream,astream}_resume` now accept `seeds: list[Event] | None = None` — power-user hook for resume-time companion events.
- **Changed:** `AGUIAdapter.__init__` validates `messages` reducer eagerly + raises `TypeError` for malformed `include_reducers` shapes.

### Adaptations from PR #56

- `FrontendStateMutated` correctly extends `IntegrationEvent` (was `Event` in 0.4.x — auto-merged from main).
- `astream_resume` body uses main's `_astream_entry` helper instead of the inline delegate-build pattern from 0.4.x.
- `_astream_v2`'s `is_resume` check uses `LGCommand` (main's alias) to avoid collision with the new event-taxonomy `Command` class.
- Test event class `FocusEcho` extends `IntegrationEvent` per main's strict taxonomy enforcement.
- CHANGELOG `[Unreleased]` entries dropped the downstream-specific bug reference.

### Known limitation (carried over from PR #56, documented in 3 places)

`@on(FrontendStateMutated)` *handlers* do not fire on resume — `Command(resume=...)` carries one value and seeds dispatch out-of-graph. Reducers DO fire (the contribution is materialized into channels via `apre_seed` before the resume step). Use `@on(Resumed)` for resume-time side effects.

## Test plan

- [x] `uv run pytest tests/` — 633 pass / 1 skip
- [x] `uv run mypy src/` — strict clean (25 source files)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] CI green
- [ ] Downstream smoke against this port (the v0.4.2 line is the canonical fix path; 0.5.x port is equivalent — no behavioral divergence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
