### PR TITLE
feat(agui): ResumeFactory helpers — agui_messages_to_langchain, merge_frontend_messages, extract_resume_input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **agui**: `agui_messages_to_langchain(messages, *, drop_invalid_tool_calls=False) -> list[BaseMessage]` — public helper at `langgraph_events.agui` for converting AG-UI protocol messages to LangChain `BaseMessage` instances. Mirrors the existing internal LangChain→AG-UI direction. Handles `UserMessage` (string and multimodal content with the `url > data > id` priority cascade), `AssistantMessage` (with optional `tool_calls`, parsing `function.arguments` JSON), `SystemMessage`, and `ToolMessage`. `ReasoningMessage` and `DeveloperMessage` are skipped with a DEBUG log; `ActivityMessage` and unknown roles raise `ValueError`. With `drop_invalid_tool_calls=True`, tool calls whose `function.arguments` fail to JSON-parse are dropped (WARNING-logged); if all of an `AssistantMessage`'s tool calls are dropped, the message itself is dropped. Removes the need to depend on `ag-ui-langgraph` for this utility.
+- **agui**: `merge_frontend_messages(input_data, checkpoint_state, *, reducer_name="messages", drop_invalid_tool_calls=True) -> tuple[BaseMessage, ...]` — high-level helper for `ResumeFactory` implementations. Reads existing messages from `checkpoint_state["reducers"][reducer_name]`, converts `input_data.messages` via `agui_messages_to_langchain`, and merges via langgraph's `add_messages` (id-based dedup). Defensive default for malformed tool-call JSON; pass `drop_invalid_tool_calls=False` for strict parity with upstream.
+- **agui**: `extract_resume_input(input_data) -> Any` — pulls resume input from `RunAgentInput.forwarded_props["command"]["resume"]`. If the value is a string, attempts `json.loads` (returns the decoded JSON value — dict, list, scalar — on success; the raw string on `JSONDecodeError`). Dicts/lists/numbers pass through unchanged. Returns `None` if absent or falsy.
+
 ## [0.7.0] - 2026-05-05
 
 ### Added

--- a/docs/agui.md
+++ b/docs/agui.md
@@ -325,14 +325,21 @@ Streaming-path errors propagate through the adapter's top-level handler and surf
 
 - **`extract_resume_input(input_data)`** — pulls `RunAgentInput.forwarded_props["command"]["resume"]`. If the value is a JSON string it's decoded; otherwise it passes through. Returns `None` if absent or falsy.
 - **`agui_messages_to_langchain(messages, *, drop_invalid_tool_calls=False)`** — converts a list of AG-UI protocol messages (`UserMessage`, `AssistantMessage`, `SystemMessage`, `ToolMessage` — multimodal `UserMessage` content included) to LangChain `BaseMessage` instances. `ReasoningMessage` and `DeveloperMessage` are skipped (DEBUG log); `ActivityMessage` and unknown roles raise `ValueError`. With `drop_invalid_tool_calls=True`, tool calls whose JSON `arguments` fail to parse are dropped (WARNING-logged); if every tool call on an `AssistantMessage` is dropped, the message itself is dropped.
-- **`merge_frontend_messages(input_data, checkpoint_state, *, reducer_name="messages", drop_invalid_tool_calls=True)`** — the high-level helper. Reads existing messages from `checkpoint_state["reducers"][reducer_name]`, converts `input_data.messages` via `agui_messages_to_langchain`, and merges via langgraph's `add_messages` (id-based dedup). Returns a tuple — the immutable shape resume events typically carry.
+- **`merge_frontend_messages(input_data, checkpoint_state, *, reducer_name="messages", drop_invalid_tool_calls=True)`** — the high-level helper. Reads existing messages from `checkpoint_state["reducers"][reducer_name]`, converts `input_data.messages` via `agui_messages_to_langchain`, and merges via langgraph's `add_messages` (id-based dedup; messages without ids get a UUID assigned by the merge — don't rely on positional identity downstream). Returns a tuple — the immutable shape resume events typically carry.
 
 ```python
+from langgraph_events import Event, MessageEvent
 from langgraph_events.agui import (
     detect_new_tool_results,
     extract_resume_input,
     merge_frontend_messages,
 )
+
+
+# Domain-specific resume event — define alongside your other events.
+class UserResumed(Event, MessageEvent):
+    response: object  # resume payload (dict, str, …); your shape
+    messages: tuple = ()
 
 
 def resume_factory(input_data, checkpoint_state=None):
@@ -348,6 +355,8 @@ def resume_factory(input_data, checkpoint_state=None):
     merged = merge_frontend_messages(input_data, checkpoint_state)
     return UserResumed(response=resume_input, messages=merged)
 ```
+
+`extract_resume_input` returns `None` for absent **or falsy** `resume` values (matches the convention shipped by downstream consumers — `0`, `""`, `[]`, `{}`, `False` all collapse to `None`). If your HITL flow uses `False` as a meaningful "deny" signal, normalise it on the frontend side (e.g. send `{"approved": false}` instead of bare `false`).
 
 Use the lower-level `agui_messages_to_langchain` directly when you need converted messages outside the `merge_frontend_messages` orchestration — e.g. inside a `seed_factory` that builds events from the most recent inbound `UserMessage`.
 

