### PR TITLE
feat(agui): add `on_unmapped` policy to control the missing-`agui_dict()` warning (closes #90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`AGUIAdapter(on_unmapped=...)` policy for events with no AG-UI mapping** (#90). A keyword-only `on_unmapped: Literal["warn", "ignore", "raise"]` knob controls what happens when an event reaches `FallbackMapper` (or `InterruptedMapper`'s non-serializable branch) without implementing `AGUISerializable`. `"warn"` (default) keeps today's once-per-class `UserWarning` then drops — **non-breaking**. `"ignore"` silently drops, the off-switch for apps that are mostly internal orchestration events. `"raise"` raises the new `UnmappedEventError` (a `TypeError` subclass) naming the offending class, turning the dev-lint into a hard CI gate. The policy applies to both fallback sites; serializable events and `InterruptedWithPayload` are unaffected.
+
 ## [0.12.0] - 2026-05-28
 
 ### Fixed

--- a/docs/agui.md
+++ b/docs/agui.md
@@ -80,6 +80,22 @@ Mappers claim events in priority order; first non-`None` return wins. Unclaimed 
 
 Events without `agui_dict()` are skipped with a one-time warning.
 
+### Unmapped-event policy
+
+Most events in a real `EventGraph` are internal orchestration (`Command`s, routing/control-flow `DomainEvent`s) that have no AG-UI representation, so the default per-class warning often reads as noise. Control it with `on_unmapped`:
+
+```python
+AGUIAdapter(graph, seed_factory=..., on_unmapped="ignore")
+```
+
+| value | behavior |
+|---|---|
+| `"warn"` *(default)* | Once-per-class `UserWarning`, then drop. Non-breaking. |
+| `"ignore"` | Silently drop. The off-switch for apps that are mostly internal events. |
+| `"raise"` | Raise `UnmappedEventError` (a `TypeError` subclass) naming the offending class. Strict mode — turns the dev-lint into a hard CI gate. |
+
+The policy applies to both `FallbackMapper` and the non-serializable branch of `InterruptedMapper`. Serializable events (and `InterruptedWithPayload`) are unaffected — they still emit.
+
 Outside the chain, the adapter also emits:
 
 - `StateSnapshot` / `MessagesSnapshot` from `StreamFrame` reducer data (`MessagesSnapshot` requires `message_reducer()`).

--- a/src/langgraph_events/agui/__init__.py
+++ b/src/langgraph_events/agui/__init__.py
@@ -12,6 +12,7 @@ from langgraph_events.agui._mappers import (
     FrontendToolCallRequestedMapper,
     InterruptedMapper,
     SkipInternalMapper,
+    UnmappedEventError,
 )
 from langgraph_events.agui._protocols import (
     AGUICustomEvent,
@@ -49,6 +50,7 @@ __all__ = [
     "ResumeFactory",
     "SeedFactory",
     "SkipInternalMapper",
+    "UnmappedEventError",
     "agui_messages_to_langchain",
     "build_langchain_tools",
     "create_starlette_response",

--- a/src/langgraph_events/agui/_adapter.py
+++ b/src/langgraph_events/agui/_adapter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import inspect
 import logging
 import uuid
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
 from ag_ui.core import (
     BaseEvent,
@@ -38,6 +38,7 @@ from ._context import MapperContext
 from ._events import FrontendStateMutated
 from ._mappers import (
     FallbackMapper,
+    UnmappedEventError,
     build_messages_snapshot,
     build_state_snapshot,
     default_mappers,
@@ -83,6 +84,7 @@ class AGUIAdapter:
         mappers: list[EventMapper] | None = None,
         include_reducers: bool | list[str] = True,
         error_message: str | None = None,
+        on_unmapped: Literal["warn", "ignore", "raise"] = "warn",
     ) -> None:
         if resume_factory is not None and graph._checkpointer is None:
             raise ValueError(
@@ -104,10 +106,16 @@ class AGUIAdapter:
                 f"got {type(include_reducers).__name__}"
             )
 
+        if on_unmapped not in ("warn", "ignore", "raise"):
+            raise ValueError(
+                f"on_unmapped must be 'warn', 'ignore', or 'raise', got {on_unmapped!r}"
+            )
+
         self._graph = graph
         self._seed_factory = seed_factory
         self._resume_factory = resume_factory
         self._error_message = error_message
+        self._on_unmapped = on_unmapped
         self._seed_accepts_state = self._accepts_extra_positional(seed_factory)
         self._resume_accepts_state = (
             self._accepts_extra_positional(resume_factory)
@@ -136,10 +144,10 @@ class AGUIAdapter:
         )
 
         # Build mapper chain: built-ins → user mappers → fallback
-        chain: list[Any] = default_mappers()
+        chain: list[Any] = default_mappers(on_unmapped)
         if mappers:
             chain.extend(mappers)
-        chain.append(FallbackMapper())
+        chain.append(FallbackMapper(on_unmapped))
         self._mappers: list[EventMapper] = chain
 
     def _project_state(self, reducers: dict[str, Any]) -> dict[str, Any]:
@@ -747,6 +755,11 @@ class AGUIAdapter:
         try:
             async for agui_event in self._stream_event_source(input_data, ctx, config):
                 yield agui_event
+
+        except UnmappedEventError:
+            # on_unmapped="raise" is a strict CI gate — propagate instead of
+            # masking it as a RunErrorEvent.
+            raise
 
         except Exception as exc:
             logger.exception("EventGraph stream failed")

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -40,6 +40,18 @@ if TYPE_CHECKING:
 _warned_classes: set[type] = set()
 
 
+class UnmappedEventError(TypeError):
+    """Raised by ``AGUIAdapter(on_unmapped="raise")`` for an event that reaches
+    the fallback path without implementing ``AGUISerializable``."""
+
+    def __init__(self, cls: type) -> None:
+        super().__init__(
+            f"{cls.__name__} has no AG-UI mapping and does not implement "
+            f"agui_dict(). Implement AGUISerializable to serialize it, register "
+            f"a custom EventMapper, or pass on_unmapped='ignore' to drop it."
+        )
+
+
 def _warn_missing_agui_dict(cls: type) -> None:
     if cls not in _warned_classes:
         _warned_classes.add(cls)
@@ -49,6 +61,20 @@ def _warn_missing_agui_dict(cls: type) -> None:
             f"to include this event in the AG-UI stream.",
             stacklevel=3,
         )
+
+
+def _handle_unmapped(cls: type, on_unmapped: str) -> list[BaseEvent]:
+    """Apply the ``on_unmapped`` policy to an event with no AG-UI mapping.
+
+    ``"raise"`` raises ``UnmappedEventError``; ``"warn"`` emits the
+    once-per-class warning; ``"ignore"`` is silent. ``warn`` and ``ignore``
+    both drop the event by returning ``[]``.
+    """
+    if on_unmapped == "raise":
+        raise UnmappedEventError(cls)
+    if on_unmapped == "warn":
+        _warn_missing_agui_dict(cls)
+    return []
 
 
 def _langchain_to_agui_messages(
@@ -166,6 +192,9 @@ class InterruptedMapper:
     other ``Interrupted`` subclasses must implement ``AGUISerializable``.
     """
 
+    def __init__(self, on_unmapped: str = "warn") -> None:
+        self._on_unmapped = on_unmapped
+
     def map(self, event: Event, ctx: MapperContext) -> list[BaseEvent] | None:
         if not isinstance(event, Interrupted):
             return None
@@ -178,8 +207,7 @@ class InterruptedMapper:
                 )
             ]
         if not isinstance(event, AGUISerializable):
-            _warn_missing_agui_dict(type(event))
-            return []
+            return _handle_unmapped(type(event), self._on_unmapped)
         return [
             CustomEvent(
                 type=EventType.CUSTOM,
@@ -192,10 +220,12 @@ class InterruptedMapper:
 class FallbackMapper:
     """Map any unclaimed event to AG-UI CustomEvent."""
 
+    def __init__(self, on_unmapped: str = "warn") -> None:
+        self._on_unmapped = on_unmapped
+
     def map(self, event: Event, ctx: MapperContext) -> list[BaseEvent] | None:
         if not isinstance(event, AGUISerializable):
-            _warn_missing_agui_dict(type(event))
-            return []
+            return _handle_unmapped(type(event), self._on_unmapped)
         name = (
             event.agui_event_name
             if isinstance(event, AGUICustomEvent)
@@ -210,12 +240,12 @@ class FallbackMapper:
         ]
 
 
-def default_mappers() -> list[Any]:
+def default_mappers(on_unmapped: str = "warn") -> list[Any]:
     """Return the default mapper chain in priority order."""
     return [
         SkipInternalMapper(),
         FrontendToolCallRequestedMapper(),
-        InterruptedMapper(),
+        InterruptedMapper(on_unmapped),
         # FallbackMapper is always last — added by the adapter after user mappers
     ]
 

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -32,6 +32,7 @@ from langgraph_events.agui import (
     FrontendToolCallRequested,
     InterruptedWithPayload,
     MapperContext,
+    UnmappedEventError,
     build_langchain_tools,
     detect_new_tool_results,
 )
@@ -88,6 +89,10 @@ class ApprovalRequested(Interrupted):
 
     def agui_dict(self) -> dict[str, Any]:
         return {"draft": self.draft}
+
+
+class PlainInterrupt(Interrupted):
+    """An Interrupted subclass with no AG-UI mapping (no agui_dict())."""
 
 
 class _ReviewPayload(dict):
@@ -633,6 +638,108 @@ def describe_AGUIAdapter():
                 # Each class warned exactly once
                 assert len(nodict1_warnings) == 1
                 assert len(nodict2_warnings) == 1
+
+        def when_on_unmapped_policy():
+            async def it_ignore_suppresses_warning_but_still_emits_serializable():
+                @on(UserAsked)
+                def emit_plain(event: UserAsked) -> PlainEvent:
+                    return PlainEvent(value="hi")
+
+                @on(PlainEvent)
+                def emit_dict(event: PlainEvent) -> TaskCreated:
+                    return TaskCreated(title="ok")
+
+                graph = EventGraph(
+                    [emit_plain, emit_dict], reducers=[message_reducer()]
+                )
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="go"),
+                    on_unmapped="ignore",
+                )
+                _warned_classes.discard(PlainEvent)
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    events = await _collect(adapter, _make_input())
+
+                assert not any("PlainEvent" in str(x.message) for x in w)
+                serialized = [
+                    e
+                    for e in events
+                    if e.type == EventType.CUSTOM and e.name == "TaskCreated"
+                ]
+                assert len(serialized) == 1
+                assert serialized[0].value == {"title": "ok"}
+
+            async def it_raise_raises_unmapped_event_error_naming_class():
+                @on(UserAsked)
+                def emit_plain(event: UserAsked) -> PlainEvent:
+                    return PlainEvent(value="hi")
+
+                graph = EventGraph([emit_plain], reducers=[message_reducer()])
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="go"),
+                    on_unmapped="raise",
+                )
+                with pytest.raises(UnmappedEventError, match="PlainEvent"):
+                    await _collect(adapter, _make_input())
+
+            def it_unmapped_event_error_is_a_typeerror():
+                assert issubclass(UnmappedEventError, TypeError)
+
+            async def it_applies_to_interrupted_mapper_ignore():
+                @on(UserAsked)
+                def ask(event: UserAsked) -> PlainInterrupt:
+                    return PlainInterrupt()
+
+                graph = EventGraph(
+                    [ask],
+                    checkpointer=MemorySaver(),
+                    reducers=[message_reducer()],
+                )
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="go"),
+                    on_unmapped="ignore",
+                )
+                _warned_classes.discard(PlainInterrupt)
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    events = await _collect(adapter, _make_input())
+
+                assert not any("PlainInterrupt" in str(x.message) for x in w)
+                # No "interrupted" custom event emitted for the dropped interrupt.
+                assert not any(
+                    e.type == EventType.CUSTOM and e.name == "interrupted"
+                    for e in events
+                )
+
+            async def it_applies_to_interrupted_mapper_raise():
+                @on(UserAsked)
+                def ask(event: UserAsked) -> PlainInterrupt:
+                    return PlainInterrupt()
+
+                graph = EventGraph(
+                    [ask],
+                    checkpointer=MemorySaver(),
+                    reducers=[message_reducer()],
+                )
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="go"),
+                    on_unmapped="raise",
+                )
+                with pytest.raises(UnmappedEventError, match="PlainInterrupt"):
+                    await _collect(adapter, _make_input())
+
+            def it_rejects_invalid_policy_value(simple_graph):
+                with pytest.raises(ValueError, match="on_unmapped"):
+                    AGUIAdapter(
+                        graph=simple_graph,
+                        seed_factory=lambda inp: UserAsked(question="go"),
+                        on_unmapped="silent",  # type: ignore[arg-type]
+                    )
 
         def when_include_reducers():
             async def it_emits_state_snapshot():


### PR DESCRIPTION
## Summary

Adds a single keyword-only policy knob to `AGUIAdapter.__init__` so apps can control the per-class warning emitted for events that reach the fallback path without implementing `AGUISerializable` (#90). In a real `EventGraph` most events are internal orchestration with no AG-UI representation, so the default warning reads as noise.

```python
def __init__(self, graph, *, seed_factory, ..., on_unmapped: Literal["warn", "ignore", "raise"] = "warn")
```

Both fallback sites — `FallbackMapper.map` and `InterruptedMapper`'s non-serializable branch — route through one shared `_handle_unmapped(cls, on_unmapped)` helper.

| value | behavior |
|---|---|
| `"warn"` *(default)* | Once-per-class `UserWarning`, then drop. **Non-breaking.** |
| `"ignore"` | Silently drop. Off-switch for mostly-internal-event apps. |
| `"raise"` | Raise `UnmappedEventError` (a `TypeError` subclass) naming the offending class, with a remediation hint. Strict CI gate. |

## Notes

- `"raise"` propagates **past** the adapter's broad `except Exception → RunErrorEvent` handler (via a dedicated `except UnmappedEventError: raise`), so strict mode is a hard failure rather than a masked error event. This was surfaced by the `raise` test during TDD and is covered for both the fallback and interrupt code paths.
- Serializable events and `InterruptedWithPayload` are unaffected — decision order is unchanged: serializable → emit, otherwise → policy.
- `UnmappedEventError` is exported from `langgraph_events.agui`.

## Acceptance criteria

- [x] `on_unmapped="ignore"` emits no warning for unmapped events; serializable events still emit.
- [x] `on_unmapped="raise"` raises `UnmappedEventError` (subclass of `TypeError`) naming the class, with a remediation hint.
- [x] Default (`"warn"`) unchanged: once-per-class `UserWarning`, output dropped.
- [x] Policy applies to **both** `FallbackMapper` and the non-serializable branch of `InterruptedMapper`.
- [x] Unit tests cover all three modes (+ invalid-value rejection); CHANGELOG + docs updated.

## Verification

- `uv run pytest tests/` → **933 passed, 1 skipped**
- `uv run ruff check` clean, `ruff format` applied, `uv run mypy src/` → no issues

Ships as **0.13.0** (default `"warn"` is byte-for-byte non-breaking). Version bump left for a separate `scripts/release.py` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)