### PR TITLE
fix: stable order-independent identity for inline Command.handle() nodes (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Inline `Command.handle()` nodes now have a stable, order-independent checkpoint identity** (#97). Inline command handlers were registered as graph nodes named after the method (`handle`) and then de-duplicated **positionally** (`handle`, `handle_2`, …) by their order in `EventGraph(handlers=[...])`. Because several `Command.handle()` methods are real pause points (they return `Interrupted` / AG-UI `FrontendToolCallRequested`), a checkpoint could pause *inside* one of these positionally-named nodes — so reordering `handlers=[...]` silently remapped which command each `handle_N` dispatched to, with nothing in the baseline/coverage tooling able to detect it (the baseline stores a reorder-invariant sorted set of names). Inline command-handler nodes are now keyed by the command's `__qualname__` (e.g. `Order.Place`) — the same stable identity used elsewhere for command privacy and return contracts — so the node a paused checkpoint resumes into never depends on registration order. `graph.handler_names`, the resume gate, and `write_baseline`'s `handlers` list all record these qualname identities. The human-readable handler label shown in choreography / mermaid / `HandlerRaised`/`InvariantViolated` diagnostics is unchanged (still the method name).
+
+### Changed
+- **Inline command handler baselines must be regenerated once after upgrading** (#97). A pre-#97 baseline recorded inline command handlers by their positional `handle`/`handle_N` names, which no longer resolve to a live node — so `assert_all_baselined_handlers_cover` will (correctly) raise `HandlerCoverageError` until you run `write_baseline(graph, BASELINE)` to re-record the qualname identities. A checkpoint that was paused inside an inline command handler under the old positional name before the upgrade will not resume afterward (the old name was order-dependent and cannot be reconstructed safely); recover a specific in-flight checkpoint by adding `@on(previously="handle_N")` to that command's handler, or set `EventGraph(on_unresumable="halt"|"warn")` to degrade gracefully.
+
 ## [0.17.0] - 2026-06-08
 
 ### Fixed

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,7 +33,7 @@ Modifiers:
 - `*field_matchers` — [field dispatch](control-flow.md#field-matchers); `type` values do `isinstance`, `str` values do equality.
 - `raises=` — [declared exceptions](control-flow.md#handler-exceptions).
 - `invariants={InvariantClass: predicate}` — [preconditions](control-flow.md#invariants).
-- `node_name=` — pin a **stable node identity** (defaults to the function name) so renaming the function never breaks an interrupted checkpoint. `previously=` (str or tuple) — historic node names to keep resumable after a rename. Both are reserved (a field named `node_name`/`previously` can't be matched via `**field_matchers`). See [Handler renames](event-migrations.md#handler-renames).
+- `node_name=` — pin a **stable node identity** (defaults to the function name) so renaming the function never breaks an interrupted checkpoint. `previously=` (str or tuple) — historic node names to keep resumable after a rename. Both are reserved (a field named `node_name`/`previously` can't be matched via `**field_matchers`). Inline `Command.handle()` handlers default their node identity to the **command's `__qualname__`** (e.g. `Order.Place`), not the method name, so it is stable regardless of `handlers=[...]` order. See [Handler renames](event-migrations.md#handler-renames).
 
 Returns enforced against the declared annotation, or the subscribed `Command.Outcomes` when unannotated.
 

--- a/docs/event-migrations.md
+++ b/docs/event-migrations.md
@@ -378,6 +378,13 @@ def confirm(event: Confirmed) -> Approved: ...
 
     The CI handler gate catches undeclared renames *before* deploy; `on_unresumable` is the runtime last-resort net for anything that slips through.
 
+### Inline command handlers are keyed by the command qualname
+
+An inline `Command.handle()` handler's node identity is the **command's `__qualname__`** (e.g. `Order.Place`), not the method name — so it is stable and order-independent. Reordering the `handlers=[...]` list is safe, and you do **not** need `@on(node_name=...)` to pin it (that pin is for standalone `@on` functions, whose identity is otherwise the function name).
+
+!!! note "Upgrading a baseline recorded before this fix (#97)"
+    Earlier releases recorded inline command handlers by positional names (`handle`, `handle_2`, …). After upgrading, those names no longer resolve, so `assert_all_baselined_handlers_cover` will raise `HandlerCoverageError` until you **regenerate the baseline once** with `write_baseline(graph, BASELINE)`. This firing is expected — it is the gate doing its job. A checkpoint paused inside an inline command handler *before* the upgrade cannot resume afterward (the old positional name was order-dependent and can't be reconstructed); recover a specific one with `@on(previously="handle_N")` on that command's handler, or set `on_unresumable="halt"/"warn"`.
+
 ### Renaming an event *and* a handler together
 
 The two tracks are independent — do both, in one PR:

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -480,13 +480,44 @@ def _validate_on_unresumable(value: str) -> None:
         )
 
 
+def _validate_handler_metas(metas: list[HandlerMeta]) -> None:
+    """Run all build-time handler-identity checks (node names, then aliases)."""
+    _validate_node_names(metas)
+    _validate_handler_aliases(metas)
+
+
+def _validate_node_names(metas: list[HandlerMeta]) -> None:
+    """Raise if two handlers resolve to the same graph-node identity.
+
+    ``node_name`` uniqueness is the invariant interrupted checkpoints depend on:
+    a paused thread resumes into the node of that name, so two handlers sharing
+    one is a silent mis-dispatch. Display-name collisions are deduplicated
+    positionally, but ``node_name`` is not (an inline command's qualname or an
+    ``@on(node_name=...)`` pin is taken as-is) — so guard it explicitly and fail
+    at build time with a clear message rather than an opaque LangGraph
+    ``add_node`` error at compile. The usual trigger is the same command (or two
+    handlers pinned to the same name) registered twice in ``handlers=[...]``.
+    """
+    seen: dict[str, HandlerMeta] = {}
+    for meta in metas:
+        prior = seen.get(meta.node_name)
+        if prior is not None:
+            raise ValueError(
+                f"Handlers {prior.name!r} and {meta.name!r} both resolve to "
+                f"graph node {meta.node_name!r}; node identity must be unique. "
+                f"Register each command/handler once, or give one a distinct "
+                f"@on(node_name=...)."
+            )
+        seen[meta.node_name] = meta
+
+
 def _validate_handler_aliases(metas: list[HandlerMeta]) -> None:
     """Raise if any ``@on(previously=...)`` alias is unusable.
 
     Each historic node name becomes a real graph node, so it must be unique
     and must not shadow a live handler node — surfaced at build time.
     """
-    live_names = {meta.name for meta in metas}
+    live_names = {meta.node_name for meta in metas}
     seen_aliases: set[str] = set()
     for meta in metas:
         for alias in meta.previous_names:
@@ -548,6 +579,24 @@ def _verify_no_unclaimed_params(meta: HandlerMeta) -> None:
             f"a matching instance via EventGraph(services=[...]); for state, "
             f"register a Reducer; otherwise remove the parameter."
         )
+
+
+def _dedup_handler_name(meta: HandlerMeta, count: int) -> HandlerMeta:
+    """Suffix a colliding display name positionally (``handle`` → ``handle_2``).
+
+    The stable ``node_name`` (graph / checkpoint identity) follows the
+    deduplicated name for ordinary handlers, but an inline ``Command.handle()``
+    handler keeps its command-qualname ``node_name`` untouched — so reordering
+    ``handlers=[...]`` never remaps which command a paused checkpoint resumes
+    into. See issue #97.
+    """
+    deduped = f"{meta.name}_{count}"
+    # An inline command (or an @on(node_name=...) pin) owns an identity distinct
+    # from its display name — keep it; an ordinary handler's identity *is* its
+    # name, so it follows the dedup suffix.
+    has_stable_identity = meta.node_name != meta.name
+    node_name = meta.node_name if has_stable_identity else deduped
+    return dataclasses.replace(meta, name=deduped, node_name=node_name)
 
 
 def _expand_command_handlers(
@@ -669,19 +718,16 @@ class EventGraph:
                 service_names=service_names,
             )
             _verify_no_unclaimed_params(meta)
-            # Deduplicate node names — preserve all other meta fields
-            # (raises, field_matchers, field_inject_params, ...) so the second
-            # copy behaves identically to the first.
+            # Deduplicate colliding display names positionally; see
+            # _dedup_handler_name for how the stable node identity is preserved.
             if meta.name in seen_names:
                 seen_names[meta.name] += 1
-                meta = dataclasses.replace(
-                    meta, name=f"{meta.name}_{seen_names[meta.name]}"
-                )
+                meta = _dedup_handler_name(meta, seen_names[meta.name])
             else:
                 seen_names[meta.name] = 1
             self._handler_metas.append(meta)
 
-        _validate_handler_aliases(self._handler_metas)
+        _validate_handler_metas(self._handler_metas)
 
         self._return_info: dict[str, ReturnInfo] = {}
         self._return_contracts: dict[str, ReturnContract | None] = {}
@@ -757,9 +803,11 @@ class EventGraph:
 
         These are the names an interrupted checkpoint can pause at;
         ``@on(previously=...)`` aliases are excluded (use them to *cover* a
-        renamed name, not to enumerate live handlers).
+        renamed name, not to enumerate live handlers). For inline
+        ``Command.handle()`` handlers this is the command's ``__qualname__``
+        (stable, order-independent), not the method name.
         """
-        return frozenset(meta.name for meta in self._handler_metas)
+        return frozenset(meta.node_name for meta in self._handler_metas)
 
     @property
     def compiled(self) -> CompiledStateGraph:
@@ -814,8 +862,8 @@ class EventGraph:
                 services_by_type=self._services_by_type or None,
                 services_by_name=self._services_by_name or None,
             )
-            graph.add_node(meta.name, cast("Any", handler_node))
-            handler_names.append(meta.name)
+            graph.add_node(meta.node_name, cast("Any", handler_node))
+            handler_names.append(meta.node_name)
             # Register an alias node per historic name (@on(previously=...)) so an
             # interrupted checkpoint paused at the old node re-enters the same
             # handler on resume. The dispatcher only ever returns canonical

--- a/src/langgraph_events/_handler.py
+++ b/src/langgraph_events/_handler.py
@@ -14,6 +14,7 @@ from langgraph_events._event import Event, Invariant
 from langgraph_events._event_log import (
     EventLog,
 )
+from langgraph_events._identity import command_identity
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -342,6 +343,13 @@ class HandlerMeta:
     event_types: tuple[type[Event], ...]
     log_param: str | None
     is_async: bool
+    # Stable graph-node / checkpoint identity. Equals ``name`` for ordinary
+    # handlers, but for inline ``Command.handle()`` handlers it is the command's
+    # ``__qualname__`` (e.g. ``Order.Place``) so the node a paused checkpoint
+    # resumes into never depends on ``handlers=[...]`` order. ``name`` stays the
+    # human-readable handler label used in choreography/mermaid/diagnostics.
+    # Required — always populated by ``extract_handler_meta``; never empty.
+    node_name: str
     # Historic node names this handler answered to, declared via
     # ``@on(previously=...)``. The graph registers an alias node per name so an
     # interrupted checkpoint paused at the old node still resumes after a rename.
@@ -602,8 +610,18 @@ def extract_handler_meta(
             ),
         )
 
+    name = getattr(fn, "_node_name", None) or fn.__name__
+    # Inline command handlers route by their command's qualname (stable,
+    # order-independent); every other handler routes by its own name. The
+    # qualname intentionally wins over any ``_node_name`` here — inline handlers
+    # never carry one today (``_expand_command_handlers`` calls bare ``on(h)``),
+    # but were that to change, command identity must stay the resume identity.
+    inline_command = getattr(fn, "_inline_command", None)
+    node_name = command_identity(inline_command) if inline_command is not None else name
+
     return HandlerMeta(
-        name=getattr(fn, "_node_name", None) or fn.__name__,
+        name=name,
+        node_name=node_name,
         fn=fn,
         event_types=tuple(event_types),
         previous_names=getattr(fn, "_previous_names", ()),

--- a/src/langgraph_events/_identity.py
+++ b/src/langgraph_events/_identity.py
@@ -1,0 +1,19 @@
+"""Stable identity strings derived from a class's ``__qualname__``.
+
+A single source of truth so the command identity used for the graph-node /
+checkpoint name (``_handler``), command-privacy diagnostics, and smell messages
+never drift apart. Pure string transform — imports nothing from the package, so
+it is safe to import from any layer without a cycle.
+"""
+
+from __future__ import annotations
+
+
+def command_identity(cls: type) -> str:
+    """Return ``cls.__qualname__`` with the ``<locals>.`` marker stripped.
+
+    Function-/test-local classes carry ``<locals>`` segments in their qualname
+    (e.g. ``outer.<locals>.Order.Place``); strip them so the identity reads as
+    the bare nesting path (``Order.Place``) wherever it is surfaced to users.
+    """
+    return cls.__qualname__.replace("<locals>.", "")

--- a/src/langgraph_events/_internal.py
+++ b/src/langgraph_events/_internal.py
@@ -218,13 +218,15 @@ def make_dispatch(
         if any(isinstance(e, Halted) for e in pending):
             return END
 
-        # Find handlers whose event_types match any pending event
+        # Find handlers whose event_types match any pending event. Route by
+        # ``node_name`` (the registered graph node), which for inline command
+        # handlers is the command qualname rather than the method name.
         matched: list[str] = []
         seen: set[str] = set()
         for meta in handler_metas:
-            if meta.name not in seen and any(meta.matches(e) for e in pending):
-                seen.add(meta.name)
-                matched.append(meta.name)
+            if meta.node_name not in seen and any(meta.matches(e) for e in pending):
+                seen.add(meta.node_name)
+                matched.append(meta.node_name)
 
         if not matched:
             return END

--- a/src/langgraph_events/_namespace/_command_privacy.py
+++ b/src/langgraph_events/_namespace/_command_privacy.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from langgraph_events._event import Command, DomainEvent
+from langgraph_events._identity import command_identity
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -75,7 +76,7 @@ def enforce_command_privacy(
 
 
 def _qualname(cls: type) -> str:
-    return cls.__qualname__.replace("<locals>.", "")
+    return command_identity(cls)
 
 
 def _unnested_outcome_msg(

--- a/src/langgraph_events/_namespace/_smells.py
+++ b/src/langgraph_events/_namespace/_smells.py
@@ -19,6 +19,8 @@ import warnings
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
+from langgraph_events._identity import command_identity
+
 if TYPE_CHECKING:
     from langgraph_events._event import Event
     from langgraph_events._namespace._model import NamespaceModel
@@ -50,7 +52,7 @@ class CommandChainWarning(UserWarning):
 
 def _qualname(cls: type) -> str:
     """Return ``cls.__qualname__`` with ``<locals>.`` strip-out for cleanliness."""
-    return cls.__qualname__.replace("<locals>.", "")
+    return command_identity(cls)
 
 
 def emit_command_chain_warnings(model: NamespaceModel) -> None:

--- a/src/langgraph_events/serde/migrations/testing.py
+++ b/src/langgraph_events/serde/migrations/testing.py
@@ -120,7 +120,7 @@ def assert_all_baselined_handlers_cover(
     passes trivially.
     """
     baselined = _load_baseline_handlers(Path(baseline_path))
-    reachable = {meta.name for meta in graph._handler_metas}
+    reachable = {meta.node_name for meta in graph._handler_metas}
     reachable |= {
         alias for meta in graph._handler_metas for alias in meta.previous_names
     }

--- a/tests/test_command_handle.py
+++ b/tests/test_command_handle.py
@@ -98,6 +98,20 @@ class WithLog(Namespace):
             return WithLog.Cmd.Done(observed_count=len(log))
 
 
+# Module-level domain whose inline handler method is named something other
+# than ``handle`` — exercises that node identity comes from the command
+# qualname, not the method ``__name__``.
+class Bazaar(Namespace):
+    class Sell(Command):
+        item: str = ""
+
+        class Sold(DomainEvent):
+            item: str = ""
+
+        def sell(self) -> Bazaar.Sell.Sold:
+            return Bazaar.Sell.Sold(item=self.item)
+
+
 # Module-level domains for inline-outcome-coverage tests. These can't live
 # inside describe_/when_ blocks because Python can't resolve forward refs on
 # handle's return annotation from a nested function scope.
@@ -431,6 +445,76 @@ def describe_Command_handle():
                 graph = EventGraph([Shop.Buy, react])
                 log = graph.invoke(Shop.Buy(item="pear"))
                 assert log.has(Shop.Buy.Bought)
+
+    def describe_inline_handler_node_identity():
+        # An inline command handler's graph-node name must be a stable,
+        # order-independent identity derived from the command's __qualname__
+        # — not the method __name__ (``handle``) deduplicated positionally
+        # (``handle``, ``handle_2``) by registration order. See issue #97.
+
+        def _name_to_command(graph: EventGraph) -> dict[str, type]:
+            return {
+                meta.node_name: meta.fn._inline_command for meta in graph._handler_metas
+            }
+
+        def when_command_registered():
+
+            def it_names_node_after_the_command_qualname():
+                graph = EventGraph([Shop3.CmdA])
+                assert graph.handler_names == frozenset({"Shop3.CmdA"})
+
+        def when_two_command_handlers_share_a_method_name():
+            # CmdA and CmdB both define ``handle``; under the old scheme they
+            # collapsed to ``handle``/``handle_2`` by list position.
+
+            def it_assigns_qualname_node_names_regardless_of_order():
+                ab = EventGraph([Shop3.CmdA, Shop3.CmdB]).handler_names
+                ba = EventGraph([Shop3.CmdB, Shop3.CmdA]).handler_names
+                assert ab == ba == frozenset({"Shop3.CmdA", "Shop3.CmdB"})
+
+            def it_keeps_the_name_to_command_mapping_stable_under_reorder():
+                ab = _name_to_command(EventGraph([Shop3.CmdA, Shop3.CmdB]))
+                ba = _name_to_command(EventGraph([Shop3.CmdB, Shop3.CmdA]))
+                assert ab == ba
+                assert ab == {
+                    "Shop3.CmdA": Shop3.CmdA,
+                    "Shop3.CmdB": Shop3.CmdB,
+                }
+
+            def it_never_produces_a_positional_handle_node():
+                names = EventGraph([Shop3.CmdA, Shop3.CmdB]).handler_names
+                assert not any("handle" in name for name in names)
+                assert not any(name.endswith("_2") for name in names)
+
+            def it_dispatches_to_the_correct_command_under_each_order():
+                for handlers in ([Shop3.CmdA, Shop3.CmdB], [Shop3.CmdB, Shop3.CmdA]):
+                    graph = EventGraph(handlers)
+                    assert graph.invoke(Shop3.CmdA()).has(Shop3.CmdA.DoneA)
+                    assert graph.invoke(Shop3.CmdB()).has(Shop3.CmdB.DoneB)
+
+        def when_handler_method_has_a_custom_name():
+
+            def it_still_uses_the_command_qualname():
+                graph = EventGraph([Bazaar.Sell])
+                assert graph.handler_names == frozenset({"Bazaar.Sell"})
+
+        def when_built_via_from_namespaces():
+
+            def it_also_uses_qualname_node_names():
+                graph = EventGraph.from_namespaces(Shop3)
+                assert graph.handler_names == frozenset({"Shop3.CmdA", "Shop3.CmdB"})
+
+        def when_two_handlers_resolve_to_the_same_node_name():
+            # node_name uniqueness is the invariant checkpoints depend on. The
+            # old positional dedup guaranteed it structurally; the qualname
+            # scheme must guard it explicitly — otherwise the collision only
+            # surfaces as an opaque LangGraph "node already present" error at
+            # compile, instead of a clear framework error at construction.
+
+            def it_raises_a_clear_error_at_construction():
+                with pytest.raises(ValueError, match=r"Shop3\.CmdA") as excinfo:
+                    EventGraph([Shop3.CmdA, Shop3.CmdA])
+                assert "node" in str(excinfo.value).lower()
 
     def describe_service_injection():
 

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -2406,6 +2406,43 @@ def describe_assert_all_baselined_handlers_cover():
                 assert isinstance(excinfo.value, CoverageError)
                 assert excinfo.value.uncovered == ("place",)
 
+    def when_baseline_recorded_old_positional_inline_command_names():
+        # Pre-#97 baselines recorded inline command handlers by their
+        # positional ``handle``/``handle_2`` names. After the fix those nodes
+        # are keyed by the command qualname, so the old names no longer
+        # resolve — the gate must fire, forcing a one-time baseline rebuild.
+
+        def it_raises_until_the_baseline_is_regenerated(tmp_path: Any):
+            import json
+
+            from langgraph_events.serde.migrations import (
+                assert_all_baselined_handlers_cover,
+            )
+            from langgraph_events.serde.migrations.detect import (
+                HandlerCoverageError,
+                write_baseline,
+            )
+
+            graph = EventGraph([Persona.Approve, Story.Approve])
+            baseline = tmp_path / "b.json"
+            baseline.write_text(
+                json.dumps(
+                    {
+                        "version": 2,
+                        "events": [],
+                        "handlers": [{"name": "handle"}, {"name": "handle_2"}],
+                    }
+                )
+            )
+
+            with pytest.raises(HandlerCoverageError) as excinfo:
+                assert_all_baselined_handlers_cover(graph, baseline)
+            assert excinfo.value.uncovered == ("handle", "handle_2")
+
+            # The documented one-time migration: regenerate the baseline.
+            write_baseline(graph, baseline)
+            assert_all_baselined_handlers_cover(graph, baseline)
+
     def when_baseline_predates_handler_tracking():
         def it_loads_a_v1_baseline_and_passes(tmp_path: Any):
             import json


### PR DESCRIPTION
## Summary

Fixes #97. Inline `Command.handle()` handlers were registered as graph nodes named after the method (`handle`) and de-duplicated **positionally** (`handle`, `handle_2`, …) by their order in `EventGraph(handlers=[...])`. Because several `Command.handle()` methods are real pause points (they return `Interrupted` / AG-UI `FrontendToolCallRequested`), a checkpoint could pause *inside* one of these positionally-named nodes — so reordering the handlers list **silently remapped which command each `handle_N` resumed into**, with nothing in the baseline/coverage tooling able to detect it (the baseline stores a reorder-invariant sorted set).

## Approach

Split the two concepts that were both riding on `HandlerMeta.name`:

- **`node_name`** (new) — the stable graph / checkpoint identity = the command's `__qualname__` (e.g. `Order.Place`). Used by the dispatcher, `handler_names`, `add_node`, alias validation, the coverage gate, and the baseline. Order-independent and unique.
- **`name`** (unchanged) — the human-readable display label (method name, still positionally deduped). Choreography / mermaid / `HandlerRaised` diagnostics are byte-for-byte unchanged.

Verified safe: LangGraph reserves only `|` and `:` in node names — dotted qualnames survive checkpoint `next`/resume round-trips.

## Backward compatibility

A documented **one-time migration**: a pre-#97 baseline's positional names no longer resolve, so `assert_all_baselined_handlers_cover` correctly raises `HandlerCoverageError` until `write_baseline(...)` is re-run. A specific in-flight checkpoint can be rescued with `@on(previously="handle_N")`, or `on_unresumable="halt"/"warn"`.

## Review-driven hardening (DHH + Gang of Four)

- Enforce `node_name` uniqueness with a clear build-time error (`_validate_node_names`) instead of an opaque LangGraph "node already present" error at compile.
- Make `HandlerMeta.node_name` a required field (no `""` sentinel).
- Single-source the command-identity string in `_identity.command_identity`, reused by `_handler`, `_command_privacy`, and `_smells`.

## Tests

- **Reorder-invariance** (the core regression): `handler_names` and the `node_name → command` mapping are identical across `[Add, Remove]` and `[Remove, Add]`.
- Qualname naming, no positional `handle_N`, custom method name, `from_namespaces` parity, dispatch correctness under both orderings.
- Node-identity uniqueness guard raises a clear error.
- Baseline interaction: old positional baseline raises, then passes after regeneration.

`978 passed, 1 skipped` · ruff · ruff format · mypy all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)