### PR TITLE
Re-export Event and HandlerReturn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Event` and `HandlerReturn` are now re-exported, not merely importable.** Both were imported
+  into the package namespace under a `# noqa: F401` but never re-exported, so a consumer running
+  mypy with `no_implicit_reexport` (which `strict = true` implies) got
+  `Module "langgraph_events" does not explicitly export attribute "Event"` — despite `Event`
+  being annotated in four places across the docs and `HandlerReturn` being a documented handler
+  return type. `Event` joins `__all__`; `HandlerReturn` re-exports through an explicit
+  `as` alias, staying out of `__all__` as intended so `import *` is unchanged.
+
 ## [0.23.0] - 2026-08-22
 
 ### Added

--- a/src/langgraph_events/__init__.py
+++ b/src/langgraph_events/__init__.py
@@ -14,7 +14,7 @@ from langgraph_events._event import (
     Cancelled,
     Command,
     DomainEvent,
-    Event,  # noqa: F401 (importable for reducer event_type=Event catch-all)
+    Event,
     Halted,
     HandlerRaised,
     IntegrationEvent,
@@ -62,7 +62,7 @@ from langgraph_events._reducer import (
 )
 from langgraph_events._reflection import QueryTool, Reflection
 from langgraph_events._types import (
-    HandlerReturn,  # noqa: F401 (importable but not promoted)
+    HandlerReturn as HandlerReturn,  # re-exported without promoting into __all__
 )
 
 # --- Deprecated top-level aliases ----------------------------------------
@@ -103,6 +103,7 @@ __all__ = [
     "CommandPrivacyError",
     "DomainEvent",
     "DomainPatternWarning",
+    "Event",
     "EventGraph",
     "EventLog",
     "FoldReducer",

--- a/tests/test_event_typing.py
+++ b/tests/test_event_typing.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import assert_type
 
-from langgraph_events import IntegrationEvent
+from langgraph_events import Event, HandlerReturn, IntegrationEvent
 
 
 class Ordered(IntegrationEvent):
@@ -40,3 +40,16 @@ def constructor_rejects_a_mistyped_field() -> None:
 def events_are_frozen() -> None:
     event = Ordered(sku="abc")
     event.sku = "def"  # type: ignore[misc]
+
+
+def the_package_reexports_its_documented_public_names() -> None:
+    """``Event`` and ``HandlerReturn`` are importable by design; the docs use both.
+
+    Under ``no_implicit_reexport`` a name the package imports but never re-exports is
+    invisible to a consumer, however public its docstring claims to be.
+    """
+
+    def catch_all(event: Event) -> HandlerReturn:
+        return None
+
+    assert_type(catch_all(Ordered()), HandlerReturn)


### PR DESCRIPTION
## The bug

Both names are pulled into the package namespace under a `# noqa: F401` whose comment states the
intent outright:

```python
Event,           # noqa: F401 (importable for reducer event_type=Event catch-all)
HandlerReturn,   # noqa: F401 (importable but not promoted)
```

Neither is re-exported. So a consumer running mypy with `no_implicit_reexport` — which
`strict = true` implies — gets:

```
Module "langgraph_events" does not explicitly export attribute "Event"
```

Not hypothetical: `Event` is annotated in **four** places across `docs/concepts.md`,
`docs/reducers.md` and `docs/control-flow.md`, and a downstream app has been suppressing this
error repo-wide.

## The fix

The two names need different mechanisms because their stated intent differs:

| name | intent | mechanism |
|---|---|---|
| `Event` | genuinely public, documented | joins `__all__` |
| `HandlerReturn` | "importable but not promoted" | explicit `X as X` alias, stays out of `__all__` |

`import *` is unchanged — `__all__` gains only `Event` (49 → 50 entries, still sorted). Both
fixes make the `noqa: F401` unnecessary, since `__all__` membership and an `as` alias each count
as usage.

## Test

`tests/test_event_typing.py` gains an assertion that uses both names the way a consumer does — a
`catch_all(event: Event) -> HandlerReturn` handler. It fails with exactly those two
`attr-defined` errors before the change, and the mypy gate already checks that file.

Verified: 1147 tests pass on 3.11, 3.12 and 3.13; `mypy` and `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)