--- a/docs/agui.md
+++ b/docs/agui.md
@@ -319,6 +319,38 @@ def ship(event: UserConfirmed) -> ShippedRelease:
 
 Streaming-path errors propagate through the adapter's top-level handler and surface to the frontend as a `RUN_ERROR` event with the diagnostic message. Conformant CopilotKit clients and LangChain chat models satisfy these invariants by default.
 
+## Resume Helpers
+
+`detect_new_tool_results` covers the *frontend-tool-result* arm of resume. The other arm — when the frontend sends a `Command(resume=…)` plus new chat messages (e.g. answering a typed `Interrupted` payload) — has three small helpers that collapse the boilerplate every consumer would otherwise write inside `resume_factory`:
+
+- **`extract_resume_input(input_data)`** — pulls `RunAgentInput.forwarded_props["command"]["resume"]`. If the value is a JSON string it's decoded; otherwise it passes through. Returns `None` if absent or falsy.
+- **`agui_messages_to_langchain(messages, *, drop_invalid_tool_calls=False)`** — converts a list of AG-UI protocol messages (`UserMessage`, `AssistantMessage`, `SystemMessage`, `ToolMessage` — multimodal `UserMessage` content included) to LangChain `BaseMessage` instances. `ReasoningMessage` and `DeveloperMessage` are skipped (DEBUG log); `ActivityMessage` and unknown roles raise `ValueError`. With `drop_invalid_tool_calls=True`, tool calls whose JSON `arguments` fail to parse are dropped (WARNING-logged); if every tool call on an `AssistantMessage` is dropped, the message itself is dropped.
+- **`merge_frontend_messages(input_data, checkpoint_state, *, reducer_name="messages", drop_invalid_tool_calls=True)`** — the high-level helper. Reads existing messages from `checkpoint_state["reducers"][reducer_name]`, converts `input_data.messages` via `agui_messages_to_langchain`, and merges via langgraph's `add_messages` (id-based dedup). Returns a tuple — the immutable shape resume events typically carry.
+
+```python
+from langgraph_events.agui import (
+    detect_new_tool_results,
+    extract_resume_input,
+    merge_frontend_messages,
+)
+
+
+def resume_factory(input_data, checkpoint_state=None):
+    # 1. Frontend tool result path (covered above)
+    tool_results = detect_new_tool_results(input_data, checkpoint_state)
+    if tool_results:
+        return ToolsExecuted(messages=tuple(tool_results))
+
+    # 2. Command(resume=…) + new chat messages path
+    resume_input = extract_resume_input(input_data)
+    if resume_input is None:
+        return None
+    merged = merge_frontend_messages(input_data, checkpoint_state)
+    return UserResumed(response=resume_input, messages=merged)
+```
+
+Use the lower-level `agui_messages_to_langchain` directly when you need converted messages outside the `merge_frontend_messages` orchestration — e.g. inside a `seed_factory` that builds events from the most recent inbound `UserMessage`.
+
 ## Typed Interrupt Payloads
 
 For HITL flows whose frontend needs an action-discriminated dict (entity-review vs environment-select vs walkthrough-choice, …), subclass `InterruptedWithPayload[PayloadT]` and implement `interrupt_payload(self) -> PayloadT`. The built-in `InterruptedMapper` recognises the contract and emits the payload as `CustomEvent(name="interrupted", value=...)` — no `agui_dict()` override needed.

--- a/src/langgraph_events/agui/__init__.py
+++ b/src/langgraph_events/agui/__init__.py
@@ -20,6 +20,11 @@ from langgraph_events.agui._protocols import (
     ResumeFactory,
     SeedFactory,
 )
