### PR TITLE
fix(serde): preserve namespace identity for Events nested in langgraph.types.Interrupt (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **serde**: `NamespaceAwareSerde` now preserves namespace identity for `Event` instances nested inside `langgraph.types.Interrupt` (the dataclass LangGraph wraps every interrupted value in before checkpointing). Previously, every namespaced `Interrupted`/`InterruptedWithPayload` subclass round-tripped through a checkpointer would silently decode back as `Interrupt(value=None, id=...)` because LangGraph's generic dataclass branch (`EXT_CONSTRUCTOR_KW_ARGS`) recurses into a hardcoded `_msgpack_default` and bypassed our namespace-aware `default=`. `Interrupt` is now intercepted directly under a dedicated ext code so the wrapped value re-enters our encoder. (#60)
+- **serde**: `NamespaceAwareSerde` now preserves namespace identity for `Event` instances nested inside `langgraph.types.Interrupt` (the dataclass LangGraph wraps every interrupted value in before checkpointing). Previously, every namespaced `Interrupted`/`InterruptedWithPayload` subclass round-tripped through a checkpointer would silently decode back as `Interrupt(value=None, id=...)` because LangGraph's generic dataclass branch (`EXT_CONSTRUCTOR_KW_ARGS`) recurses into a hardcoded `_msgpack_default` and bypassed our namespace-aware `default=`. `Interrupt` is now intercepted directly under a dedicated ext code so the wrapped value re-enters our encoder. Note: this fix applies to checkpoints written *after* the upgrade — checkpoints already persisted under v0.6.0 still decode their nested events as `None` (same risk profile as before). (#60)
 
 ## [0.6.0] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **serde**: `NamespaceAwareSerde` now preserves namespace identity for `Event` instances nested inside `langgraph.types.Interrupt` (the dataclass LangGraph wraps every interrupted value in before checkpointing). Previously, every namespaced `Interrupted`/`InterruptedWithPayload` subclass round-tripped through a checkpointer would silently decode back as `Interrupt(value=None, id=...)` because LangGraph's generic dataclass branch (`EXT_CONSTRUCTOR_KW_ARGS`) recurses into a hardcoded `_msgpack_default` and bypassed our namespace-aware `default=`. `Interrupt` is now intercepted directly under a dedicated ext code so the wrapped value re-enters our encoder. (#60)
+
 ## [0.6.0] - 2026-05-04
 
 ### Added

--- a/src/langgraph_events/serde/_jsonplus.py
+++ b/src/langgraph_events/serde/_jsonplus.py
@@ -71,6 +71,12 @@ def _default(obj: Any) -> Any:
         # upstream's dataclass branch handle it) is what keeps a nested
         # namespaced ``Interrupted`` subclass inside ``obj.value`` reachable
         # through our ``_default`` and revivable under EXT_NAMESPACE_AWARE_EVENT.
+        #
+        # Tracks (value, id) explicitly rather than walking
+        # ``dataclasses.fields(obj)`` — Interrupt has a custom ``__init__``
+        # that doesn't accept arbitrary kwargs, so a generic walk would not
+        # round-trip cleanly anyway. ``it_matches_the_schema_we_encode``
+        # in tests/test_serde.py guards against silent field drift.
         return ormsgpack.Ext(EXT_INTERRUPT, _encode((obj.value, obj.id)))
     return _msgpack_default(obj)
 

--- a/src/langgraph_events/serde/_jsonplus.py
+++ b/src/langgraph_events/serde/_jsonplus.py
@@ -20,6 +20,7 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 import ormsgpack
+from langgraph.types import Interrupt
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -42,6 +43,10 @@ except ImportError as exc:  # pragma: no cover - smoke fence on LangGraph drift
 
 # Unique among LangGraph's existing ext codes (currently 0..6).
 EXT_NAMESPACE_AWARE_EVENT = 100
+# Dedicated code so we can recurse via our own ``_default`` when re-encoding
+# the wrapped value — LangGraph's generic dataclass path uses ``_msgpack_enc``
+# which is hardcoded to ``default=_msgpack_default`` and would bypass us.
+EXT_INTERRUPT = 101
 
 
 def _encode(obj: Any) -> bytes:
@@ -60,6 +65,13 @@ def _default(obj: Any) -> Any:
                 ),
             ),
         )
