### PR TITLE
fix(graph): unpack Union members inside Scatter[A | B] (closes #66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Scatter return-type parser**: `Scatter[A | B]` now extracts both `A` and `B` as scatter targets, matching the behavior of the equivalent `Scatter[A] | Scatter[B]` form. Previously the Union argument was rejected by an `isinstance(..., type)` check and silently dropped, so `info.scatter_types` came back empty — orphan-warning detection and choreography diagrams missed those targets entirely. (closes #66)
+
 ## [0.9.0] - 2026-05-07
 
 ### Added

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -104,7 +104,9 @@ def _scatter_event_types(scatter_alias: Any) -> list[type[Event]]:
     """Extract Event types from a parameterized ``Scatter[X]`` alias.
 
     Unpacks Union/UnionType members so ``Scatter[A | B]`` behaves like
-    ``Scatter[A] | Scatter[B]`` for topology parsing.
+    ``Scatter[A] | Scatter[B]`` for topology parsing. Non-Event members
+    (e.g. ``None`` from ``Scatter[A | None]``) are silently dropped — only
+    Event subclasses participate in topology.
     """
     out: list[type[Event]] = []
     for arg in typing.get_args(scatter_alias):

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
+import types
 import typing
 import warnings
 from collections.abc import Mapping as _Mapping
@@ -99,6 +100,24 @@ class ReturnContract(NamedTuple):
     """Human-readable origin of the contract, used in error messages."""
 
 
+def _scatter_event_types(scatter_alias: Any) -> list[type[Event]]:
+    """Extract Event types from a parameterized ``Scatter[X]`` alias.
+
+    Unpacks Union/UnionType members so ``Scatter[A | B]`` behaves like
+    ``Scatter[A] | Scatter[B]`` for topology parsing.
+    """
+    out: list[type[Event]] = []
+    for arg in typing.get_args(scatter_alias):
+        if typing.get_origin(arg) in (typing.Union, types.UnionType):
+            members = typing.get_args(arg)
+        else:
+            members = (arg,)
+        for member in members:
+            if isinstance(member, type) and issubclass(member, Event):
+                out.append(member)
+    return out
+
+
 def _parse_return_types(fn: Callable[..., Any]) -> ReturnInfo:
     """Parse handler return annotation into a ``ReturnInfo``."""
     try:
@@ -134,10 +153,7 @@ def _parse_return_types(fn: Callable[..., Any]) -> ReturnInfo:
         if arg is Scatter:
             has_scatter = True
         elif typing.get_origin(arg) is Scatter:
-            # Parameterized Scatter[X] — extract event types
-            for scatter_arg in typing.get_args(arg):
-                if isinstance(scatter_arg, type) and issubclass(scatter_arg, Event):
-                    scatter_types.append(scatter_arg)
+            scatter_types.extend(_scatter_event_types(arg))
         elif isinstance(arg, type) and issubclass(arg, Event):
             if issubclass(arg, Interrupted):
                 has_interrupted = True

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -1,6 +1,7 @@
 """Integration tests for EventGraph — the full event-driven graph engine."""
 
 import asyncio
+import typing
 import warnings
 
 import pytest
@@ -4148,7 +4149,74 @@ def describe_OrphanedEventWarning():
             ):
                 EventGraph([scatter_producer])
 
+        def it_warns_for_each_orphan_in_scatter_typing_union():
+            # Same behavior as ``Scatter[A | B]`` for the legacy ``typing.Union``
+            # spelling — exercises the helper's ``typing.Union`` branch.
+            class TypingUnionScatterA(IntegrationEvent):
+                pass
+
+            class TypingUnionScatterB(IntegrationEvent):
+                pass
+
+            @on(Started)
+            def scatter_producer(
+                event: Started,
+            ) -> Scatter[typing.Union[TypingUnionScatterA, TypingUnionScatterB]]:  # noqa: UP007
+                return Scatter([TypingUnionScatterA()])
+
+            with pytest.warns(
+                OrphanedEventWarning,
+                match=r"TypingUnionScatterA.*TypingUnionScatterB",
+            ):
+                EventGraph([scatter_producer])
+
+        def it_warns_for_each_orphan_in_union_of_scatters():
+            # ``Scatter[A] | Scatter[B]`` — the original workaround form, parsed
+            # at the outer ``_parse_return_types`` loop rather than the helper.
+            class OuterScatterA(IntegrationEvent):
+                pass
+
+            class OuterScatterB(IntegrationEvent):
+                pass
+
+            @on(Started)
+            def scatter_producer(
+                event: Started,
+            ) -> Scatter[OuterScatterA] | Scatter[OuterScatterB]:
+                return Scatter([OuterScatterA()])
+
+            with pytest.warns(
+                OrphanedEventWarning, match=r"OuterScatterA.*OuterScatterB"
+            ):
+                EventGraph([scatter_producer])
+
     def when_not_orphaned():
