### PR TITLE
fix: route async resume gate through aget_state (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`aresume()` / `astream_resume()` no longer crash against async-only checkpointers** (#95). The `on_unresumable` resume-pending gate introduced in 0.15.0 read checkpoint state through the **synchronous** `get_state`, which `AsyncPostgresSaver` (and any async-only checkpointer) rejects from the running event loop — raising `asyncio.InvalidStateError` before any policy (`raise`/`warn`/`halt`) could run, and taking down every async resume (including the library's own `AGUIAdapter` SSE path). The async resume gate and the async `on_unresumable` policy arms now read and write checkpoint state exclusively through the async API (`aget_state`/`aupdate_state`), matching how `ainvoke()`-based flows already behave. The sync `resume()`/`stream_resume()` paths are unchanged.
+
+### Added
+- **`EventGraph.aget_state(config)` — async sibling of `get_state()`.** Reads event-level thread state through the async checkpointer API, so deployments on async-only checkpointers can inspect a thread's state and interrupt status from within the event loop without tripping `InvalidStateError`.
+
 ## [0.16.0] - 2026-06-08
 
 ### Added

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -1099,6 +1099,18 @@ class EventGraph:
             return True
         return bool(self._compile().get_state(config).next)
 
+    async def _aresume_is_pending(self, kwargs: dict[str, Any]) -> bool:
+        """Async sibling of :meth:`_resume_is_pending`.
+
+        Reads the checkpoint via ``aget_state`` so the async resume entry
+        points (:meth:`aresume`/:meth:`astream_resume`) never drive an
+        async-only checkpointer synchronously from the running event loop.
+        """
+        config = kwargs.get("config")
+        if config is None:
+            return True
+        return bool((await self._compile().aget_state(config)).next)
+
     def _unresumable_message(self) -> str:
         return (
             "resume() called on a thread that is not awaiting input. The paused "
@@ -1107,20 +1119,22 @@ class EventGraph:
             "handler, or set EventGraph(on_unresumable='halt'|'warn')."
         )
 
-    def _unresumable_raise_or_warn(self, kwargs: dict[str, Any]) -> EventLog | None:
+    def _unresumable_raise_or_warn(self) -> bool:
         """Shared ``raise``/``warn`` arm of the ``on_unresumable`` policy.
 
-        ``raise`` raises; ``warn`` warns and returns the unchanged log; ``halt``
-        returns ``None`` so the (sync or async) caller appends the terminal
-        event itself. Keeps the policy ladder in one place across the sync and
-        async resume paths.
+        ``raise`` raises; ``warn`` warns and returns ``True`` so the (sync or
+        async) caller returns the unchanged log via the read method that suits
+        its path; ``halt`` returns ``False`` so the caller appends the terminal
+        event itself. The state read is deliberately left to the caller: the
+        async path must use ``aget_state`` (an async-only checkpointer rejects
+        sync reads from the running loop). Keeps the policy ladder in one place.
         """
         if self._on_unresumable == "raise":
             raise UnresumableError(self._unresumable_message())
         if self._on_unresumable == "warn":
             warnings.warn(self._unresumable_message(), stacklevel=4)
-            return self.get_state(kwargs.get("config")).events
-        return None
+            return True
+        return False
 
     def _apply_unresumable_policy(
         self, value: Event, kwargs: dict[str, Any]
@@ -1132,10 +1146,9 @@ class EventGraph:
         ends observably; the thread is already inert (not pending), so
         ``update_state`` only records the event.
         """
-        log = self._unresumable_raise_or_warn(kwargs)
-        if log is not None:
-            return log
         config = kwargs.get("config")
+        if self._unresumable_raise_or_warn():
+            return self.get_state(config).events
         self._compile().update_state(
             cast("RunnableConfig", config),
             {"events": [self._unresumable_event(value)]},
@@ -1146,18 +1159,18 @@ class EventGraph:
     async def _aapply_unresumable_policy(
         self, value: Event, kwargs: dict[str, Any]
     ) -> EventLog:
-        """Async sibling of :meth:`_apply_unresumable_policy` — ``halt`` uses
-        ``aupdate_state`` so async checkpointers aren't driven synchronously."""
-        log = self._unresumable_raise_or_warn(kwargs)
-        if log is not None:
-            return log
+        """Async sibling of :meth:`_apply_unresumable_policy` — every checkpoint
+        read/write uses the async API (``aget_state``/``aupdate_state``) so
+        async-only checkpointers aren't driven synchronously."""
         config = kwargs.get("config")
+        if self._unresumable_raise_or_warn():
+            return (await self.aget_state(config)).events
         await self._compile().aupdate_state(
             cast("RunnableConfig", config),
             {"events": [self._unresumable_event(value)]},
             as_node="__seed__",
         )
-        return self.get_state(config).events
+        return (await self.aget_state(config)).events
 
     @staticmethod
     def _unresumable_event(value: Event) -> Unresumable:
@@ -1183,15 +1196,16 @@ class EventGraph:
         awaiting input, the ``on_unresumable`` policy applies (default raise).
         """
         self._require_checkpointer("aresume")
-        if not self._resume_is_pending(kwargs):
+        if not await self._aresume_is_pending(kwargs):
             return await self._aapply_unresumable_policy(value, kwargs)
         return await self._arun(LGCommand(resume=value), **kwargs)
 
-    def get_state(self, config: Any) -> GraphState:
-        """Get event-level state of a checkpointed thread."""
-        self._require_checkpointer("get_state")
-        compiled = self._compile()
-        snapshot = compiled.get_state(config)
+    def _graph_state(self, snapshot: Any) -> GraphState:
+        """Build a :class:`GraphState` from a checkpoint snapshot.
+
+        Shared by the sync :meth:`get_state` and async :meth:`aget_state` so
+        the snapshot-to-state logic stays in one place across both paths.
+        """
         all_events = snapshot.values.get("events", [])
         log = EventLog(all_events)
         # Determine interrupt status from the snapshot.
@@ -1204,6 +1218,21 @@ class EventGraph:
             is_interrupted=is_interrupted,
             interrupted=log.latest(Interrupted) if is_interrupted else None,
         )
+
+    def get_state(self, config: Any) -> GraphState:
+        """Get event-level state of a checkpointed thread."""
+        self._require_checkpointer("get_state")
+        return self._graph_state(self._compile().get_state(config))
+
+    async def aget_state(self, config: Any) -> GraphState:
+        """Async version of :meth:`get_state`.
+
+        Reads the checkpoint via ``aget_state`` so async-only checkpointers
+        (e.g. ``AsyncPostgresSaver``) aren't driven synchronously from the
+        running event loop.
+        """
+        self._require_checkpointer("aget_state")
+        return self._graph_state(await self._compile().aget_state(config))
 
     # --- LLM token helpers ---
 
@@ -1632,7 +1661,7 @@ class EventGraph:
                 from LangGraph.
         """
         self._require_checkpointer("astream_resume")
-        if not self._resume_is_pending(kwargs):
+        if not await self._aresume_is_pending(kwargs):
             # raises for the 'raise' policy; warn/halt return a log to adapt
             log = await self._aapply_unresumable_policy(value, kwargs)
             if self._on_unresumable == "halt":

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
     from langchain_core.runnables import RunnableConfig
     from langgraph.graph.state import CompiledStateGraph
     from langgraph.store.base import BaseStore
+    from langgraph.types import StateSnapshot
 
     from langgraph_events._reducer import BaseReducer
 
@@ -1119,15 +1120,13 @@ class EventGraph:
             "handler, or set EventGraph(on_unresumable='halt'|'warn')."
         )
 
-    def _unresumable_raise_or_warn(self) -> bool:
-        """Shared ``raise``/``warn`` arm of the ``on_unresumable`` policy.
-
-        ``raise`` raises; ``warn`` warns and returns ``True`` so the (sync or
-        async) caller returns the unchanged log via the read method that suits
-        its path; ``halt`` returns ``False`` so the caller appends the terminal
-        event itself. The state read is deliberately left to the caller: the
-        async path must use ``aget_state`` (an async-only checkpointer rejects
-        sync reads from the running loop). Keeps the policy ladder in one place.
+    def _unresumable_short_circuits(self) -> bool:
+        """Apply the ``raise``/``warn`` arm of ``on_unresumable``; return whether
+        the caller should short-circuit (``True`` for ``warn`` — return the log
+        unchanged) rather than append a terminal event (``False`` for ``halt``).
+        ``raise`` raises. The state read is left to the caller so each path uses
+        the matching reader (the async path must ``await aget_state`` — an
+        async-only checkpointer rejects sync reads from the running loop).
         """
         if self._on_unresumable == "raise":
             raise UnresumableError(self._unresumable_message())
@@ -1147,7 +1146,7 @@ class EventGraph:
         ``update_state`` only records the event.
         """
         config = kwargs.get("config")
-        if self._unresumable_raise_or_warn():
+        if self._unresumable_short_circuits():
             return self.get_state(config).events
         self._compile().update_state(
             cast("RunnableConfig", config),
@@ -1163,7 +1162,7 @@ class EventGraph:
         read/write uses the async API (``aget_state``/``aupdate_state``) so
         async-only checkpointers aren't driven synchronously."""
         config = kwargs.get("config")
-        if self._unresumable_raise_or_warn():
+        if self._unresumable_short_circuits():
             return (await self.aget_state(config)).events
         await self._compile().aupdate_state(
             cast("RunnableConfig", config),
@@ -1200,7 +1199,7 @@ class EventGraph:
             return await self._aapply_unresumable_policy(value, kwargs)
         return await self._arun(LGCommand(resume=value), **kwargs)
 
-    def _graph_state(self, snapshot: Any) -> GraphState:
+    def _graph_state(self, snapshot: StateSnapshot) -> GraphState:
         """Build a :class:`GraphState` from a checkpoint snapshot.
 
         Shared by the sync :meth:`get_state` and async :meth:`aget_state` so

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -13,6 +13,7 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
+from langgraph.checkpoint.memory import MemorySaver
 
 from langgraph_events import (
     STATE_SNAPSHOT_EVENT_NAME,
@@ -35,6 +36,8 @@ from langgraph_events import (
     ScalarReducer,
     Scatter,
     SystemPromptSet,
+    Unresumable,
+    UnresumableError,
     aemit_custom,
     aemit_state_snapshot,
     emit_custom,
@@ -4812,6 +4815,159 @@ def describe_on_unresumable():
 
             with pytest.raises(UnresumableError):
                 asyncio.run(drain())
+
+
+class _AsyncOnlySaver(MemorySaver):
+    """Mimics ``AsyncPostgresSaver``: a synchronous checkpoint read from a
+    running event loop is rejected.
+
+    Async-only checkpointers raise ``InvalidStateError`` on sync checkpointer
+    access issued from the running loop; ``MemorySaver`` allows it, which is
+    why ``MemorySaver``-only suites miss the async-resume regression (#95).
+    The sync ``get_tuple`` is guarded so any sync ``get_state`` on the async
+    path trips it; ``aget_tuple`` is overridden to reach the in-memory store
+    *without* the guard, because a real async saver has a genuinely separate
+    async implementation (``MemorySaver``'s merely delegates to the now-guarded
+    sync method).
+    """
+
+    @staticmethod
+    def _reject_in_loop() -> None:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return  # no running loop (sync setup) — allow
+        raise asyncio.InvalidStateError(
+            "Synchronous calls to AsyncPostgresSaver are only allowed from a "
+            "different thread."
+        )
+
+    def get_tuple(self, config):  # type: ignore[override]
+        self._reject_in_loop()
+        return super().get_tuple(config)
+
+    async def aget_tuple(self, config):  # type: ignore[override]
+        return super().get_tuple(config)  # unguarded async path
+
+
+def describe_async_only_checkpointer():
+    # #95: aresume()/astream_resume() must not drive an async-only checkpointer
+    # (e.g. AsyncPostgresSaver) synchronously. The resume-pending gate and the
+    # on_unresumable policy reads previously went through sync get_state, which
+    # such a checkpointer rejects from the running event loop.
+
+    async def _apaused(saver, tid):
+        """Pause a thread inside ``waiter`` via ainvoke; return its config."""
+
+        @on(Started)
+        def waiter(event: Started) -> _Pause:
+            return _Pause()
+
+        @on(_Go)
+        def go(event: _Go) -> None:
+            return None
+
+        cfg = {"configurable": {"thread_id": tid}}
+        await EventGraph([waiter, go], checkpointer=saver).ainvoke(
+            Started(data="x"), config=cfg
+        )
+        return cfg
+
+    def when_the_thread_is_genuinely_pending():
+        def without_sync_checkpointer_access():
+            @pytest.mark.asyncio
+            async def it_aresumes():
+                @on(Started)
+                def waiter(event: Started) -> _Pause:
+                    return _Pause()
+
+                @on(_Go)
+                def go(event: _Go) -> Ended:
+                    return Ended(result="went")
+
+                saver = _AsyncOnlySaver()
+                cfg = {"configurable": {"thread_id": "async-only-aresume"}}
+                graph = EventGraph([waiter, go], checkpointer=saver)
+                await graph.ainvoke(Started(data="x"), config=cfg)
+
+                log = await graph.aresume(_Go(), config=cfg)
+                assert log.latest(Resumed) is not None
+                assert log.latest(Ended) == Ended(result="went")
+
+            @pytest.mark.asyncio
+            async def it_astream_resumes():
+                @on(Started)
+                def waiter(event: Started) -> _Pause:
+                    return _Pause()
+
+                @on(_Go)
+                def go(event: _Go) -> Ended:
+                    return Ended(result="went")
+
+                saver = _AsyncOnlySaver()
+                cfg = {"configurable": {"thread_id": "async-only-astream"}}
+                graph = EventGraph([waiter, go], checkpointer=saver)
+                await graph.ainvoke(Started(data="x"), config=cfg)
+
+                events = [e async for e in graph.astream_resume(_Go(), config=cfg)]
+                assert any(isinstance(e, Ended) for e in events)
+
+    def when_the_thread_is_not_pending():
+        @pytest.mark.asyncio
+        async def it_aresume_raises_under_default_policy():
+            saver = _AsyncOnlySaver()
+            cfg = await _apaused(saver, "async-only-raise")
+
+            @on(_Go)
+            def go(event: _Go) -> None:
+                return None
+
+            v2 = EventGraph([go], checkpointer=saver)  # waiter removed
+            with pytest.raises(UnresumableError):
+                await v2.aresume(_Go(), config=cfg)
+
+        @pytest.mark.asyncio
+        async def it_aresume_warns_and_leaves_the_log_unchanged():
+            saver = _AsyncOnlySaver()
+            cfg = await _apaused(saver, "async-only-warn")
+
+            @on(_Go)
+            def go(event: _Go) -> None:
+                return None
+
+            v2 = EventGraph([go], checkpointer=saver, on_unresumable="warn")
+            with pytest.warns(UserWarning, match="not awaiting input"):
+                log = await v2.aresume(_Go(), config=cfg)
+
+            assert not any(isinstance(e, Halted) for e in log)
+
+        @pytest.mark.asyncio
+        async def it_aresume_halt_finalizes_the_thread_terminally():
+            saver = _AsyncOnlySaver()
+            cfg = await _apaused(saver, "async-only-halt")
+
+            @on(_Go)
+            def go(event: _Go) -> None:
+                return None
+
+            v2 = EventGraph([go], checkpointer=saver, on_unresumable="halt")
+            log = await v2.aresume(_Go(), config=cfg)
+
+            assert isinstance(log.latest(Unresumable), Halted)
+
+        @pytest.mark.asyncio
+        async def it_astream_resume_halt_yields_the_terminal_event():
+            saver = _AsyncOnlySaver()
+            cfg = await _apaused(saver, "async-only-astream-halt")
+
+            @on(_Go)
+            def go(event: _Go) -> None:
+                return None
+
+            v2 = EventGraph([go], checkpointer=saver, on_unresumable="halt")
+            events = [e async for e in v2.astream_resume(_Go(), config=cfg)]
+
+            assert any(isinstance(e, Unresumable) for e in events)
 
 
 def describe_assert_resume_recovers():

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -4825,10 +4825,10 @@ class _AsyncOnlySaver(MemorySaver):
     access issued from the running loop; ``MemorySaver`` allows it, which is
     why ``MemorySaver``-only suites miss the async-resume regression (#95).
     The sync ``get_tuple`` is guarded so any sync ``get_state`` on the async
-    path trips it; ``aget_tuple`` is overridden to reach the in-memory store
-    *without* the guard, because a real async saver has a genuinely separate
-    async implementation (``MemorySaver``'s merely delegates to the now-guarded
-    sync method).
+    path trips it; both ``get_tuple`` and ``aget_tuple`` reach the store through
+    a shared ``_unguarded_get_tuple`` so the async path never routes through the
+    guarded sync sibling — a real async saver has a genuinely separate async
+    implementation (``MemorySaver``'s merely delegates to the sync method).
     """
 
     @staticmethod
@@ -4842,12 +4842,15 @@ class _AsyncOnlySaver(MemorySaver):
             "different thread."
         )
 
-    def get_tuple(self, config):  # type: ignore[override]
-        self._reject_in_loop()
+    def _unguarded_get_tuple(self, config):
         return super().get_tuple(config)
 
+    def get_tuple(self, config):  # type: ignore[override]
+        self._reject_in_loop()
+        return self._unguarded_get_tuple(config)
+
     async def aget_tuple(self, config):  # type: ignore[override]
-        return super().get_tuple(config)  # unguarded async path
+        return self._unguarded_get_tuple(config)
 
 
 def describe_async_only_checkpointer():
@@ -4953,7 +4956,7 @@ def describe_async_only_checkpointer():
             v2 = EventGraph([go], checkpointer=saver, on_unresumable="halt")
             log = await v2.aresume(_Go(), config=cfg)
 
-            assert isinstance(log.latest(Unresumable), Halted)
+            assert log.latest(Unresumable) is not None
 
         @pytest.mark.asyncio
         async def it_astream_resume_halt_yields_the_terminal_event():


### PR DESCRIPTION
Fixes #95.

## Problem

`EventGraph.aresume()` / `astream_resume()` raise `asyncio.InvalidStateError` against an async-only checkpointer (`AsyncPostgresSaver`). The `on_unresumable` resume-pending gate added in 0.15.0 reads checkpoint state through the **synchronous** `get_state`, which such checkpointers reject from the running event loop — failing *before* any policy (`raise`/`warn`/`halt`) can run, and taking down every async resume including the library's own `AGUIAdapter` SSE path. `MemorySaver` allows in-loop sync access, so the existing suite missed the regression.

## Fix

All async resume reads/writes now go through the async checkpointer API:

- Extract snapshot→`GraphState` into a shared `_graph_state` helper; add public **`aget_state()`** (async sibling of `get_state()`).
- Add async gate **`_aresume_is_pending`** reading via `aget_state`.
- Decouple `_unresumable_raise_or_warn` from the state read (returns a bool); the async policy arm reads/writes via `aget_state`/`aupdate_state`.
- Point `aresume`/`astream_resume` at the async gate. Sync `resume`/`stream_resume` unchanged.

## Tests

New `describe_async_only_checkpointer` block with an `_AsyncOnlySaver` double mimicking `AsyncPostgresSaver` (sync `get_tuple` rejected in-loop; async path bypasses the guard). Covers happy-path `aresume`/`astream_resume` plus all three `on_unresumable` policies. Verified red (6 failures with `InvalidStateError` at the gate) → green.

## Verification

- Full suite: 969 passed, 1 skipped
- `ruff check`, `ruff format --check`, `mypy src/` (strict): clean
- CHANGELOG `[Unreleased]` updated (Fixed #95 + Added `aget_state`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)