### PR TITLE
feat: lifecycle archetypes — compose shared lifecycles, keep per-entity identity (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Lifecycle archetypes — compose a shared lifecycle across domains while keeping per-entity identity** (#98). A reusable archetype `Namespace` can define a lifecycle's behavior *once* (e.g. a persistence `Persist`/`Approve` loop); consuming domains **subclass** its commands to give them their own per-entity event identity and field types, and plug in per-entity operations through a `Policy` the namespace supplies. Three pieces make this work: (1) subclassing an archetype `Command` now inherits its inline handler — the framework rebinds a **distinct** handler function per subclass, so several domains' commands coexist as graph nodes instead of tripping the `_inline_command` collision guard (a subclass that declares its own public method still overrides the inherited handler). Because archetype handlers construct outcomes reflectively (`type(self).Outcome(...)`), each subclass emits its **own** event (`Persona.Persist.Persisted` ≠ `Story.Persist.Persisted`). (2) New `namespace_of(target)` resolves the `Namespace` that owns a `Command`/`DomainEvent` (class or instance) — the bridge an archetype handler uses to reach the consuming domain's `Policy` (`namespace_of(self).Policy`), and that reactions use to dispatch per-entity (`namespace_of(event).Approve(...)`). (3) `class Foo(Namespace, uses=[Archetype])` records the composition on `Foo.__uses__` for intent + introspection (validated; no copying or aliasing). See `docs/concepts.md` (Lifecycle archetypes) and `examples/persistable.py`.
+
 ## [0.18.0] - 2026-06-08
 
 ### Fixed

--- a/docs/api.md
+++ b/docs/api.md
@@ -89,6 +89,15 @@ Returns enforced against the declared annotation, or the subscribed `Command.Out
 |---|---|---|
 | `on_namespace_finalize(cls, callback)` | Function | Schedule `callback(cls, namespace_cls)` to fire once `cls`'s enclosing `Namespace.__init_subclass__` finishes. Lets class decorators defer `typing.get_type_hints()` calls until forward references to siblings can resolve. Fires immediately if the enclosing Namespace has already finalized (e.g. when applied post-hoc to a bound class). |
 
+## Composition { #archetypes }
+
+| Export | Type | Description |
+|---|---|---|
+| `Namespace(..., uses=[Archetype])` | Class kwarg | Records that a namespace composes one or more archetype `Namespace`s (stored on `__uses__`) for intent + introspection. Validates each entry is a `Namespace`. Does not copy or alias members. |
+| `namespace_of(target)` | Function | Return the `Namespace` class that owns `target` (a `Command`/`DomainEvent` class or instance), or `None`. The bridge for [lifecycle archetypes](concepts.md#archetypes): an archetype handler running on a subclass instance calls `namespace_of(self).Policy` to reach the consuming domain's convention. |
+
+Subclassing an archetype `Command` inherits its `handle()` (the framework rebinds a distinct handler per subclass, so they coexist as graph nodes) while keeping per-entity event identity + field types. Archetype handlers must construct outcomes reflectively (`type(self).Outcome`). See [Concepts › Lifecycle archetypes](concepts.md#archetypes).
+
 ## Streaming & Frames
 
 | Export | Type | Description |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -211,6 +211,39 @@ A `Namespace` is where related features attach:
 !!! note "On `Namespace`"
     `Namespace` is a namespace — for grouping. A richer construct (with identity and size discipline) may layer on top in a future release.
 
+## Lifecycle archetypes { #archetypes }
+
+When several domains share the *same* lifecycle (e.g. a persistence `Persist` → `Approve` loop across `Persona`, `Story`, `Scenario`) but each needs its **own** event identity and field types, define the behavior once in an **archetype** `Namespace` and **subclass** its commands per domain.
+
+```python
+class Persistable(Namespace):                       # archetype — behavior once
+    class Policy(Protocol):                          # the bridge: per-entity ops
+        def persist(self, candidate: object) -> str: ...
+
+    class Persist(Command):
+        candidate: object = None
+        def handle(self):
+            policy = namespace_of(self).Policy()     # resolve the consuming domain
+            return type(self).Persisted(entity_id=policy.persist(self.candidate))
+
+class Persona(Namespace, uses=[Persistable]):
+    class Persist(Persistable.Persist):              # inherit behavior…
+        candidate: PersonaCandidate = ...            # …override the field type
+        class Persisted(DomainEvent):                # …and keep your own event
+            entity_id: str = ""
+    class Policy:                                    # implement the bridge
+        def persist(self, candidate): return persona_store.create(candidate)
+```
+
+How it works:
+
+- **Inherit, don't copy.** Subclassing an archetype command reuses its handler — the framework rebinds a *distinct* handler per subclass, so two domains' commands coexist as graph nodes (no `_inline_command` collision). The handler emits its outcome **reflectively** (`type(self).Persisted`), so each subclass yields its own per-entity event. *Archetype handlers must construct outcomes reflectively* — never hard-name the archetype's event class.
+- **The Policy bridge.** Per-entity operations live behind a `Policy` the consuming namespace supplies; the archetype handler reaches it with [`namespace_of(self)`](api.md#archetypes) — `namespace_of(self).Policy`. The same bridge works in reactions: `namespace_of(event).Approve(...)`.
+- **`uses=[…]`** records the composition on the namespace (`Persona.__uses__`) for intent and introspection. It does not copy or alias members — you reference `Persistable.Persist` / your own `Persona.Persist` directly.
+- A subclass that declares its **own** handler overrides the inherited one.
+
+Worked example: [`examples/persistable.py`](https://github.com/cadance-io/langgraph-events/blob/main/examples/persistable.py).
+
 ## System events
 
 `SystemEvent` subclasses control runtime flow; subscribe like any event. See [Control Flow](control-flow.md) for `Interrupted` / `Resumed`, `HandlerRaised`, `InvariantViolated`. Full table in [API](api.md#system-events).

--- a/examples/persistable.py
+++ b/examples/persistable.py
@@ -1,0 +1,162 @@
+"""Lifecycle archetype composition — langgraph-events demo (issue #98).
+
+A reusable *archetype* defines a lifecycle's **behavior once**; consuming
+domains inherit it while keeping their **own per-entity event identity and
+field types**, and plug in per-entity operations through a **Policy** bridge.
+
+This mirrors a real pattern: a persistence lifecycle (``Persist`` →
+``Approve``) shared across several entity domains (Persona, Story, …) that each
+carry a differently-typed candidate and persist to their own store.
+
+Key pieces:
+
+- ``Persistable`` — the archetype ``Namespace``. Its command handlers emit
+  outcomes **reflectively** (``type(self).Persisted``) and delegate per-entity
+  work to ``namespace_of(self).Policy`` — so one handler serves every domain.
+- ``Persona`` / ``Story`` — domains that ``uses=[Persistable]`` and **subclass**
+  the archetype commands to give them typed candidates + their own events, plus
+  a ``Policy`` implementation. Subclassing an archetype command rebinds a
+  distinct handler, so they coexist as graph nodes without collision.
+- One reaction, ``auto_approve``, reacts to *every* domain's ``Persisted`` via
+  ``namespace_of`` — the same bridge, at the reaction layer.
+
+Usage:
+    python examples/persistable.py
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from langgraph_events import (
+    Command,
+    DomainEvent,
+    EventGraph,
+    Namespace,
+    namespace_of,
+    on,
+)
+
+# In-memory "database" the policies persist into, keyed by domain.
+_STORE: dict[str, dict[str, object]] = {}
+
+
+class Persistable(Namespace):
+    """Archetype: the persist → approve lifecycle, defined once."""
+
+    class Policy(Protocol):
+        """The bridge: per-entity operations each consuming domain implements."""
+
+        def persist(self, candidate: object) -> str: ...
+
+        def approve(self, entity_id: str) -> None: ...
+
+    class Persist(Command):
+        candidate: object = None
+
+        def handle(self):
+            policy = namespace_of(self).Policy()
+            return type(self).Persisted(entity_id=policy.persist(self.candidate))
+
+    class Approve(Command):
+        entity_id: str = ""
+
+        def handle(self):
+            namespace_of(self).Policy().approve(self.entity_id)
+            return type(self).Approved(entity_id=self.entity_id)
+
+
+@dataclass
+class PersonaCandidate:
+    name: str = ""
+
+
+@dataclass
+class StoryCandidate:
+    title: str = ""
+
+
+class Persona(Namespace, uses=[Persistable]):
+    class Persist(Persistable.Persist):
+        candidate: PersonaCandidate = field(default_factory=PersonaCandidate)
+
+        class Persisted(DomainEvent):
+            entity_id: str = ""
+
+    class Approve(Persistable.Approve):
+        class Approved(DomainEvent):
+            entity_id: str = ""
+
+    class Policy:
+        def persist(self, candidate: object) -> str:
+            assert isinstance(candidate, PersonaCandidate)
+            entity_id = f"persona:{candidate.name}"
+            _STORE.setdefault("persona", {})[entity_id] = candidate
+            return entity_id
+
+        def approve(self, entity_id: str) -> None:
+            _STORE["persona"][entity_id] = "approved"
+
+
+class Story(Namespace, uses=[Persistable]):
+    class Persist(Persistable.Persist):
+        candidate: StoryCandidate = field(default_factory=StoryCandidate)
+
+        class Persisted(DomainEvent):
+            entity_id: str = ""
+
+    class Approve(Persistable.Approve):
+        class Approved(DomainEvent):
+            entity_id: str = ""
+
+    class Policy:
+        def persist(self, candidate: object) -> str:
+            assert isinstance(candidate, StoryCandidate)
+            entity_id = f"story:{candidate.title}"
+            _STORE.setdefault("story", {})[entity_id] = candidate
+            return entity_id
+
+        def approve(self, entity_id: str) -> None:
+            _STORE["story"][entity_id] = "approved"
+
+
+@on(Persona.Persist.Persisted, Story.Persist.Persisted)
+def auto_approve(
+    event: Persona.Persist.Persisted | Story.Persist.Persisted,
+) -> Persona.Approve | Story.Approve:
+    """One reaction, every domain: resolve the domain via ``namespace_of`` and
+    approve it. Returns that domain's own ``Approve`` command."""
+    return namespace_of(event).Approve(entity_id=event.entity_id)
+
+
+def main() -> None:
+    graph = EventGraph(
+        [Persona.Persist, Persona.Approve, Story.Persist, Story.Approve, auto_approve]
+    )
+
+    persona_log = graph.invoke(Persona.Persist(candidate=PersonaCandidate(name="ada")))
+    story_log = graph.invoke(Story.Persist(candidate=StoryCandidate(title="quest")))
+
+    # Each domain emits ITS OWN per-entity event (distinct identity), produced
+    # by the single inherited archetype handler dispatching through its Policy.
+    persisted = persona_log.latest(Persona.Persist.Persisted)
+    approved = persona_log.latest(Persona.Approve.Approved)
+    print(f"persona persisted -> {type(persisted).__qualname__}: {persisted.entity_id}")
+    print(f"persona approved  -> {type(approved).__qualname__}: {approved.entity_id}")
+
+    s_persisted = story_log.latest(Story.Persist.Persisted)
+    s_approved = story_log.latest(Story.Approve.Approved)
+    print(
+        f"story persisted   -> {type(s_persisted).__qualname__}: {s_persisted.entity_id}"
+    )
+    print(
+        f"story approved    -> {type(s_approved).__qualname__}: {s_approved.entity_id}"
+    )
+
+    print(f"Persona uses {[ns.__name__ for ns in Persona.__uses__]}")
+    print(f"store: {_STORE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/langgraph_events/__init__.py
+++ b/src/langgraph_events/__init__.py
@@ -30,6 +30,7 @@ from langgraph_events._event import (
     SystemEvent,
     SystemPromptSet,
     Unresumable,
+    namespace_of,
     on_namespace_finalize,
 )
 from langgraph_events._event_log import EventLog
@@ -128,6 +129,7 @@ __all__ = [
     "emit_custom",
     "emit_state_snapshot",
     "message_reducer",
+    "namespace_of",
     "on",
     "on_namespace_finalize",
 ]

--- a/src/langgraph_events/_event.py
+++ b/src/langgraph_events/_event.py
@@ -13,7 +13,7 @@ from dataclasses import fields as dc_fields
 from typing import TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from langchain_core.messages import BaseMessage, SystemMessage
 
@@ -104,6 +104,24 @@ def on_namespace_finalize(cls: type, callback: Callable[[type, type], None]) -> 
     _NAMESPACE_FINALIZE_CALLBACKS.setdefault(cls, []).append(callback)
 
 
+def namespace_of(target: type | Event) -> type[Namespace] | None:
+    """Return the ``Namespace`` class that owns *target* — a ``Command`` /
+    ``DomainEvent`` class or instance — or ``None`` if it carries no namespace
+    stamp or its namespace isn't registered.
+
+    The bridge for archetype composition: an archetype command's handler runs
+    on a subclass instance (``Foo.Persist``), and ``namespace_of(self)`` returns
+    the consuming namespace (``Foo``) so the handler can reach conventions the
+    namespace supplies — e.g. ``namespace_of(self).Policy`` — without touching
+    the private registry.
+    """
+    cls = target if isinstance(target, type) else type(target)
+    name = getattr(cls, "__namespace__", None)
+    if name is None:
+        return None
+    return _NAMESPACE_REGISTRY.get(name)
+
+
 def _iter_nested_events(container: type, *, recurse_commands: bool) -> list[type]:
     """Every ``Event`` subclass nested directly under *container*, in
     declaration order.
@@ -179,9 +197,16 @@ class Namespace:
 
     __namespace_name__: ClassVar[str]
     __reducers__: ClassVar[tuple[Any, ...]]
+    __uses__: ClassVar[tuple[type, ...]] = ()
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:
+    def __init_subclass__(cls, *, uses: Sequence[type] = (), **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
+        for archetype in uses:
+            if not (isinstance(archetype, type) and issubclass(archetype, Namespace)):
+                raise TypeError(
+                    f"uses= entries must be Namespace subclasses, got {archetype!r}"
+                )
+        cls.__uses__ = tuple(uses)
         existing = _NAMESPACE_REGISTRY.get(cls.__name__)
         if existing is not None and existing is not cls:
             raise TypeError(
@@ -367,6 +392,67 @@ def _validate_handle_signature(cls: type, handle: Any) -> None:
         )
 
 
+def _find_inline_handler(cls: type[Command]) -> Any | None:
+    """Return the Command's sole public method (its inline handler), or ``None``.
+
+    A Command represents one intent and gets one handler. The handler method may
+    be named anything meaningful (``handle``, ``place``, ``buy``, ...); the sole
+    public method in the class body is picked up. Helpers must be underscore-
+    prefixed; dunders, nested DomainEvent classes, and properties don't count.
+    ``staticmethod`` / ``classmethod`` count toward the limit so they still
+    trigger the same rejection via ``_validate_handle_signature``.
+    """
+    public_methods = [
+        (name, attr)
+        for name, attr in cls.__dict__.items()
+        if not name.startswith("_")
+        and (inspect.isfunction(attr) or isinstance(attr, (staticmethod, classmethod)))
+    ]
+    if len(public_methods) > 1:
+        names = ", ".join(sorted(name for name, _ in public_methods))
+        raise TypeError(
+            f"Command {cls.__qualname__!r} declares more than one public "
+            f"method ({names}). A Command represents a single intent and "
+            f"may have at most one public method (its handler). Make "
+            f"helpers private with a leading underscore, or move them to "
+            f"a separate utility class."
+        )
+    if not public_methods:
+        return None
+    _, handle = public_methods[0]
+    _validate_handle_signature(cls, handle)
+    return handle
+
+
+def _rebind_inherited_handler(cls: type[Command]) -> None:
+    """Resolve the handler for a Command that inherits a stamped base command.
+
+    If the subclass declares its own public method, that overrides the archetype
+    handler. Otherwise the handler is inherited — give it a *distinct* clone so
+    each subclass is its own graph node: the graph binds each inline handler to
+    exactly one Command (``_inline_command`` guard), so several commands
+    subclassing one archetype command to compose a shared lifecycle would
+    otherwise share the parent's handler object and collide. The clone has the
+    same code/closure (identical behavior); the handler emits its outcome
+    reflectively (``type(self).Outcome``), so the clone yields the subclass's
+    own per-entity event.
+    """
+    own = _find_inline_handler(cls)
+    if own is not None:
+        cls.__command_handler__ = own
+        return
+    handler = cls.__command_handler__
+    if handler is None or not inspect.isfunction(handler):
+        return
+    cls.__command_handler__ = types.FunctionType(
+        handler.__code__,
+        handler.__globals__,
+        handler.__name__,
+        handler.__defaults__,
+        handler.__closure__,
+    )
+
+
 class Command(Event, _event_base=True, metaclass=_NestedEventMeta):
     """Imperative intent. Must be nested inside a ``Namespace`` subclass.
 
@@ -392,6 +478,7 @@ class Command(Event, _event_base=True, metaclass=_NestedEventMeta):
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         if _inherits_namespace(cls):
+            _rebind_inherited_handler(cls)
             return
         if not _is_nested_in_class(cls):
             raise TypeError(
@@ -399,35 +486,8 @@ class Command(Event, _event_base=True, metaclass=_NestedEventMeta):
                 f"subclass, e.g. "
                 f"class Order(Namespace): class {cls.__name__}(Command): ..."
             )
-        # A Command represents one intent and gets one handler. The handler
-        # method may be named anything meaningful (``handle``, ``place``,
-        # ``buy``, ...); the framework picks up the sole public method in
-        # the class body. Helpers must be underscore-prefixed; dunders,
-        # nested DomainEvent classes, and properties don't count.
-        # ``staticmethod`` / ``classmethod`` count toward the limit so they
-        # still trigger the same rejection as before via
-        # ``_validate_handle_signature``.
-        public_methods = [
-            (name, attr)
-            for name, attr in cls.__dict__.items()
-            if not name.startswith("_")
-            and (
-                inspect.isfunction(attr)
-                or isinstance(attr, (staticmethod, classmethod))
-            )
-        ]
-        if len(public_methods) > 1:
-            names = ", ".join(sorted(name for name, _ in public_methods))
-            raise TypeError(
-                f"Command {cls.__qualname__!r} declares more than one public "
-                f"method ({names}). A Command represents a single intent and "
-                f"may have at most one public method (its handler). Make "
-                f"helpers private with a leading underscore, or move them to "
-                f"a separate utility class."
-            )
-        if public_methods:
-            _, handle = public_methods[0]
-            _validate_handle_signature(cls, handle)
+        handle = _find_inline_handler(cls)
+        if handle is not None:
             cls.__command_handler__ = handle
 
 

--- a/tests/test_archetype.py
+++ b/tests/test_archetype.py
@@ -1,0 +1,199 @@
+"""Lifecycle archetype composition: inherit an archetype command's behavior
+while keeping per-entity identity + typing, with a Policy bridge (issue #98)."""
+
+import pytest
+
+from langgraph_events import (
+    Command,
+    DomainEvent,
+    EventGraph,
+    Namespace,
+    namespace_of,
+)
+
+
+class Lifecyclic(Namespace):
+    """Archetype: defines the lifecycle behavior once. The handler emits its
+    outcome reflectively (``type(self).Persisted``) so subclasses emit their
+    own per-entity event, and carries no return annotation so each subclass's
+    ``Outcomes`` drives the contract."""
+
+    class Persist(Command):
+        value: str = ""
+
+        def handle(self):
+            return type(self).Persisted(out=self.value)
+
+
+class Sprocket(Namespace):
+    class Persist(Lifecyclic.Persist):
+        class Persisted(DomainEvent):
+            out: str = ""
+
+
+class Cog(Namespace):
+    class Persist(Lifecyclic.Persist):
+        class Persisted(DomainEvent):
+            out: str = ""
+
+
+class Openable(Namespace):
+    """Archetype whose shared handler delegates per-entity work to the
+    consuming namespace's ``Policy`` (the bridge)."""
+
+    class Open(Command):
+        subject: str = ""
+
+        def handle(self):
+            policy = namespace_of(self).Policy()
+            return type(self).Opened(ref=policy.open(self.subject))
+
+
+class Account(Namespace):
+    class Open(Openable.Open):
+        class Opened(DomainEvent):
+            ref: str = ""
+
+    class Policy:
+        def open(self, subject: str) -> str:
+            return f"account::{subject}"
+
+
+class Ticket(Namespace):
+    class Open(Openable.Open):
+        class Opened(DomainEvent):
+            ref: str = ""
+
+    class Policy:
+        def open(self, subject: str) -> str:
+            return f"ticket::{subject}"
+
+
+class Overrider(Namespace):
+    class Persist(Lifecyclic.Persist):
+        class Overridden(DomainEvent):
+            note: str = ""
+
+        def handle(self):
+            return type(self).Overridden(note="custom")
+
+
+def describe_archetype_command_inheritance():
+
+    def when_two_commands_subclass_one_archetype_command():
+
+        def it_gives_each_a_distinct_handler():
+            assert (
+                Sprocket.Persist.__command_handler__
+                is not Cog.Persist.__command_handler__
+            )
+
+        def without_a_handler_collision():
+
+            def it_builds_one_graph():
+                graph = EventGraph([Sprocket.Persist, Cog.Persist])
+                assert {"Sprocket.Persist", "Cog.Persist"} <= set(graph.handler_names)
+
+
+def describe_per_entity_outcome():
+
+    def when_subclasses_define_their_own_event():
+
+        def it_keeps_distinct_event_identity():
+            assert Sprocket.Persist.Persisted is not Cog.Persist.Persisted
+
+        def it_synthesizes_per_entity_outcomes():
+            assert Sprocket.Persist.Outcomes is Sprocket.Persist.Persisted
+
+        def it_stamps_the_consuming_namespace():
+            assert Sprocket.Persist.Persisted.__namespace__ == "Sprocket"
+
+    def when_an_inherited_command_is_invoked():
+
+        def it_emits_its_own_event_reflectively():
+            log = EventGraph([Sprocket.Persist, Cog.Persist]).invoke(
+                Sprocket.Persist(value="hi")
+            )
+            assert log.latest(Sprocket.Persist.Persisted) == Sprocket.Persist.Persisted(
+                out="hi"
+            )
+            assert log.latest(Cog.Persist.Persisted) is None
+
+
+def describe_namespace_of():
+    """Bridge enabler: an archetype handler resolves the consuming namespace
+    (and its ``Policy``) from the command instance."""
+
+    def when_given_a_command_class():
+
+        def it_returns_the_owning_namespace():
+            assert namespace_of(Sprocket.Persist) is Sprocket
+
+    def when_given_an_event_instance():
+
+        def it_returns_the_owning_namespace():
+            assert namespace_of(Cog.Persist(value="x")) is Cog
+
+
+def describe_policy_bridge():
+
+    def when_two_domains_compose_one_archetype():
+
+        def it_emits_each_domains_own_event():
+            graph = EventGraph([Account.Open, Ticket.Open])
+            log = graph.invoke(Account.Open(subject="alice"))
+            assert log.latest(Account.Open.Opened) is not None
+            assert log.latest(Ticket.Open.Opened) is None
+
+        def it_dispatches_to_each_domains_policy():
+            graph = EventGraph([Account.Open, Ticket.Open])
+            opened_a = graph.invoke(Account.Open(subject="alice")).latest(
+                Account.Open.Opened
+            )
+            opened_t = graph.invoke(Ticket.Open(subject="bug")).latest(
+                Ticket.Open.Opened
+            )
+            assert opened_a.ref == "account::alice"
+            assert opened_t.ref == "ticket::bug"
+
+
+def describe_handler_override():
+
+    def when_a_subclass_defines_its_own_handler():
+
+        def it_uses_the_overriding_handler():
+            log = EventGraph([Overrider.Persist]).invoke(Overrider.Persist(value="x"))
+            assert log.latest(Overrider.Persist.Overridden) is not None
+
+
+def describe_uses_declaration():
+
+    def when_archetypes_are_declared():
+
+        def it_records_them_for_introspection():
+            class Vault(Namespace, uses=[Openable]):
+                class Open(Openable.Open):
+                    class Opened(DomainEvent):
+                        ref: str = ""
+
+                class Policy:
+                    def open(self, subject: str) -> str:
+                        return subject
+
+            assert Vault.__uses__ == (Openable,)
+
+    def when_no_archetypes_are_declared():
+
+        def it_defaults_to_empty():
+            class Plain(Namespace):
+                pass
+
+            assert Plain.__uses__ == ()
+
+    def when_a_non_namespace_is_declared():
+
+        def it_raises_type_error():
+            with pytest.raises(TypeError, match="Namespace"):
+
+                class BadUses(Namespace, uses=[object]):
+                    pass


### PR DESCRIPTION
Closes #98.

Compose a reusable lifecycle (e.g. a persistence `Persist`/`Approve` loop) across domains while each keeps its **own per-entity event identity and field types**. Design grounded in and validated against a real downstream persistence-lifecycle shape — earlier copy / by-reference designs were prototyped and verified *broken* for that use case (handler collision; wrong-namespace emission; can't vary field types).

## What's in it

1. **Inherit, don't copy** (`_event.py`). Subclassing an archetype `Command` inherits its inline handler; the framework rebinds a **distinct** handler clone per subclass, so several domains' commands coexist as graph nodes instead of tripping the `_inline_command` collision guard. A subclass that declares its own public method still overrides the inherited handler (this also fixes a latent bug where an inheriting subclass's own handler was ignored). Archetype handlers construct outcomes reflectively (`type(self).Outcome(...)`), so each subclass emits its **own** event (`Order.Persist.Persisted` ≠ `Invoice.Persist.Persisted`).
2. **`namespace_of(target)`** — the Policy bridge: resolve the `Namespace` owning a `Command`/`DomainEvent` (class or instance). Archetype handlers reach the consuming domain's `Policy` via `namespace_of(self).Policy`; reactions dispatch per-entity via `namespace_of(event).Approve(...)`.
3. **`class Foo(Namespace, uses=[Archetype])`** — records composition on `Foo.__uses__` for intent + introspection (validated; no copying or aliasing).

## Scope notes
- The speculative `uses=` metaclass read-through and `from_namespaces` resolution from the original plan were dropped as **YAGNI** — the bridge design (subclass + `namespace_of` + `Policy`) made them non-load-bearing. `namespace_of` is the public bridge instead.

## Verification
- `tests/test_archetype.py` — 14 new tests (TDD: each first confirmed red for the expected reason)
- Full suite: **992 passed, 1 skipped** (no regressions, incl. mermaid-sync)
- `ruff check` + `ruff format --check` clean; `mypy src/` clean
- `examples/persistable.py` runs: two domains share one lifecycle, emit per-entity events through their own `Policy`, in one graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)