+
+        def when_all_scatter_union_members_subscribed():
+            def it_does_not_warn():
+                class SubscribedScatterA(IntegrationEvent):
+                    pass
+
+                class SubscribedScatterB(IntegrationEvent):
+                    pass
+
+                @on(Started)
+                def scatter_producer(
+                    event: Started,
+                ) -> Scatter[SubscribedScatterA | SubscribedScatterB]:
+                    return Scatter([SubscribedScatterA()])
+
+                @on(SubscribedScatterA)
+                def consume_a(event: SubscribedScatterA):
+                    pass
+
+                @on(SubscribedScatterB)
+                def consume_b(event: SubscribedScatterB):
+                    pass
+
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error", OrphanedEventWarning)
+                    EventGraph([scatter_producer, consume_a, consume_b])
 
         def it_does_not_warn_for_subscribed_via_inheritance():
             class Base(IntegrationEvent):

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -4130,6 +4130,24 @@ def describe_OrphanedEventWarning():
             with pytest.warns(OrphanedEventWarning, match="ScatterOrphan"):
                 EventGraph([scatter_producer])
 
+        def it_warns_for_each_orphan_in_scatter_union():
+            class UnionScatterA(IntegrationEvent):
+                pass
+
+            class UnionScatterB(IntegrationEvent):
+                pass
+
+            @on(Started)
+            def scatter_producer(
+                event: Started,
+            ) -> Scatter[UnionScatterA | UnionScatterB]:
+                return Scatter([UnionScatterA()])
+
+            with pytest.warns(
+                OrphanedEventWarning, match=r"UnionScatterA.*UnionScatterB"
+            ):
+                EventGraph([scatter_producer])
+
     def when_not_orphaned():
 
         def it_does_not_warn_for_subscribed_via_inheritance():

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -471,7 +471,7 @@ class _HubScatter(Namespace):
 @on(_HubScatter.ScatterTrigger)
 def hub_scatter(
     event: _HubScatter.ScatterTrigger,
-) -> Scatter[_HubScatter.S1] | Scatter[_HubScatter.S2] | Scatter[_HubScatter.S3]:
+) -> Scatter[_HubScatter.S1 | _HubScatter.S2 | _HubScatter.S3]:
     return Scatter([_HubScatter.S1()])
 
 


### PR DESCRIPTION
## Summary

- `_parse_return_types` was dropping the `A | B` argument inside `Scatter[A | B]` because the inner `isinstance(scatter_arg, type)` check rejects a `Union`. Result: empty `scatter_types`, missing orphan warnings, missing choreography-diagram edges. The workaround `Scatter[A] | Scatter[B]` worked, hiding the bug.
- Extract `_scatter_event_types` that walks into `typing.Union` / `types.UnionType` before the type check, so both forms produce the same `scatter_types`.
- Simplify the PR #65 hub-scatter fixture in `tests/test_namespace.py` to the natural `Scatter[S1 | S2 | S3]` form — its diagram-style tests now exercise the fixed Union path end-to-end.

## Test plan

- [x] New unit-level test `it_warns_for_each_orphan_in_scatter_union` confirms both Union members are produced (and thus orphan-warned) for the natural `Scatter[A | B]` form. Verified red before the fix; green after.
- [x] Existing hub-scatter diagram tests pass with the simplified `Scatter[S1 | S2 | S3]` fixture (linkStyle indices, `-.->` arrows, etc.).
- [x] Full suite: 764 passed, 1 skipped.
- [x] `ruff check`, `ruff format --check`, `mypy src/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)