+    if isinstance(obj, Interrupt):
+        # LangGraph wraps every interrupted value in this dataclass before
+        # checkpointing. Re-encoding via our ``_encode`` (rather than letting
+        # upstream's dataclass branch handle it) is what keeps a nested
+        # namespaced ``Interrupted`` subclass inside ``obj.value`` reachable
+        # through our ``_default`` and revivable under EXT_NAMESPACE_AWARE_EVENT.
+        return ormsgpack.Ext(EXT_INTERRUPT, _encode((obj.value, obj.id)))
     return _msgpack_default(obj)
 
 
@@ -72,6 +84,13 @@ def _make_ext_hook(errors: list[str]) -> Callable[[int, bytes], Any]:
     """
 
     def _ext_hook(code: int, data: bytes) -> Any:
+        if code == EXT_INTERRUPT:
+            # Inner unpack uses our hook so a nested EXT_NAMESPACE_AWARE_EVENT
+            # inside ``value`` resolves back to its namespaced class.
+            value, id_ = ormsgpack.unpackb(
+                data, ext_hook=_ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
+            )
+            return Interrupt(value=value, id=id_)
         if code != EXT_NAMESPACE_AWARE_EVENT:
             return _msgpack_ext_hook(code, data)
         tup = ormsgpack.unpackb(

--- a/src/langgraph_events/serde/_jsonplus.py
+++ b/src/langgraph_events/serde/_jsonplus.py
@@ -96,7 +96,22 @@ def _make_ext_hook(errors: list[str]) -> Callable[[int, bytes], Any]:
             value, id_ = ormsgpack.unpackb(
                 data, ext_hook=_ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
             )
-            return Interrupt(value=value, id=id_)
+            try:
+                return Interrupt(value=value, id=id_)
+            except TypeError as exc:
+                # Mirrors the EXT_NAMESPACE_AWARE_EVENT branch below: degrade
+                # gracefully through ``loads_typed``'s ``errors`` channel if
+                # ``Interrupt.__init__`` shape changes upstream (the static
+                # schema guard in tests/test_serde.py catches drift at test
+                # time, but this covers an unpinned-LangGraph runtime gap).
+                errors.append(
+                    f"Cannot revive langgraph.types.Interrupt(value=..., "
+                    f"id=...): {type(exc).__name__}: {exc}. The Interrupt "
+                    f"dataclass shape may have changed since the checkpoint "
+                    f"was written; update NamespaceAwareSerde to track the "
+                    f"new fields."
+                )
+                raise
         if code != EXT_NAMESPACE_AWARE_EVENT:
             return _msgpack_ext_hook(code, data)
         tup = ormsgpack.unpackb(

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -205,6 +205,34 @@ def describe_NamespaceAwareSerde():
                 assert not isinstance(back.value, Story.Approve.Approved)
                 assert back.value.note == "persona"
 
+        def when_a_checkpoint_carries_multiple_interrupts():
+            # LangGraph's runner emits a *tuple* of ``Interrupt``s on a
+            # checkpoint write (one per parallel branch / interrupt site).
+            # Single-Interrupt round-trip is covered above; this guards the
+            # actual emission shape so a regression that breaks tuple/list
+            # iteration through ``_default`` shows up here.
+            def it_preserves_each_nested_event_class_identity():
+                serde = NamespaceAwareSerde()
+                ivs = [
+                    Interrupt(value=Persona.Approve.Approved(note="x"), id="a"),
+                    Interrupt(value=Story.Approve.Approved(note="y"), id="b"),
+                ]
+
+                back = serde.loads_typed(serde.dumps_typed(ivs))
+
+                assert len(back) == 2
+                assert isinstance(back[0], Interrupt)
+                assert isinstance(back[1], Interrupt)
+                assert isinstance(back[0].value, Persona.Approve.Approved)
+                assert isinstance(back[1].value, Story.Approve.Approved)
+                # Sibling identity is not collapsed across either roundtrip.
+                assert not isinstance(back[0].value, Story.Approve.Approved)
+                assert not isinstance(back[1].value, Persona.Approve.Approved)
+                assert back[0].id == "a"
+                assert back[1].id == "b"
+                assert back[0].value.note == "x"
+                assert back[1].value.note == "y"
+
         def when_round_tripped_through_a_real_interrupt_flow():
             def with_MemorySaver_and_NamespaceAwareSerde():
                 # ``filterwarnings("error", ...)`` locks the warning fix in:

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -5,9 +5,20 @@ from __future__ import annotations
 import warnings
 
 import pytest
+from conftest import Started
 from langgraph.checkpoint.memory import MemorySaver
+from langgraph.types import Interrupt
 
-from langgraph_events import Command, DomainEvent, EventGraph, Namespace
+from langgraph_events import (
+    Command,
+    DomainEvent,
+    EventGraph,
+    IntegrationEvent,
+    Interrupted,
+    Namespace,
+    Resumed,
+    on,
+)
 from langgraph_events.serde import NamespaceAwareSerde
 
 
@@ -36,6 +47,21 @@ class Story(Namespace):
 
         def handle(self) -> Story.Approve.Approved:
             return Story.Approve.Approved(note=self.note)
+
+
+# Namespace whose nested ``Reviewed`` is an ``Interrupted`` subclass. This is
+# the shape that hits #60 — handlers return ``Review.Ask.Reviewed(...)`` and
+# LangGraph wraps it in ``langgraph.types.Interrupt(value=..., id=...)`` for
+# the checkpoint write.
+class Review(Namespace):
+    class Ask(Command):
+        draft: str = ""
+
+        class Reviewed(Interrupted):
+            draft: str = ""
+
+        def handle(self) -> Review.Ask.Reviewed:
+            return Review.Ask.Reviewed(draft=self.draft)
 
 
 def describe_NamespaceAwareSerde():
@@ -143,3 +169,71 @@ def describe_NamespaceAwareSerde():
                 # Sanity: helper module is importable (catches an obvious
                 # M4-style refactor regression).
                 assert _jsonplus.NamespaceAwareSerde is NamespaceAwareSerde
+
+    def describe_event_nested_in_langgraph_Interrupt():
+        # Regression for #60: every namespaced ``Interrupted`` subclass that
+        # LangGraph wraps in ``langgraph.types.Interrupt(value=..., id=...)``
+        # used to lose its identity through a checkpoint roundtrip — the
+        # nested Event was encoded by upstream's ``_msgpack_default`` (leaf
+        # ``__name__``) instead of our namespace-aware ext code, so the
+        # decode-time attribute walk failed and was silently swallowed,
+        # leaving ``Interrupt(value=None, id=...)``.
+        def when_interrupt_wraps_a_namespaced_event():
+            def it_preserves_the_nested_event_class_identity():
+                serde = NamespaceAwareSerde()
+                iv = Interrupt(
+                    value=Persona.Approve.Approved(note="persona"),
+                    id="abc123",
+                )
+
+                back = serde.loads_typed(serde.dumps_typed(iv))
+
+                assert isinstance(back, Interrupt)
+                assert back.id == "abc123"
+                assert back.value is not None  # the bug: this used to be None
+                assert isinstance(back.value, Persona.Approve.Approved)
+                # Sibling identity is not collapsed across the roundtrip.
+                assert not isinstance(back.value, Story.Approve.Approved)
+                assert back.value.note == "persona"
+
+        def when_round_tripped_through_a_real_interrupt_flow():
+            def with_MemorySaver_and_NamespaceAwareSerde():
+                def it_round_trips_a_namespaced_Interrupted_subclass():
+                    @on(Started)
+                    def ask(event: Started) -> Review.Ask.Reviewed:
+                        return Review.Ask.Reviewed(draft=event.data)
+
+                    class Approved(IntegrationEvent):
+                        pass
+
+                    @on(Resumed, interrupted=Review.Ask.Reviewed)
+                    def resume(
+                        event: Resumed, interrupted: Review.Ask.Reviewed
+                    ) -> Approved:
+                        # If the nested Event lost identity through the
+                        # checkpoint roundtrip, ``interrupted`` would be
+                        # revived as something other than ``Reviewed`` (or
+                        # ``None``) and this handler wouldn't match.
+                        assert isinstance(interrupted, Review.Ask.Reviewed)
+                        assert interrupted.draft == "hello"
+                        return Approved()
+
+                    graph = EventGraph(
+                        [ask, resume],
+                        checkpointer=MemorySaver(serde=NamespaceAwareSerde()),
+                    )
+                    config = {"configurable": {"thread_id": "review"}}
+                    graph.invoke(Started(data="hello"), config=config)
+
+                    state = graph.get_state(config)
+                    assert state.is_interrupted
+
+                    # The resume handler's own assertions verify that the
+                    # round-tripped ``interrupted`` value retained its
+                    # namespaced ``Review.Ask.Reviewed`` identity (and its
+                    # ``draft`` field). Before the fix, ``Interrupt.value``
+                    # decoded back as ``None``, the field-matcher had nothing
+                    # to inject, the handler never fired, and ``Approved``
+                    # never appeared in the log.
+                    log = graph.resume(Approved(), config=config)
+                    assert log.latest(Approved) == Approved()

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import warnings
 
 import pytest
@@ -62,6 +63,14 @@ class Review(Namespace):
 
         def handle(self) -> Review.Ask.Reviewed:
             return Review.Ask.Reviewed(draft=self.draft)
+
+
+# Module-level so the ``resume`` handler's return annotation is resolvable by
+# ``typing.get_type_hints`` against the module globals. Defining it inside the
+# test function would trigger an "unresolved type hints" warning at handler
+# registration.
+class ReviewApproved(IntegrationEvent):
+    pass
 
 
 def describe_NamespaceAwareSerde():
@@ -198,25 +207,31 @@ def describe_NamespaceAwareSerde():
 
         def when_round_tripped_through_a_real_interrupt_flow():
             def with_MemorySaver_and_NamespaceAwareSerde():
+                # ``filterwarnings("error", ...)`` locks the warning fix in:
+                # if a future change demotes ``ReviewApproved`` back to a
+                # local class, this test fails instead of silently emitting
+                # the "Failed to resolve type hints" UserWarning.
+                @pytest.mark.filterwarnings(
+                    r"error:Failed to resolve.*type hints.*:UserWarning"
+                )
                 def it_round_trips_a_namespaced_Interrupted_subclass():
                     @on(Started)
                     def ask(event: Started) -> Review.Ask.Reviewed:
                         return Review.Ask.Reviewed(draft=event.data)
 
-                    class Approved(IntegrationEvent):
-                        pass
-
                     @on(Resumed, interrupted=Review.Ask.Reviewed)
                     def resume(
                         event: Resumed, interrupted: Review.Ask.Reviewed
-                    ) -> Approved:
-                        # If the nested Event lost identity through the
-                        # checkpoint roundtrip, ``interrupted`` would be
-                        # revived as something other than ``Reviewed`` (or
-                        # ``None``) and this handler wouldn't match.
+                    ) -> ReviewApproved:
+                        # The field-matcher only dispatches here if the
+                        # round-tripped ``interrupted`` is a
+                        # ``Review.Ask.Reviewed``. Before the fix it was
+                        # ``None`` (Interrupt.value lost), the handler never
+                        # fired, and ``ReviewApproved`` never appeared in
+                        # the log.
                         assert isinstance(interrupted, Review.Ask.Reviewed)
                         assert interrupted.draft == "hello"
-                        return Approved()
+                        return ReviewApproved()
 
                     graph = EventGraph(
                         [ask, resume],
@@ -228,12 +243,21 @@ def describe_NamespaceAwareSerde():
                     state = graph.get_state(config)
                     assert state.is_interrupted
 
-                    # The resume handler's own assertions verify that the
-                    # round-tripped ``interrupted`` value retained its
-                    # namespaced ``Review.Ask.Reviewed`` identity (and its
-                    # ``draft`` field). Before the fix, ``Interrupt.value``
-                    # decoded back as ``None``, the field-matcher had nothing
-                    # to inject, the handler never fired, and ``Approved``
-                    # never appeared in the log.
-                    log = graph.resume(Approved(), config=config)
-                    assert log.latest(Approved) == Approved()
+                    log = graph.resume(ReviewApproved(), config=config)
+                    assert log.latest(ReviewApproved) == ReviewApproved()
+
+        def describe_Interrupt_schema_guard():
+            # ``_default``/``_ext_hook`` track ``Interrupt`` by its two known
+            # fields (``value``, ``id``). If LangGraph ever adds another
+            # field, our hardcoded reconstruction would silently drop it on
+            # round-trip — this guard surfaces that drift loudly so the
+            # serde gets updated alongside the LangGraph bump.
+            def it_matches_the_schema_we_encode():
+                fields = {f.name for f in dataclasses.fields(Interrupt)}
+                assert fields == {"value", "id"}, (
+                    f"langgraph.types.Interrupt fields drifted from "
+                    f"{{'value', 'id'}} to {fields}. NamespaceAwareSerde "
+                    f"hardcodes (value, id) in _jsonplus.py — extend "
+                    f"_default and the EXT_INTERRUPT branch of _ext_hook "
+                    f"to cover the new field(s)."
+                )


### PR DESCRIPTION
## Summary

Fixes #60. `NamespaceAwareSerde` round-tripped top-level `Event` instances correctly but silently corrupted Events reached transitively through a non-Event dataclass field — most notably `langgraph.types.Interrupt(value=<our Event>, id=...)`, which LangGraph wraps every interrupted value in before checkpointing. End-user symptom: every namespaced `Interrupted`/`InterruptedWithPayload` subclass decoded back as `Interrupt(value=None, id=...)`.

### Root cause

When our `_default` fell through to LangGraph's `_msgpack_default` for the `Interrupt` dataclass, the recursive `_msgpack_enc(...)` call inside upstream's `EXT_CONSTRUCTOR_KW_ARGS` branch is hardcoded to `default=_msgpack_default` (`langgraph/checkpoint/serde/jsonplus.py:649-650`), so our namespace-aware `default=` was bypassed for the nested Event. It then encoded by leaf `__name__`, the decode-time attribute walk in `_msgpack_ext_hook` couldn't resolve the namespaced class, and LangGraph's blanket `except Exception: return` (`jsonplus.py:475`) swallowed the `AttributeError` — yielding `Interrupt(value=None, ...)`.

### Fix (narrow)

Intercept `langgraph.types.Interrupt` directly in our `_default` under a dedicated ext code (`EXT_INTERRUPT = 101`), re-encoding the wrapped value through our own `_encode` so the nested Event re-enters our `default` and gets ext code 100 with `__qualname__`. Symmetric branch in `_ext_hook` decodes it back. No other dataclass paths are touched — the same template can be applied later if other wrappers (e.g. `Send`, Pydantic) surface as failure cases.

### Files

- `src/langgraph_events/serde/_jsonplus.py` — `Interrupt` import, `EXT_INTERRUPT = 101`, branch in `_default`, branch in `_ext_hook`.
- `tests/test_serde.py` — new `Review` namespace with a nested `Interrupted` subclass + two regression tests:
  1. unit-level `Interrupt(value=<namespaced Event>)` round-trip through `dumps_typed`/`loads_typed`,
  2. full `MemorySaver(serde=NamespaceAwareSerde())` interrupt/resume flow that field-injects the round-tripped `interrupted` value into a resume handler.
  Both fail without the fix and pass with it. Closes the gap noted in the issue: PR #59 didn't checkpoint-roundtrip a namespaced `Interrupted` subclass through a real `MemorySaver`.
- `CHANGELOG.md` — `[Unreleased] / Fixed` entry referencing #60.

## Test plan

- [x] `uv run pytest tests/test_serde.py -v` — 6 passed (including 2 new regression tests).
- [x] `uv run pytest tests/` — 664 passed, 1 skipped.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run ruff format --check src/ tests/` — clean.
- [x] `uv run mypy src/` — clean.
- [x] Confirmed both new tests fail without the fix with `Interrupt(value=None, ...)` (the exact symptom from the issue), and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)