### PR TITLE
feat(privacy)!: reject empty-typed Scatter at build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Scatter must enumerate concrete event types**. Return annotations of the form `-> Scatter`, `-> Scatter[Any]`, `-> Scatter[Event]`, `-> Scatter[DomainEvent]`, `-> Scatter[IntegrationEvent]`, `-> Scatter[SystemEvent]`, and `-> Scatter[T]` (TypeVar) are now rejected at `EventGraph` construction with a `TypeError`. These shapes contributed no usable types to the privacy graph, so the v0.9.0 `enforce_command_privacy()` check passed silently and the leak was only caught at runtime — turning the previous build-time `CommandPrivacyError` into something developers could paper over by widening the annotation. **Migration**: replace `-> Scatter` with `-> Scatter[Event1 | Event2 | ...]` enumerating the concrete events you scatter. The error message points at the right form (and steers away from demoting the offending `Command` to `DomainEvent`/`IntegrationEvent`, which would silently lose privacy guarantees).
+- **NamespaceModel JSON schema bumped to v2**. `CommandHandler.has_untyped_scatter` and `Policy.has_untyped_scatter` are removed (the represented condition is now impossible at build time). The "Scatter handlers: …" footer in mermaid output and the bare `Scatter` token in text output are both gone for the same reason. Consumers reading `to_dict()` must update.
+
 ### Fixed
 - **Scatter return-type parser**: `Scatter[A | B]` now extracts both `A` and `B` as scatter targets, matching the behavior of the equivalent `Scatter[A] | Scatter[B]` form. Previously the Union argument was rejected by an `isinstance(..., type)` check and silently dropped, so `info.scatter_types` came back empty — orphan-warning detection and choreography diagrams missed those targets entirely. (closes #66)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -115,7 +115,7 @@ from langgraph_events.stream import (
 
 | Export | Type | Description |
 |---|---|---|
-| `CommandPrivacyError` | TypeError subclass | Raised at `EventGraph` construction (and at runtime for bare-`Scatter` reactors) when a handler emits a `DomainEvent` it isn't allowed to emit. Outcomes nested inside a `Command` are private to that Command's inline `handle()` — neither sibling Commands nor non-inline reactors may produce them |
+| `CommandPrivacyError` | TypeError subclass | Raised at `EventGraph` construction; also at runtime when a handler with a broad base-class annotation (e.g. `-> DomainEvent`) constructs a `Cmd.Private(...)` that bypasses the static contract check. Outcomes nested inside a `Command` are private to that Command's inline `handle()` — neither sibling Commands nor non-inline reactors may produce them |
 
 ## AG-UI Subpackage
 

--- a/src/langgraph_events/_event.py
+++ b/src/langgraph_events/_event.py
@@ -725,7 +725,7 @@ class Scatter:
     Example::
 
         @on(BatchReceived)
-        def split(event: BatchReceived) -> Scatter:
+        def split(event: BatchReceived) -> Scatter[ItemToProcess]:
             return Scatter([ItemToProcess(item=i) for i in event.items])
     """
 

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -21,11 +21,13 @@ from langgraph_events._event import (
     Event,
     Halted,
     HandlerRaised,
+    IntegrationEvent,
     Interrupted,
     Invariant,
     InvariantViolated,
     Namespace,
     Scatter,
+    SystemEvent,
     _iter_nested_outcomes,
 )
 from langgraph_events._event_log import EventLog
@@ -78,7 +80,6 @@ class ReturnInfo(NamedTuple):
 
     event_types: list[type[Event]]
     scatter_types: list[type[Event]]
-    has_scatter: bool
     has_interrupted: bool
     has_annotation: bool
 
@@ -98,6 +99,14 @@ class ReturnContract(NamedTuple):
 
     source: str
     """Human-readable origin of the contract, used in error messages."""
+
+
+_ABSTRACT_EVENT_BASES: tuple[type, ...] = (
+    Event,
+    DomainEvent,
+    IntegrationEvent,
+    SystemEvent,
+)
 
 
 def _scatter_event_types(scatter_alias: Any) -> list[type[Event]]:
@@ -120,8 +129,59 @@ def _scatter_event_types(scatter_alias: Any) -> list[type[Event]]:
     return out
 
 
+def _format_scatter_repr(scatter_alias: Any) -> str:
+    """Render a Scatter annotation back into a readable form for error text."""
+    args = typing.get_args(scatter_alias)
+    if not args:
+        return "Scatter"
+    parts: list[str] = []
+    for arg in args:
+        if typing.get_origin(arg) in (typing.Union, types.UnionType):
+            inner = " | ".join(
+                getattr(m, "__name__", repr(m)) for m in typing.get_args(arg)
+            )
+            parts.append(inner)
+        else:
+            parts.append(getattr(arg, "__name__", repr(arg)))
+    return f"Scatter[{' | '.join(parts)}]"
+
+
+def _raise_empty_scatter(fn: Callable[..., Any], offending: str) -> None:
+    """Reject a Scatter annotation that contributes no concrete event types.
+
+    Bare ``Scatter``, ``Scatter[Any]``, ``Scatter[TypeVar]``, and
+    ``Scatter[<abstract base>]`` (Event/DomainEvent/IntegrationEvent/
+    SystemEvent) all bypass build-time privacy enforcement because the
+    resolved target set is empty or non-discriminating. Raise at build time
+    so users can't paper over a privacy violation by widening the annotation.
+    """
+    handler_name = getattr(fn, "__name__", "handler")
+    cmd: type[Command] | None = getattr(fn, "_inline_command", None)
+    if cmd is not None:
+        nested = _iter_nested_outcomes(cmd)
+        suggested = (
+            " | ".join(o.__name__ for o in nested) if nested else "EventA | EventB"
+        )
+        location = f"Inline handler {handler_name!r} on {cmd.__qualname__}"
+    else:
+        suggested = "EventA | EventB"
+        location = f"Handler {handler_name!r}"
+    raise TypeError(
+        f"{location} returns {offending}, which declares no concrete event "
+        f"types and bypasses build-time privacy enforcement. "
+        f"Use `Scatter[{suggested}]` to enumerate the events you scatter. "
+        f"(Do not work around this by demoting your Command to a "
+        f"DomainEvent/IntegrationEvent — that loses privacy and outcome "
+        f"guarantees.)"
+    )
+
+
 def _parse_return_types(fn: Callable[..., Any]) -> ReturnInfo:
-    """Parse handler return annotation into a ``ReturnInfo``."""
+    """Parse handler return annotation into a ``ReturnInfo``.
+
+    Raises ``TypeError`` for Scatter shapes that contribute no concrete event
+    types — see :func:`_raise_empty_scatter`.
+    """
     try:
         hints = _resolve_type_hints(fn)
     except Exception as exc:
@@ -134,7 +194,7 @@ def _parse_return_types(fn: Callable[..., Any]) -> ReturnInfo:
 
     return_hint = hints.get("return")
     if return_hint is None:
-        return ReturnInfo([], [], False, False, False)
+        return ReturnInfo([], [], False, False)
 
     # If the top-level hint is Scatter[X], wrap it so the loop sees Scatter[X]
     # as a single candidate (otherwise get_args returns the type params).
@@ -147,21 +207,23 @@ def _parse_return_types(fn: Callable[..., Any]) -> ReturnInfo:
 
     event_types: list[type[Event]] = []
     scatter_types: list[type[Event]] = []
-    has_scatter = False
     has_interrupted = False
     for arg in candidates:
         if arg is type(None):
             continue
         if arg is Scatter:
-            has_scatter = True
+            _raise_empty_scatter(fn, "bare `Scatter`")
         elif typing.get_origin(arg) is Scatter:
-            scatter_types.extend(_scatter_event_types(arg))
+            members = _scatter_event_types(arg)
+            if not members or any(m in _ABSTRACT_EVENT_BASES for m in members):
+                _raise_empty_scatter(fn, f"`{_format_scatter_repr(arg)}`")
+            scatter_types.extend(members)
         elif isinstance(arg, type) and issubclass(arg, Event):
             if issubclass(arg, Interrupted):
                 has_interrupted = True
             event_types.append(arg)
 
-    return ReturnInfo(event_types, scatter_types, has_scatter, has_interrupted, True)
+    return ReturnInfo(event_types, scatter_types, has_interrupted, True)
 
 
 class GraphState(NamedTuple):
@@ -305,14 +367,6 @@ def _verify_inline_outcome_coverage(meta: HandlerMeta, info: ReturnInfo) -> None
     if not nested_outcomes:
         return
     handler_name = getattr(meta.fn, "__name__", "handler")
-    if info.has_scatter:
-        example = " | ".join(o.__name__ for o in nested_outcomes)
-        raise TypeError(
-            f"Inline handler {handler_name!r} on {cmd.__qualname__} uses bare "
-            f"`Scatter`; this is not allowed on a Command's inline handler. "
-            f"Use `Scatter[{example}]` — or drop the annotation to let "
-            f"`Outcomes` drive the contract."
-        )
     covered = tuple(info.event_types) + tuple(info.scatter_types)
     missing = [o for o in nested_outcomes if not any(issubclass(c, o) for c in covered)]
     if not missing:

--- a/src/langgraph_events/_internal.py
+++ b/src/langgraph_events/_internal.py
@@ -597,13 +597,15 @@ def _collect_and_check(
 
 
 def _assert_no_private_leak(result: Event | Scatter, meta: HandlerMeta | None) -> None:
-    """Closes the bare-``Scatter`` privacy escape at runtime.
+    """Defense-in-depth runtime check for Command-private leaks.
 
-    Static analysis catches Command-private leaks for handlers whose return
-    annotation enumerates concrete types, but a reactor annotated bare
-    ``-> Scatter`` reveals nothing at build time. Check at emission instead:
-    a non-inline handler may not produce any ``DomainEvent`` whose
-    ``__command__`` is set.
+    Empty-typed ``Scatter`` annotations (bare, ``Scatter[Any]``,
+    ``Scatter[Event]``, ``Scatter[DomainEvent]``, ``Scatter[TypeVar]``) are
+    rejected at build time, so static analysis is the primary guard. This
+    check still fires when a handler with a broad return annotation (e.g.
+    ``-> Event``) constructs ``Scatter([Cmd.Private(...)])`` at runtime —
+    Python's type system doesn't enforce annotations at the call site, so
+    the runtime check catches what the static check structurally cannot see.
     """
     if meta is None:
         return

--- a/src/langgraph_events/_internal.py
+++ b/src/langgraph_events/_internal.py
@@ -602,9 +602,9 @@ def _assert_no_private_leak(result: Event | Scatter, meta: HandlerMeta | None) -
     Empty-typed ``Scatter`` annotations (bare, ``Scatter[Any]``,
     ``Scatter[Event]``, ``Scatter[DomainEvent]``, ``Scatter[TypeVar]``) are
     rejected at build time, so static analysis is the primary guard. This
-    check still fires when a handler with a broad return annotation (e.g.
-    ``-> Event``) constructs ``Scatter([Cmd.Private(...)])`` at runtime —
-    Python's type system doesn't enforce annotations at the call site, so
+    check still fires when a handler with a broad base-class annotation (e.g.
+    ``-> DomainEvent``) constructs ``Scatter([Cmd.Private(...)])`` at runtime
+    — Python's type system doesn't enforce annotations at the call site, so
     the runtime check catches what the static check structurally cannot see.
     """
     if meta is None:

--- a/src/langgraph_events/_namespace/_json.py
+++ b/src/langgraph_events/_namespace/_json.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from langgraph_events._namespace._model import NamespaceModel
 
-SCHEMA_VERSION = "1"
+SCHEMA_VERSION = "2"
 """Top-level ``schema_version`` string stamped on ``to_dict()`` output.
 
 Bumped when fields are removed, renamed, or change meaning. Additions
@@ -28,7 +28,6 @@ def _encode_reaction(r: Any) -> dict[str, Any]:
         "field_matchers": [list(fm) for fm in r.field_matchers],
         "side_effect": r.side_effect,
         "has_annotation": r.has_annotation,
-        "has_untyped_scatter": r.has_untyped_scatter,
     }
     if isinstance(r, NamespaceModel.CommandHandler):
         base["kind"] = "command_handler"