+from langgraph_events.agui._resume import (
+    agui_messages_to_langchain,
+    extract_resume_input,
+    merge_frontend_messages,
+)
 from langgraph_events.agui._tools import (
     build_langchain_tools,
     detect_new_tool_results,
@@ -44,8 +49,11 @@ __all__ = [
     "ResumeFactory",
     "SeedFactory",
     "SkipInternalMapper",
+    "agui_messages_to_langchain",
     "build_langchain_tools",
     "create_starlette_response",
     "detect_new_tool_results",
     "encode_sse_stream",
+    "extract_resume_input",
+    "merge_frontend_messages",
 ]

--- a/src/langgraph_events/agui/_resume.py
+++ b/src/langgraph_events/agui/_resume.py
@@ -151,6 +151,8 @@ def merge_frontend_messages(
         input_data.messages or [],
         drop_invalid_tool_calls=drop_invalid_tool_calls,
     )
+    # langgraph's add_messages signature accepts dict/tuple/str shapes for
+    # checkpoint-stored messages; our inputs and output are always BaseMessage.
     merged: list[BaseMessage] = add_messages(existing, new)  # type: ignore[arg-type,assignment]
     return tuple(merged)
 

--- a/src/langgraph_events/agui/_resume.py
+++ b/src/langgraph_events/agui/_resume.py
@@ -1,0 +1,170 @@
+"""Helpers for AG-UI ResumeFactory implementations.
+
+Bridges AG-UI ``RunAgentInput`` shapes into LangChain/langgraph state suitable
+for resume events. All public helpers here are pure functions — no I/O, no
+global state.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ag_ui.core import Message
+    from ag_ui.core.types import RunAgentInput
+    from langchain_core.messages import BaseMessage
+    from langchain_core.messages.tool_call import ToolCall as LCToolCall
+
+logger = logging.getLogger(__name__)
+
+
+def agui_messages_to_langchain(  # noqa: PLR0912
+    messages: list[Message],
+    *,
+    drop_invalid_tool_calls: bool = False,
+) -> list[BaseMessage]:
+    """Convert AG-UI protocol messages to LangChain ``BaseMessage`` instances.
+
+    Reasoning and developer messages are skipped (logged at DEBUG); activity
+    and unknown roles raise ``ValueError``.
+
+    With ``drop_invalid_tool_calls=True``, ``AssistantMessage`` tool_calls
+    whose ``function.arguments`` fail ``json.loads`` are dropped (with a
+    WARNING). If all tool_calls in a message are invalid, the message itself
+    is dropped. The default ``False`` propagates ``json.JSONDecodeError`` —
+    matches upstream ``ag-ui-langgraph``.
+    """
+    from ag_ui.core import AssistantMessage, UserMessage  # noqa: PLC0415
+    from ag_ui.core import SystemMessage as AGUISystemMessage  # noqa: PLC0415
+    from ag_ui.core import ToolMessage as AGUIToolMessage  # noqa: PLC0415
+    from ag_ui.core.types import (  # noqa: PLC0415
+        BinaryInputContent,
+        TextInputContent,
+    )
+    from langchain_core.messages import (  # noqa: PLC0415
+        AIMessage,
+        HumanMessage,
+        SystemMessage,
+        ToolMessage,
+    )
+
+    out: list[BaseMessage] = []
+    for m in messages:
+        if isinstance(m, UserMessage):
+            content: str | list[str | dict[Any, Any]]
+            if isinstance(m.content, list):
+                parts: list[str | dict[Any, Any]] = []
+                for p in m.content:
+                    if isinstance(p, TextInputContent):
+                        parts.append({"type": "text", "text": p.text})
+                    elif isinstance(p, BinaryInputContent):
+                        url = p.url or (
+                            f"data:{p.mime_type};base64,{p.data}" if p.data else p.id
+                        )
+                        parts.append({"type": "image_url", "image_url": {"url": url}})
+                content = parts
+            else:
+                content = m.content
+            out.append(HumanMessage(id=m.id, content=content, name=m.name))
+        elif isinstance(m, AssistantMessage):
+            tool_calls: list[LCToolCall] = []
+            for tc in m.tool_calls or []:
+                raw = tc.function.arguments
+                if not raw:
+                    args: Any = {}
+                else:
+                    try:
+                        args = json.loads(raw)
+                    except json.JSONDecodeError:
+                        if drop_invalid_tool_calls:
+                            logger.warning(
+                                "Dropping AG-UI tool_call %s — unparseable arguments",
+                                tc.id,
+                            )
+                            continue
+                        raise
+                tool_calls.append(
+                    {
+                        "id": tc.id,
+                        "name": tc.function.name,
+                        "args": args,
+                        "type": "tool_call",
+                    }
+                )
+            if drop_invalid_tool_calls and m.tool_calls and not tool_calls:
+                logger.warning(
+                    "Dropping AG-UI assistant message %s — all tool_calls invalid",
+                    m.id,
+                )
+                continue
+            out.append(
+                AIMessage(
+                    id=m.id,
+                    content=m.content or "",
+                    tool_calls=tool_calls,
+                    name=m.name,
+                )
+            )
+        elif isinstance(m, AGUISystemMessage):
+            out.append(SystemMessage(id=m.id, content=m.content, name=m.name))
+        elif isinstance(m, AGUIToolMessage):
+            out.append(
+                ToolMessage(id=m.id, content=m.content, tool_call_id=m.tool_call_id)
+            )
+        elif m.role in ("reasoning", "developer"):
+            logger.debug("Skipping AG-UI %s message %s", m.role, m.id)
+        else:
+            raise ValueError(f"Unsupported message role: {m.role}")
+    return out
+
+
+def merge_frontend_messages(
+    input_data: RunAgentInput,
+    checkpoint_state: dict[str, Any] | None,
+    *,
+    reducer_name: str = "messages",
+    drop_invalid_tool_calls: bool = True,
+) -> tuple[BaseMessage, ...]:
+    """Merge frontend AG-UI messages into the existing reducer message list.
+
+    Reads existing messages from
+    ``checkpoint_state["reducers"][reducer_name]`` (empty if missing or
+    ``None``), converts ``input_data.messages`` via
+    :func:`agui_messages_to_langchain`, and merges via langgraph's
+    ``add_messages`` (id-based dedup).
+
+    Defensive default: malformed tool-call JSON is dropped (with a WARNING).
+    Pass ``drop_invalid_tool_calls=False`` for strict parity with upstream.
+    """
+    from langgraph.graph.message import add_messages  # noqa: PLC0415
+
+    reducers = (checkpoint_state or {}).get("reducers") or {}
+    existing = list(reducers.get(reducer_name) or [])
+    new = agui_messages_to_langchain(
+        input_data.messages or [],
+        drop_invalid_tool_calls=drop_invalid_tool_calls,
+    )
+    merged: list[BaseMessage] = add_messages(existing, new)  # type: ignore[arg-type,assignment]
+    return tuple(merged)
+
+
+def extract_resume_input(input_data: RunAgentInput) -> Any:
+    """Pull resume input from ``RunAgentInput.forwarded_props.command.resume``.
+
+    If the value is a string, attempts ``json.loads`` (returns the decoded
+    JSON value on success; the raw string on ``JSONDecodeError``). Dicts,
+    lists, and numbers pass through unchanged. Returns ``None`` if absent or
+    falsy.
+    """
+    forwarded = input_data.forwarded_props or {}
+    resume = (forwarded.get("command") or {}).get("resume")
+    if not resume:
+        return None
+    if isinstance(resume, str):
+        try:
+            return json.loads(resume)
+        except json.JSONDecodeError:
+            return resume
+    return resume

--- a/src/langgraph_events/agui/_resume.py
+++ b/src/langgraph_events/agui/_resume.py
@@ -30,11 +30,12 @@ def agui_messages_to_langchain(  # noqa: PLR0912
     Reasoning and developer messages are skipped (logged at DEBUG); activity
     and unknown roles raise ``ValueError``.
 
-    With ``drop_invalid_tool_calls=True``, ``AssistantMessage`` tool_calls
-    whose ``function.arguments`` fail ``json.loads`` are dropped (with a
-    WARNING). If all tool_calls in a message are invalid, the message itself
-    is dropped. The default ``False`` propagates ``json.JSONDecodeError`` —
-    matches upstream ``ag-ui-langgraph``.
+    The default ``drop_invalid_tool_calls=False`` propagates
+    ``json.JSONDecodeError`` for parity with upstream ``ag-ui-langgraph`` —
+    drop-in replacement for migrators. Set ``True`` for production resume
+    factories that need resilience: ``AssistantMessage`` tool_calls whose
+    ``function.arguments`` fail ``json.loads`` are dropped (WARNING-logged);
+    if all tool_calls in a message are invalid, the message itself is dropped.
     """
     from ag_ui.core import AssistantMessage, UserMessage  # noqa: PLC0415
     from ag_ui.core import SystemMessage as AGUISystemMessage  # noqa: PLC0415
@@ -113,10 +114,14 @@ def agui_messages_to_langchain(  # noqa: PLR0912
             out.append(
                 ToolMessage(id=m.id, content=m.content, tool_call_id=m.tool_call_id)
             )
-        elif m.role in ("reasoning", "developer"):
-            logger.debug("Skipping AG-UI %s message %s", m.role, m.id)
         else:
-            raise ValueError(f"Unsupported message role: {m.role}")
+            role = getattr(m, "role", type(m).__name__)
+            if role in ("reasoning", "developer"):
+                logger.debug(
+                    "Skipping AG-UI %s message %s", role, getattr(m, "id", "?")
+                )
+            else:
+                raise ValueError(f"Unsupported message role: {role}")
     return out
 
 

--- a/tests/test_agui_resume.py
+++ b/tests/test_agui_resume.py
@@ -1,0 +1,527 @@
+"""Tests for AG-UI ResumeFactory helpers in `langgraph_events.agui`."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from ag_ui.core.types import (
+    ActivityMessage,
+    AssistantMessage,
+    BinaryInputContent,
+    DeveloperMessage,
+    FunctionCall,
+    ReasoningMessage,
+    RunAgentInput,
+    TextInputContent,
+    ToolCall,
+    UserMessage,
+)
+from ag_ui.core.types import SystemMessage as AGUISystemMessage
+from ag_ui.core.types import ToolMessage as AGUIToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from langgraph_events.agui import (
+    agui_messages_to_langchain,
+    extract_resume_input,
+    merge_frontend_messages,
+)
+
+
+def make_run_agent_input(
+    *,
+    messages: list[Any] | None = None,
+    forwarded_props: Any = None,
+) -> RunAgentInput:
+    return RunAgentInput(
+        thread_id="t",
+        run_id="r",
+        state={},
+        messages=messages or [],
+        tools=[],
+        context=[],
+        forwarded_props=forwarded_props if forwarded_props is not None else {},
+    )
+
+
+def describe_agui_messages_to_langchain():
+    def when_message_is_user():
+        def when_content_is_string():
+            def it_returns_a_human_message():
+                msg = UserMessage(id="u1", content="hello")
+                result = agui_messages_to_langchain([msg])
+                assert len(result) == 1
+                assert isinstance(result[0], HumanMessage)
+
+            def it_preserves_id():
+                msg = UserMessage(id="u1", content="hello")
+                assert agui_messages_to_langchain([msg])[0].id == "u1"
+
+            def it_preserves_content():
+                msg = UserMessage(id="u1", content="hello")
+                assert agui_messages_to_langchain([msg])[0].content == "hello"
+
+            def it_preserves_name():
+                msg = UserMessage(id="u1", content="hello", name="alice")
+                assert agui_messages_to_langchain([msg])[0].name == "alice"
+
+        def when_content_is_a_multimodal_list():
+            def when_part_is_text():
+                def it_emits_a_text_part_dict():
+                    msg = UserMessage(
+                        id="u1",
+                        content=[TextInputContent(text="hi there")],
+                    )
+                    [out] = agui_messages_to_langchain([msg])
+                    assert out.content == [{"type": "text", "text": "hi there"}]
+
+            def when_part_is_binary():
+                def with_url():
+                    def it_uses_url_as_image_url():
+                        msg = UserMessage(
+                            id="u1",
+                            content=[
+                                BinaryInputContent(
+                                    mime_type="image/png", url="https://x/y.png"
+                                )
+                            ],
+                        )
+                        [out] = agui_messages_to_langchain([msg])
+                        assert out.content == [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": "https://x/y.png"},
+                            }
+                        ]
+
+                def with_data_only():
+                    def it_builds_data_uri_using_mime_type():
+                        msg = UserMessage(
+                            id="u1",
+                            content=[
+                                BinaryInputContent(mime_type="image/png", data="AAA=")
+                            ],
+                        )
+                        [out] = agui_messages_to_langchain([msg])
+                        assert out.content == [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": "data:image/png;base64,AAA="},
+                            }
+                        ]
+
+                def with_id_only():
+                    def it_uses_id_as_image_url():
+                        msg = UserMessage(
+                            id="u1",
+                            content=[
+                                BinaryInputContent(mime_type="image/png", id="ref-42")
+                            ],
+                        )
+                        [out] = agui_messages_to_langchain([msg])
+                        assert out.content == [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": "ref-42"},
+                            }
+                        ]
+
+                def with_url_and_data():
+                    def it_prefers_url_over_data():
+                        msg = UserMessage(
+                            id="u1",
+                            content=[
+                                BinaryInputContent(
+                                    mime_type="image/png",
+                                    url="https://x/y.png",
+                                    data="AAA=",
+                                )
+                            ],
+                        )
+                        [out] = agui_messages_to_langchain([msg])
+                        assert out.content[0]["image_url"]["url"] == "https://x/y.png"
+
+    def when_message_is_assistant():
+        def when_content_is_none_and_no_tool_calls():
+            def it_returns_an_ai_message():
+                msg = AssistantMessage(id="a1", content=None)
+                [out] = agui_messages_to_langchain([msg])
+                assert isinstance(out, AIMessage)
+
+            def it_emits_empty_string_content():
+                msg = AssistantMessage(id="a1", content=None)
+                [out] = agui_messages_to_langchain([msg])
+                assert out.content == ""
+
+        def when_content_is_a_string_and_no_tool_calls():
+            def it_passes_content_through():
+                msg = AssistantMessage(id="a1", content="reply")
+                [out] = agui_messages_to_langchain([msg])
+                assert out.content == "reply"
+
+            def it_preserves_id_and_name():
+                msg = AssistantMessage(id="a1", content="r", name="bot")
+                [out] = agui_messages_to_langchain([msg])
+                assert out.id == "a1"
+                assert out.name == "bot"
+
+        def when_message_has_tool_calls():
+            def it_parses_arguments_json_into_args_dict():
+                msg = AssistantMessage(
+                    id="a1",
+                    content=None,
+                    tool_calls=[
+                        ToolCall(
+                            id="tc1",
+                            function=FunctionCall(
+                                name="search",
+                                arguments='{"q": "hello"}',
+                            ),
+                        )
+                    ],
+                )
+                [out] = agui_messages_to_langchain([msg])
+                assert out.tool_calls == [
+                    {
+                        "id": "tc1",
+                        "name": "search",
+                        "args": {"q": "hello"},
+                        "type": "tool_call",
+                    }
+                ]
+
+            def when_arguments_string_is_empty():
+                def it_defaults_args_to_empty_dict():
+                    msg = AssistantMessage(
+                        id="a1",
+                        content=None,
+                        tool_calls=[
+                            ToolCall(
+                                id="tc1",
+                                function=FunctionCall(name="ping", arguments=""),
+                            )
+                        ],
+                    )
+                    [out] = agui_messages_to_langchain([msg])
+                    assert out.tool_calls[0]["args"] == {}
+
+    def when_message_is_system():
+        def it_returns_a_langchain_system_message():
+            msg = AGUISystemMessage(id="s1", content="be helpful")
+            [out] = agui_messages_to_langchain([msg])
+            assert isinstance(out, SystemMessage)
+            assert out.id == "s1"
+            assert out.content == "be helpful"
+
+        def it_preserves_name():
+            msg = AGUISystemMessage(id="s1", content="x", name="root")
+            [out] = agui_messages_to_langchain([msg])
+            assert out.name == "root"
+
+    def when_message_is_tool():
+        def it_returns_a_langchain_tool_message():
+            msg = AGUIToolMessage(id="tm1", content="42", tool_call_id="tc1")
+            [out] = agui_messages_to_langchain([msg])
+            assert isinstance(out, ToolMessage)
+            assert out.id == "tm1"
+            assert out.content == "42"
+            assert out.tool_call_id == "tc1"
+
+        def it_does_not_propagate_error_field():
+            msg = AGUIToolMessage(
+                id="tm1", content="42", tool_call_id="tc1", error="boom"
+            )
+            [out] = agui_messages_to_langchain([msg])
+            assert getattr(out, "status", None) != "error"
+
+    def when_role_is_reasoning():
+        def it_skips_silently():
+            msg = ReasoningMessage(id="r1", content="thinking")
+            assert agui_messages_to_langchain([msg]) == []
+
+        def it_logs_at_debug_naming_the_role(caplog):
+            import logging
+
+            caplog.set_level(logging.DEBUG, logger="langgraph_events.agui._resume")
+            msg = ReasoningMessage(id="r1", content="thinking")
+            agui_messages_to_langchain([msg])
+            assert any("reasoning" in r.message for r in caplog.records)
+
+    def when_role_is_developer():
+        def it_skips_silently():
+            msg = DeveloperMessage(id="d1", content="hint")
+            assert agui_messages_to_langchain([msg]) == []
+
+        def it_logs_at_debug_naming_the_role(caplog):
+            import logging
+
+            caplog.set_level(logging.DEBUG, logger="langgraph_events.agui._resume")
+            msg = DeveloperMessage(id="d1", content="hint")
+            agui_messages_to_langchain([msg])
+            assert any("developer" in r.message for r in caplog.records)
+
+    def when_role_is_activity():
+        def it_raises_value_error_naming_the_role():
+            msg = ActivityMessage(id="x1", activity_type="typing", content={})
+            with pytest.raises(ValueError, match="activity"):
+                agui_messages_to_langchain([msg])
+
+    def when_role_is_unknown():
+        def it_raises_value_error_naming_the_role():
+            class Foreign:
+                role = "alien"
+                id = "z1"
+
+            with pytest.raises(ValueError, match="alien"):
+                agui_messages_to_langchain([Foreign()])  # type: ignore[list-item]
+
+    def when_message_list_is_empty():
+        def it_returns_empty_list():
+            assert agui_messages_to_langchain([]) == []
+
+    def when_messages_are_mixed():
+        def it_preserves_order_skipping_reasoning_in_place():
+            user = UserMessage(id="u1", content="hi")
+            reasoning = ReasoningMessage(id="r1", content="...")
+            assistant = AssistantMessage(id="a1", content="ok")
+            out = agui_messages_to_langchain([user, reasoning, assistant])
+            assert [m.id for m in out] == ["u1", "a1"]
+            assert isinstance(out[0], HumanMessage)
+            assert isinstance(out[1], AIMessage)
+
+    def when_drop_invalid_tool_calls_is_false_by_default():
+        def when_arguments_are_malformed():
+            def it_propagates_json_decode_error():
+                msg = AssistantMessage(
+                    id="a1",
+                    content=None,
+                    tool_calls=[
+                        ToolCall(
+                            id="tc1",
+                            function=FunctionCall(name="f", arguments="not json"),
+                        )
+                    ],
+                )
+                with pytest.raises(json.JSONDecodeError):
+                    agui_messages_to_langchain([msg])
+
+    def when_drop_invalid_tool_calls_is_true():
+        def when_one_tool_call_has_bad_json():
+            def it_drops_only_that_tool_call():
+                msg = AssistantMessage(
+                    id="a1",
+                    content=None,
+                    tool_calls=[
+                        ToolCall(
+                            id="bad",
+                            function=FunctionCall(name="f", arguments="not json"),
+                        ),
+                        ToolCall(
+                            id="good",
+                            function=FunctionCall(name="g", arguments='{"x": 1}'),
+                        ),
+                    ],
+                )
+                [out] = agui_messages_to_langchain([msg], drop_invalid_tool_calls=True)
+                assert [tc["id"] for tc in out.tool_calls] == ["good"]
+
+            def it_logs_warning_naming_the_tool_call(caplog):
+                msg = AssistantMessage(
+                    id="a1",
+                    content=None,
+                    tool_calls=[
+                        ToolCall(
+                            id="bad",
+                            function=FunctionCall(name="f", arguments="not json"),
+                        ),
+                        ToolCall(
+                            id="good",
+                            function=FunctionCall(name="g", arguments='{"x": 1}'),
+                        ),
+                    ],
+                )
+                agui_messages_to_langchain([msg], drop_invalid_tool_calls=True)
+                assert any("bad" in r.message for r in caplog.records)
+
+        def when_all_tool_calls_have_bad_json():
+            def it_drops_the_assistant_message():
+                msg = AssistantMessage(
+                    id="a1",
+                    content=None,
+                    tool_calls=[
+                        ToolCall(
+                            id="t",
+                            function=FunctionCall(name="f", arguments="bad"),
+                        )
+                    ],
+                )
+                assert (
+                    agui_messages_to_langchain([msg], drop_invalid_tool_calls=True)
+                    == []
+                )
+
+            def it_logs_warning_naming_the_message(caplog):
+                msg = AssistantMessage(
+                    id="m99",
+                    content=None,
+                    tool_calls=[
+                        ToolCall(
+                            id="t",
+                            function=FunctionCall(name="f", arguments="bad"),
+                        )
+                    ],
+                )
+                agui_messages_to_langchain([msg], drop_invalid_tool_calls=True)
+                assert any("m99" in r.message for r in caplog.records)
+
+        def when_message_has_no_tool_calls():
+            def it_passes_through_unchanged():
+                msg = AssistantMessage(id="a1", content="hello")
+                [out] = agui_messages_to_langchain([msg], drop_invalid_tool_calls=True)
+                assert out.content == "hello"
+
+
+def describe_extract_resume_input():
+    def when_forwarded_props_is_empty():
+        def it_returns_none():
+            assert extract_resume_input(make_run_agent_input()) is None
+
+    def when_command_key_is_absent():
+        def it_returns_none():
+            inp = make_run_agent_input(forwarded_props={"other": 1})
+            assert extract_resume_input(inp) is None
+
+    def when_resume_key_is_absent():
+        def it_returns_none():
+            inp = make_run_agent_input(forwarded_props={"command": {}})
+            assert extract_resume_input(inp) is None
+
+    def when_resume_is_empty_string():
+        def it_returns_none():
+            inp = make_run_agent_input(forwarded_props={"command": {"resume": ""}})
+            assert extract_resume_input(inp) is None
+
+    def when_resume_is_a_dict():
+        def it_returns_dict_unchanged():
+            inp = make_run_agent_input(
+                forwarded_props={"command": {"resume": {"k": "v"}}}
+            )
+            assert extract_resume_input(inp) == {"k": "v"}
+
+    def when_resume_is_a_json_string():
+        def it_decodes_to_its_json_value():
+            inp = make_run_agent_input(
+                forwarded_props={"command": {"resume": '{"k": 2}'}}
+            )
+            assert extract_resume_input(inp) == {"k": 2}
+
+    def when_resume_is_a_non_json_string():
+        def it_returns_string_as_is():
+            inp = make_run_agent_input(
+                forwarded_props={"command": {"resume": "approve"}}
+            )
+            assert extract_resume_input(inp) == "approve"
+
+    def when_resume_is_a_list():
+        def it_returns_list_unchanged():
+            inp = make_run_agent_input(forwarded_props={"command": {"resume": [1, 2]}})
+            assert extract_resume_input(inp) == [1, 2]
+
+    def when_resume_is_a_nonzero_number():
+        def it_returns_number_unchanged():
+            inp = make_run_agent_input(forwarded_props={"command": {"resume": 7}})
+            assert extract_resume_input(inp) == 7
+
+    def when_resume_is_zero():
+        def it_returns_none():
+            inp = make_run_agent_input(forwarded_props={"command": {"resume": 0}})
+            assert extract_resume_input(inp) is None
+
+
+def describe_merge_frontend_messages():
+    def when_checkpoint_state_is_none():
+        def it_returns_only_converted_input_messages():
+            inp = make_run_agent_input(messages=[UserMessage(id="u1", content="hi")])
+            result = merge_frontend_messages(inp, None)
+            assert len(result) == 1
+            assert isinstance(result[0], HumanMessage)
+            assert result[0].id == "u1"
+
+        def it_returns_a_tuple():
+            inp = make_run_agent_input(messages=[UserMessage(id="u1", content="hi")])
+            assert isinstance(merge_frontend_messages(inp, None), tuple)
+
+    def when_checkpoint_has_no_reducers_key():
+        def it_returns_only_converted_input_messages():
+            inp = make_run_agent_input(messages=[UserMessage(id="u1", content="hi")])
+            result = merge_frontend_messages(inp, {})
+            assert len(result) == 1
+            assert result[0].id == "u1"
+
+    def when_checkpoint_has_reducers_but_no_messages_reducer():
+        def it_returns_only_converted_input_messages():
+            inp = make_run_agent_input(messages=[UserMessage(id="u1", content="hi")])
+            result = merge_frontend_messages(inp, {"reducers": {}})
+            assert len(result) == 1
+            assert result[0].id == "u1"
+
+    def when_existing_and_new_share_id():
+        def it_dedups_via_add_messages():
+            existing = [HumanMessage(id="u1", content="old")]
+            inp = make_run_agent_input(messages=[UserMessage(id="u1", content="new")])
+            result = merge_frontend_messages(inp, {"reducers": {"messages": existing}})
+            assert len(result) == 1
+            assert result[0].content == "new"
+
+    def when_input_messages_are_empty():
+        def it_returns_existing_messages_unchanged():
+            existing = [HumanMessage(id="u1", content="kept")]
+            inp = make_run_agent_input()
+            result = merge_frontend_messages(inp, {"reducers": {"messages": existing}})
+            assert len(result) == 1
+            assert result[0].id == "u1"
+            assert result[0].content == "kept"
+
+    def when_reducer_name_is_overridden():
+        def it_pulls_from_the_named_reducer():
+            existing = [HumanMessage(id="u1", content="kept")]
+            inp = make_run_agent_input(messages=[UserMessage(id="u2", content="new")])
+            result = merge_frontend_messages(
+                inp,
+                {"reducers": {"chat": existing}},
+                reducer_name="chat",
+            )
+            assert [m.id for m in result] == ["u1", "u2"]
+
+    def when_drop_invalid_tool_calls_is_default():
+        def it_drops_invalid_tool_calls_silently():
+            msg = AssistantMessage(
+                id="a1",
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        id="bad",
+                        function=FunctionCall(name="x", arguments="not-json"),
+                    )
+                ],
+            )
+            inp = make_run_agent_input(messages=[msg])
+            result = merge_frontend_messages(inp, None)
+            assert result == ()
+
+    def when_drop_invalid_tool_calls_is_false():
+        def it_propagates_json_decode_error():
+            msg = AssistantMessage(
+                id="a1",
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        id="bad",
+                        function=FunctionCall(name="x", arguments="not-json"),
+                    )
+                ],
+            )
+            inp = make_run_agent_input(messages=[msg])
+            with pytest.raises(json.JSONDecodeError):
+                merge_frontend_messages(inp, None, drop_invalid_tool_calls=False)

--- a/tests/test_agui_resume.py
+++ b/tests/test_agui_resume.py
@@ -276,6 +276,14 @@ def describe_agui_messages_to_langchain():
             with pytest.raises(ValueError, match="alien"):
                 agui_messages_to_langchain([Foreign()])  # type: ignore[list-item]
 
+    def when_role_attribute_is_missing():
+        def it_raises_value_error_naming_the_class():
+            class NoRole:
+                id = "z1"
+
+            with pytest.raises(ValueError, match="NoRole"):
+                agui_messages_to_langchain([NoRole()])  # type: ignore[list-item]
+
     def when_message_list_is_empty():
         def it_returns_empty_list():
             assert agui_messages_to_langchain([]) == []
@@ -380,6 +388,13 @@ def describe_agui_messages_to_langchain():
                 msg = AssistantMessage(id="a1", content="hello")
                 [out] = agui_messages_to_langchain([msg], drop_invalid_tool_calls=True)
                 assert out.content == "hello"
+
+        def when_tool_calls_is_an_empty_list():
+            def it_passes_the_message_through():
+                msg = AssistantMessage(id="a1", content="hi", tool_calls=[])
+                [out] = agui_messages_to_langchain([msg], drop_invalid_tool_calls=True)
+                assert out.content == "hi"
+                assert out.tool_calls == []
 
 
 def describe_extract_resume_input():


### PR DESCRIPTION
## Summary

Adds three public helpers under `langgraph_events.agui` for consumers implementing AG-UI `ResumeFactory` protocols. Removes the need to depend on `ag-ui-langgraph` for the single helper that previously justified that dep, and collapses the resume-merge boilerplate that every AG-UI consumer would otherwise reimplement.

- **`agui_messages_to_langchain(messages, *, drop_invalid_tool_calls=False)`** — AG-UI → LangChain `BaseMessage` converter. Mirrors the existing internal LangChain→AG-UI direction in `_mappers.py`. Handles multimodal `UserMessage` (string and `list[InputContent]`) with `url > data > id` priority cascade for `BinaryInputContent`; `AssistantMessage` with optional `tool_calls` (parsing `function.arguments` JSON); `SystemMessage`; `ToolMessage`. `ReasoningMessage`/`DeveloperMessage` skipped (DEBUG-logged); `ActivityMessage` and unknown roles raise `ValueError`. With `drop_invalid_tool_calls=True`, tool calls whose JSON `arguments` fail to parse are dropped (WARNING-logged); if every tool call on an `AssistantMessage` drops, the message itself drops. Default `False` matches `ag-ui-langgraph` for drop-in migrators.
- **`merge_frontend_messages(input_data, checkpoint_state, *, reducer_name="messages", drop_invalid_tool_calls=True)`** — high-level resume-factory helper. Reads existing messages from `checkpoint_state["reducers"][reducer_name]`, converts `input_data.messages`, merges via langgraph's `add_messages` (id-based dedup). Defensive default for malformed tool-call JSON.
- **`extract_resume_input(input_data)`** — pulls `forwarded_props["command"]["resume"]`, JSON-decoding string payloads on best-effort. Returns `None` if absent **or falsy** (matches the convention shipped by downstream consumers — `False`/`0`/`[]`/`{}`/`""` collapse to `None`; HITL flows using bare `False` as a "deny" signal need to wrap it).

## Design notes (pre-empting review questions)

- **Function-scoped imports** for ag-ui and langchain types match the established pattern in `_mappers.py:58-65` and `_tools.py:47` — keeps the submodule importable without `[agui]` extra installed.
- **`# noqa: PLR0912`** on the converter is intrinsic to multimodal pydantic dispatch (4 message-type arms × tool_calls/multimodal sub-branches). Extracting helpers would either duplicate the function-scoped imports or move them to module scope (changes the lazy-import pattern). Per CLAUDE.md "don't add abstractions beyond what the task requires" — left in place.
- **`# type: ignore[arg-type,assignment]`** on the single `add_messages` call: langgraph's signature accepts dict/tuple/str shapes for checkpoint-stored messages while our call site is always `BaseMessage`. Annotated inline.
- **Asymmetric `drop_invalid_tool_calls` defaults** (converter `False`, merge helper `True`) — converter defaults to upstream parity; the high-level helper defaults to defensive because it's meant for production resume factories.
- **Where this lands**: a new `_resume.py` keeps the new public API focused. The existing private inverse `_langchain_to_agui_messages` in `_mappers.py` stays put — colocating both directions is a follow-up if a real consumer needs the inverse public.
- **Versioning**: additive, ships in `0.8.0` (next minor).

## Test plan

- [x] `uv run pytest tests/test_agui_resume.py` — 54 BDD tests, all green
- [x] `uv run pytest tests/` — full suite green (743 passed, 1 skipped — pre-existing)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — strict, clean
- [x] Coverage on `_resume.py` — 99% (line + branch). Aggregate 84% project-floor failure is pre-existing on `main` (unrelated files: `_namespace/_text.py`, `_reducer.py`, `_types.py`).

CHANGELOG entries land under `[Unreleased]`; new symbols are documented in `docs/agui.md` under a new "Resume Helpers" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)