--- a/src/langgraph_events/_namespace/_mermaid.py
+++ b/src/langgraph_events/_namespace/_mermaid.py
@@ -176,7 +176,6 @@ def render_mermaid_choreography(  # noqa: PLR0912, PLR0915
     node_id = _build_node_id_map(d)
     edges: list[_FlowEdge] = []
     side_effect_entries: list[str] = []
-    scatter_entries: list[str] = []
     referenced: set[type[Event]] = set()
     all_sources: set[str] = set()
     all_targets: set[str] = set()
@@ -271,17 +270,12 @@ def render_mermaid_choreography(  # noqa: PLR0912, PLR0915
         scatter_edges = [e for e in re_edges if e.kind == "scatter"]
 
         has_annotation = getattr(r, "has_annotation", True)
-        has_untyped_scatter = getattr(r, "has_untyped_scatter", False)
         side_effect = getattr(r, "side_effect", False)
 
         if not solid_edges and not scatter_edges:
-            if has_annotation and not has_untyped_scatter and side_effect:
+            if has_annotation and side_effect:
                 subs_label = ", ".join(_event_label(t) for t in subs)
                 side_effect_entries.append(f"{name} ({subs_label})")
-                continue
-            if has_untyped_scatter:
-                subs_label = ", ".join(_event_label(t) for t in subs)
-                scatter_entries.append(f"{name} ({subs_label})")
                 continue
             if not has_annotation:
                 # Unannotated handler with no known target → show "?" target.
@@ -480,8 +474,6 @@ def render_mermaid_choreography(  # noqa: PLR0912, PLR0915
     flow.link_style("ownership", _LINKSTYLE_OWNS)
     flow.link_style("invariant", _LINKSTYLE_INVARIANT)
 
-    if scatter_entries:
-        flow.comment(f"Scatter handlers: {', '.join(scatter_entries)}")
     if side_effect_entries:
         flow.comment(f"Side-effect handlers: {', '.join(side_effect_entries)}")
 

--- a/src/langgraph_events/_namespace/_model.py
+++ b/src/langgraph_events/_namespace/_model.py
@@ -229,7 +229,6 @@ class NamespaceModel:
         inline: bool
         side_effect: bool
         has_annotation: bool
-        has_untyped_scatter: bool
 
     @dataclass(frozen=True)
     class Policy:
@@ -244,7 +243,6 @@ class NamespaceModel:
         field_matchers: tuple[tuple[str, str], ...]
         side_effect: bool
         has_annotation: bool
-        has_untyped_scatter: bool
 
     @dataclass(frozen=True)
     class Edge:
@@ -506,9 +504,7 @@ def _build_domain_model(  # noqa: PLR0912
         is_command_handler = any(
             isinstance(t, type) and issubclass(t, CommandBase) for t in meta.event_types
         )
-        side_effect = (
-            not info.event_types and not info.scatter_types and not info.has_scatter
-        )
+        side_effect = not info.event_types and not info.scatter_types
         invariants = tuple(cls for cls, _fn in meta.invariants)
         field_matchers = tuple(
             (fname, _matcher_repr(matcher, is_type))
@@ -532,7 +528,6 @@ def _build_domain_model(  # noqa: PLR0912
                 inline=getattr(meta.fn, "_inline_command", None) is not None,
                 side_effect=side_effect,
                 has_annotation=info.has_annotation,
-                has_untyped_scatter=info.has_scatter and not info.scatter_types,
             )
             command_handlers.append(ch)
             for cmd in cmds:
@@ -548,7 +543,6 @@ def _build_domain_model(  # noqa: PLR0912
                 field_matchers=field_matchers,
                 side_effect=side_effect,
                 has_annotation=info.has_annotation,
-                has_untyped_scatter=info.has_scatter and not info.scatter_types,
             )
             policies.append(policy)
 

--- a/src/langgraph_events/_namespace/_text.py
+++ b/src/langgraph_events/_namespace/_text.py
@@ -27,8 +27,6 @@ def _command_annotations(
             label = f"Scatter[{_event_label(tgt)}]"
             if label not in scatters:
                 scatters.append(label)
-        if ch.has_untyped_scatter and "Scatter" not in scatters:
-            scatters.append("Scatter")
     return tuple(raises), tuple(invariants), tuple(scatters)
 
 
@@ -37,8 +35,6 @@ def _policy_targets(p: NamespaceModel.Policy) -> str:
     parts = [_event_label(t) for t in p.produces]
     for tgt in p.scatters:
         parts.append(f"Scatter[{_event_label(tgt)}]")
-    if p.has_untyped_scatter:
-        parts.append("Scatter")
     return ", ".join(parts)
 
 

--- a/tests/test_command_privacy.py
+++ b/tests/test_command_privacy.py
@@ -10,18 +10,25 @@ Two symmetric rules:
 
 from __future__ import annotations
 
+from typing import Any, TypeVar
+
 import pytest
 
 from langgraph_events import (
     Command,
     CommandPrivacyError,
     DomainEvent,
+    Event,
     EventGraph,
+    IntegrationEvent,
     Interrupted,
     Namespace,
     Scatter,
+    SystemEvent,
     on,
 )
+
+_T = TypeVar("_T", bound=Event)
 
 # ---- Module-level fixtures -------------------------------------------------
 # Annotations on Command.handle() and @on handlers in the test bodies below
@@ -247,24 +254,6 @@ def describe_command_privacy():
 
                 EventGraph([_PrivShared.Persist, echo])  # no raise
 
-    def describe_runtime_enforcement():
-        def when_reactor_scatters_a_Command_private_event_via_bare_Scatter():
-            # Bare ``-> Scatter`` is a legitimate annotation when the
-            # handler scatters non-private events, so we don't reject it at
-            # build time. Privacy is enforced at runtime instead, when the
-            # reactor actually emits a Command-private event.
-            def it_raises_CommandPrivacyError_at_dispatch():
-                @on(_PrivLeaky.Trigger)
-                def burst(event: _PrivLeaky.Trigger) -> Scatter:
-                    return Scatter([_PrivLeaky.Persist.Persisted()])
-
-                graph = EventGraph([_PrivLeaky.Persist, burst])
-                with pytest.raises(
-                    CommandPrivacyError,
-                    match=r"private to _PrivLeaky\.Persist",
-                ):
-                    graph.invoke(_PrivLeaky.Trigger())
-
     def describe_error():
         def it_subclasses_TypeError():
             assert issubclass(CommandPrivacyError, TypeError)
@@ -274,3 +263,138 @@ def describe_command_privacy():
                 EventGraph([_PrivSib.DoIt])
             msg = str(exc_info.value)
             assert "_PrivSib.DoIt" in msg and "_PrivSib.Stray" in msg
+
+
+# ---- Empty-typed Scatter rejection -----------------------------------------
+# A reactor that returns a Scatter without enumerating concrete event types
+# bypasses the privacy graph (the build-time check has nothing to inspect; the
+# runtime check only fires on actual emission). Reject all such shapes at
+# build time so users can't paper over a CommandPrivacyError by widening the
+# annotation.
+
+
+class _ScatHost(Namespace):
+    """Host namespace providing a Command + a trigger event for reactors."""
+
+    class Persist(Command):
+        class Persisted(DomainEvent):
+            pass
+
+        def handle(self) -> _ScatHost.Persist.Persisted:
+            return _ScatHost.Persist.Persisted()
+
+    class Trigger(DomainEvent):
+        pass
+
+    class Note(DomainEvent):
+        pass
+
+
+class _InlineBareScatter(Namespace):
+    """Inline handler returning bare ``Scatter`` (no params)."""
+
+    class Buy(Command):
+        class Done(DomainEvent):
+            pass
+
+        def handle(self) -> Scatter:
+            return Scatter([_InlineBareScatter.Buy.Done()])
+
+
+def describe_scatter_must_declare_concrete_types():
+    def describe_at_handlers():
+        def when_return_is_bare_Scatter():
+            def it_raises_TypeError_at_build():
+                @on(_ScatHost.Trigger)
+                def burst(event: _ScatHost.Trigger) -> Scatter:
+                    return Scatter([_ScatHost.Note()])
+
+                with pytest.raises(TypeError, match=r"bare `?Scatter`?"):
+                    EventGraph([_ScatHost.Persist, burst])
+
+        def when_return_is_Scatter_of_Any():
+            def it_raises_TypeError_at_build():
+                @on(_ScatHost.Trigger)
+                def burst(event: _ScatHost.Trigger) -> Scatter[Any]:
+                    return Scatter([_ScatHost.Note()])
+
+                with pytest.raises(TypeError, match=r"Scatter"):
+                    EventGraph([_ScatHost.Persist, burst])
+
+        def when_return_is_Scatter_of_Event_base():
+            def it_raises_TypeError_at_build():
+                @on(_ScatHost.Trigger)
+                def burst(event: _ScatHost.Trigger) -> Scatter[Event]:
+                    return Scatter([_ScatHost.Note()])
+
+                with pytest.raises(TypeError, match=r"Scatter"):
+                    EventGraph([_ScatHost.Persist, burst])
+
+        def when_return_is_Scatter_of_DomainEvent_base():
+            def it_raises_TypeError_at_build():
+                @on(_ScatHost.Trigger)
+                def burst(event: _ScatHost.Trigger) -> Scatter[DomainEvent]:
+                    return Scatter([_ScatHost.Note()])
+
+                with pytest.raises(TypeError, match=r"Scatter"):
+                    EventGraph([_ScatHost.Persist, burst])
+
+        def when_return_is_Scatter_of_IntegrationEvent_base():
+            def it_raises_TypeError_at_build():
+                @on(_ScatHost.Trigger)
+                def burst(event: _ScatHost.Trigger) -> Scatter[IntegrationEvent]:
+                    return Scatter([_ScatHost.Note()])
+
+                with pytest.raises(TypeError, match=r"Scatter"):
+                    EventGraph([_ScatHost.Persist, burst])
+
+        def when_return_is_Scatter_of_SystemEvent_base():
+            def it_raises_TypeError_at_build():
+                @on(_ScatHost.Trigger)
+                def burst(event: _ScatHost.Trigger) -> Scatter[SystemEvent]:
+                    return Scatter([_ScatHost.Note()])
+
+                with pytest.raises(TypeError, match=r"Scatter"):
+                    EventGraph([_ScatHost.Persist, burst])
+
+        def when_return_is_Scatter_of_TypeVar():
+            def it_raises_TypeError_at_build():
+                @on(_ScatHost.Trigger)
+                def burst(event: _ScatHost.Trigger) -> Scatter[_T]:
+                    return Scatter([_ScatHost.Note()])
+
+                with pytest.raises(TypeError, match=r"Scatter"):
+                    EventGraph([_ScatHost.Persist, burst])
+
+        def when_return_is_parameterised_Scatter_of_concrete_events():
+            def it_builds_the_graph():
+                @on(_ScatHost.Trigger)
+                def burst(event: _ScatHost.Trigger) -> Scatter[_ScatHost.Note]:
+                    return Scatter([_ScatHost.Note()])
+
+                EventGraph([_ScatHost.Persist, burst])  # no raise
+
+    def describe_inline_handler():
+        def when_inline_handle_returns_bare_Scatter():
+            def it_raises_TypeError_at_build():
+                with pytest.raises(TypeError, match=r"bare `?Scatter`?") as exc_info:
+                    EventGraph([_InlineBareScatter.Buy])
+                msg = str(exc_info.value)
+                # Inline error must name the Command and suggest the
+                # actual nested outcomes in the Scatter[...] form.
+                assert "Buy" in msg
+                assert "Scatter[Done]" in msg
+
+    def describe_error_message():
+        def it_mentions_the_demotion_anti_pattern():
+            # Pin this guidance: the only remaining escape (drop the Command,
+            # use DomainEvent/IntegrationEvent instead) loses privacy
+            # guarantees and is rarely the right answer.
+            @on(_ScatHost.Trigger)
+            def burst(event: _ScatHost.Trigger) -> Scatter:
+                return Scatter([_ScatHost.Note()])
+
+            with pytest.raises(TypeError) as exc_info:
+                EventGraph([_ScatHost.Persist, burst])
+            msg = str(exc_info.value).lower()
+            assert "demot" in msg or "domainevent" in msg or "integrationevent" in msg

--- a/tests/test_command_privacy.py
+++ b/tests/test_command_privacy.py
@@ -366,6 +366,21 @@ def describe_scatter_must_declare_concrete_types():
                 with pytest.raises(TypeError, match=r"Scatter"):
                     EventGraph([_ScatHost.Persist, burst])
 
+        def when_return_mixes_a_concrete_event():
+            # The realistic developer mistake: declare one concrete target,
+            # then "widen" with DomainEvent. The widening defeats privacy
+            # enforcement on every Cmd-private event the union implies.
+            def with_an_abstract_base():
+                def it_raises_TypeError_at_build():
+                    @on(_ScatHost.Trigger)
+                    def burst(
+                        event: _ScatHost.Trigger,
+                    ) -> Scatter[_ScatHost.Note | DomainEvent]:
+                        return Scatter([_ScatHost.Note()])
+
+                    with pytest.raises(TypeError, match=r"Scatter"):
+                        EventGraph([_ScatHost.Persist, burst])
+
         def when_return_is_parameterised_Scatter_of_concrete_events():
             def it_builds_the_graph():
                 @on(_ScatHost.Trigger)

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -1198,7 +1198,7 @@ def describe_EventGraph():
 
             def it_fans_out_work_items_and_gathers_results():
                 @on(BatchReceived)
-                def split(event: BatchReceived) -> Scatter:
+                def split(event: BatchReceived) -> Scatter[WorkItemDispatched]:
                     return Scatter(
                         [
                             WorkItemDispatched(item=item, batch_size=len(event.items))
@@ -1233,7 +1233,7 @@ def describe_EventGraph():
 
             def it_still_produces_output():
                 @on(BatchReceived)
-                def split(event: BatchReceived) -> Scatter:
+                def split(event: BatchReceived) -> Scatter[WorkItemDispatched]:
                     return Scatter([WorkItemDispatched(item=event.items[0])])
 
                 @on(WorkItemDispatched)
@@ -3228,17 +3228,6 @@ def describe_EventGraph():
             output = graph.namespaces().mermaid()
             assert "%% Side-effect handlers: side_effect (Started)" in output
             assert "Started -->|producer| Ended" in output
-
-        def it_shows_scatter_in_footer():
-            @on(Started)
-            def split(event: Started) -> Scatter:
-                return Scatter([Processed(data="a")])
-
-            graph = EventGraph([split])
-            output = graph.namespaces().mermaid()
-            # No edge to a Scatter node
-            assert "-->|split| Scatter" not in output
-            assert "%% Scatter handlers: split (Started)" in output
 
         def it_dashes_raises_edge_to_handler_raised():
             from langgraph_events import HandlerRaised

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -749,7 +749,6 @@ def describe_reaction_flags():
             policy = next(p for p in d.policies if p.name == "notify")
             assert policy.side_effect is True
             assert policy.has_annotation is True
-            assert policy.has_untyped_scatter is False
 
     def when_handler_has_no_return_annotation():
         def it_flags_has_annotation_false():
@@ -760,16 +759,6 @@ def describe_reaction_flags():
             d = EventGraph([mystery]).namespaces()
             ch = next(c for c in d.command_handlers if c.name == "mystery")
             assert ch.has_annotation is False
-
-    def when_handler_returns_bare_scatter():
-        def it_flags_has_untyped_scatter_true():
-            @on(_Batch)
-            def split(event: _Batch) -> Scatter:
-                return Scatter([_Batch()])
-
-            d = EventGraph([split]).namespaces()
-            policy = next(p for p in d.policies if p.name == "split")
-            assert policy.has_untyped_scatter is True
 
     def when_handler_declares_invariants():
         def it_preserves_invariant_classes():
@@ -1173,7 +1162,7 @@ def describe_reactor_hubs():
 def describe_json_and_to_dict():
     def it_stamps_schema_version():
         payload = EventGraph([place]).namespaces().to_dict()
-        assert payload["schema_version"] == "1"
+        assert payload["schema_version"] == "2"
 
     def it_returns_json_serializable_dict():
 

--- a/uv.lock
+++ b/uv.lock
@@ -554,10 +554,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0"
+version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -566,9 +567,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755 }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/8b74458fc3850ec3d150eb9f45e857db129dafa801fb5cf173dfc9f8bbf3/langchain_core-1.3.3.tar.gz", hash = "sha256:fa510a5db8efdc0c6ff41c0939fb5c00a0183c11f6b84233e892e3227ff69182", size = 915041 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140 },
+    { url = "https://files.pythonhosted.org/packages/1f/01/4771b7ab2af1d1aba5b710bd8f13d9225c609425214b357590a17b01be77/langchain_core-1.3.3-py3-none-any.whl", hash = "sha256:18aae8506f37da7f74398492279a7d6efcee4f8e23c4c41c7af080eeb7ef7bd1", size = 543857 },
 ]
 
 [[package]]
@@ -583,6 +584,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/f5/b1a56f703fb90952b07ff9fb5507123a39df1267d62a7f2bb821c5dbb628/langchain_openai-1.1.14.tar.gz", hash = "sha256:71b4262932fabe506ce79c175dbc956cc48f24d81e20b27662df493147750643", size = 1115195 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/fa/8c33befbc0cf81b21371cc1dab4e7bf94a80b8116194f263a5021ec02529/langchain_openai-1.1.14-py3-none-any.whl", hash = "sha256:cb525d2011f9813fc15a7dcfd4bca5b87badcbcb2c113a7fbe45d1b8a1bbb69c", size = 88705 },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/7a/9c97a7b9cbe4c5dc6a44cdb1545450c28f0c8ce89b9c1f0ee7fbad896263/langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79", size = 6982 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Reject `-> Scatter`, `-> Scatter[Any]`, `-> Scatter[Event]`, `-> Scatter[DomainEvent]`, `-> Scatter[IntegrationEvent]`, `-> Scatter[SystemEvent]`, and `-> Scatter[T]` (TypeVar) at `EventGraph` construction. These shapes contributed no concrete types to the privacy graph, so v0.9.0's `enforce_command_privacy()` passed silently and the violation only surfaced at runtime — turning the build-time `CommandPrivacyError` into a workaround developers could paper over by widening the annotation.
- Drop the now-impossible `has_untyped_scatter` field from `NamespaceModel.{CommandHandler,Policy}`, JSON, mermaid footer, and text output. JSON `SCHEMA_VERSION` → `"2"`.
- Runtime `_assert_no_private_leak` kept as defense-in-depth for broad-annotation leaks (e.g. a `-> Event`-typed handler returning `Scatter([Cmd.Private(...)])`).

## Why

v0.9.0 made the right thing easy: Command-private outcomes are colocated in `Cmd.handle()`. But the wrong thing was still possible — a developer hitting `CommandPrivacyError` could switch the offending reactor to bare `-> Scatter`, build cleanly, and ship code whose integration tests miss the dispatch path. Closing the empty-Scatter family removes that escape hatch deterministically. The remaining workaround (demote the Command to a plain `DomainEvent`/`IntegrationEvent`) can't be prevented mechanically; the new error message explicitly steers users away from it.

## Error message

```
Handler 'burst' returns `Scatter[Any]`, which declares no concrete event
types and bypasses build-time privacy enforcement. Use `Scatter[EventA | EventB]`
to enumerate the events you scatter. (Do not work around this by demoting your
Command to a DomainEvent/IntegrationEvent — that loses privacy and outcome
guarantees.)
```

Inline `Cmd.handle()` form additionally names the Command and lists the actual nested outcomes.

## Breaking changes

- Annotation migration: `-> Scatter` → `-> Scatter[Event1 | Event2 | ...]`.
- `NamespaceModel.{CommandHandler,Policy}.has_untyped_scatter` removed.
- JSON `schema_version` bumped to `"2"`; `has_untyped_scatter` no longer in the dict.
- `NamespaceModel.mermaid()` no longer emits the `%% Scatter handlers: …` footer.

## Test plan

- [x] `uv run pytest tests/` — 774 passed, 1 skipped
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] Manual: build a graph for each banned shape; confirm error names handler, suggests `Scatter[…]` form, mentions demotion anti-pattern
- [x] Manual: `examples/order.py`, `examples/error_recovery.py`, `examples/map_reduce.py` build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)