### PR TITLE
Carry message extras through to AG-UI, and stop dropping ToolMessage.error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **AG-UI message passthrough (`AGUI_EXTRAS_KEY`)** — a mapping under the reserved
+  `additional_kwargs["agui"]` key on a LangChain message becomes extra top-level fields on the
+  AG-UI message in `MessagesSnapshot`. AG-UI models set `extra="allow"`, so a client can now
+  receive structured data the protocol does not declare — a `{"failure": {"retryable": true}}`
+  hint on a failure notice, for instance. Nothing else in `additional_kwargs` crosses the wire,
+  so provider metadata and internal state stay on the backend. An entry that addresses a declared
+  AG-UI field (by name or by camelCase alias) raises `ValueError` naming the key, because it would
+  rewrite protocol data. `agui_messages_to_langchain` mirrors it: the extra fields an inbound
+  AG-UI message carries are collected back under the same key.
+
+### Fixed
+
+- **`ToolMessage.status` and AG-UI `ToolMessage.error` now map in both directions.** A tool result
+  the client marked as failed reached the model as a success, because every conversion path
+  dropped the field. `detect_new_tool_results` and `agui_messages_to_langchain` now set
+  `status="error"` when AG-UI `error` is present, and `MessagesSnapshot` now sends `error` when
+  the LangChain status is `"error"`. This is ag-ui issue #2226, whose upstream fix covered only
+  the inbound half of `ag_ui_langgraph`.
+- **`BaseMessage.name` reaches the AG-UI message.** `agui_messages_to_langchain` already read
+  `name` inbound, but the outbound mapper dropped it, so a named message did not round-trip.
+  AG-UI declares `name` on `UserMessage`, `AssistantMessage` and `SystemMessage`. Its
+  `ToolMessage` declares no `name`, so tool messages are unchanged.
+- **A `ToolMessage` with block content no longer breaks the stream.** The `tool` branch of the
+  snapshot mapper passed list content straight to AG-UI, which declares `content: str`, so the
+  pydantic `ValidationError` surfaced as a `RunError` and killed the connect stream. It now
+  degrades to `""`, matching the `system` branch.
+
 ## [0.23.1] - 2026-08-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the client marked as failed reached the model as a success, because every conversion path
   dropped the field. `detect_new_tool_results` and `agui_messages_to_langchain` now set
   `status="error"` when AG-UI `error` is present, and `MessagesSnapshot` now sends `error` when
-  the LangChain status is `"error"`. This is ag-ui issue #2226, whose upstream fix covered only
-  the inbound half of `ag_ui_langgraph`.
+  the LangChain status is `"error"`. The outbound `error` is always truthy: an errored tool
+  message with empty content sends the literal `"error"` instead, because an empty string is
+  falsy and a client writing `if (msg.error)` would read the failure as a success. This is
+  ag-ui issue #2226, whose upstream fix covered only the inbound half of `ag_ui_langgraph`.
 - **`BaseMessage.name` reaches the AG-UI message.** `agui_messages_to_langchain` already read
   `name` inbound, but the outbound mapper dropped it, so a named message did not round-trip.
   AG-UI declares `name` on `UserMessage`, `AssistantMessage` and `SystemMessage`. Its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,33 +10,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **AG-UI message passthrough (`AGUI_EXTRAS_KEY`)** — a mapping under the reserved
-  `additional_kwargs["agui"]` key on a LangChain message becomes extra top-level fields on the
-  AG-UI message in `MessagesSnapshot`. AG-UI models set `extra="allow"`, so a client can now
-  receive structured data the protocol does not declare — a `{"failure": {"retryable": true}}`
-  hint on a failure notice, for instance. Nothing else in `additional_kwargs` crosses the wire,
-  so provider metadata and internal state stay on the backend. An entry that addresses a declared
-  AG-UI field (by name or by camelCase alias) raises `ValueError` naming the key, because it would
-  rewrite protocol data. `agui_messages_to_langchain` mirrors it: the extra fields an inbound
-  AG-UI message carries are collected back under the same key.
+  `additional_kwargs["langgraph_events.agui"]` key on a LangChain message becomes extra top-level
+  fields on the AG-UI message in `MessagesSnapshot`. AG-UI models set `extra="allow"`, so a client
+  can now receive structured data the protocol does not declare — a `{"failure": {"retryable":
+  true}}` hint on a failure notice, for instance. Nothing else in `additional_kwargs` crosses the
+  wire, so provider metadata and internal state stay on the backend. `agui_messages_to_langchain`
+  and `detect_new_tool_results` mirror it: the extra fields an inbound AG-UI message carries are
+  collected back under the same key.
+
+  The key is package-qualified on purpose. `additional_kwargs` is a shared namespace that
+  LangChain provider integrations also write into, and there is no opt-in and no version gate, so
+  a plain `"agui"` would have started forwarding a consumer's existing key silently. **Check
+  `additional_kwargs` for prior use before adopting this.** Read the constant, not the literal.
+
+- **`AGUI_EXTRAS_MAX_BYTES`** — a size cap on the extra fields one inbound AG-UI message may
+  carry, 8 KiB of JSON. Inbound extras are unvalidated client input: they enter
+  `additional_kwargs`, flow through `add_messages` into the checkpoint, and are served back out on
+  the next `MessagesSnapshot` — to every client on that thread, not only the one that sent it.
+  Without a cap a client could grow a thread's checkpoint without bound. Extras over the cap, or
+  extras that do not encode as JSON, are dropped with a `WARNING` naming the message; the message
+  itself still converts. The trust boundary is documented in `docs/agui.md` and on
+  `collect_inbound_extras`.
+
+### Changed
+
+- **`BaseMessage.name` now reaches the AG-UI message.** `agui_messages_to_langchain` already read
+  `name` inbound, but the outbound mapper dropped it, so a named message did not round-trip.
+  AG-UI declares `name` on `UserMessage`, `AssistantMessage` and `SystemMessage`. Its
+  `ToolMessage` declares no `name`, so tool messages are unchanged. This changes the wire payload
+  for every existing consumer, which is why it is filed here rather than under `Fixed`.
 
 ### Fixed
 
 - **`ToolMessage.status` and AG-UI `ToolMessage.error` now map in both directions.** A tool result
   the client marked as failed reached the model as a success, because every conversion path
   dropped the field. `detect_new_tool_results` and `agui_messages_to_langchain` now set
-  `status="error"` when AG-UI `error` is present, and `MessagesSnapshot` now sends `error` when
+  `status="error"` when the AG-UI `error` is truthy, and `MessagesSnapshot` now sends `error` when
   the LangChain status is `"error"`. The outbound `error` is always truthy: an errored tool
   message with empty content sends the literal `"error"` instead, because an empty string is
-  falsy and a client writing `if (msg.error)` would read the failure as a success. This is
-  ag-ui issue #2226, whose upstream fix covered only the inbound half of `ag_ui_langgraph`.
-- **`BaseMessage.name` reaches the AG-UI message.** `agui_messages_to_langchain` already read
-  `name` inbound, but the outbound mapper dropped it, so a named message did not round-trip.
-  AG-UI declares `name` on `UserMessage`, `AssistantMessage` and `SystemMessage`. Its
-  `ToolMessage` declares no `name`, so tool messages are unchanged.
+  falsy and a client writing `if (msg.error)` would read the failure as a success. Truthiness is
+  the one rule that governs the field in both directions, so a client that initialises
+  `error: ""` on every tool result reports no failure. Only *presence* maps: the error text does
+  not come back, because LangChain's `ToolMessage` has no field for it and `content` is where a
+  tool's failure reason belongs. This is ag-ui issue #2226, whose upstream fix covered only the
+  inbound half of `ag_ui_langgraph`.
+- **A bad extras mapping no longer poisons a thread.** `MessagesSnapshot` is rebuilt from the
+  **checkpointed** message list on every `connect()`. A collision or a non-mapping value used to
+  raise `ValueError` inside that build. The raise escaped the adapter's async generator into the
+  consumer's HTTP handler and never became a `RunError`, so one bad value broke every later
+  connect on that thread until someone edited the checkpoint. The build now degrades instead: a
+  non-mapping value is dropped whole, a non-string key or an entry naming a declared AG-UI field
+  drops that entry only, and each cause warns once per message class.
 - **A `ToolMessage` with block content no longer breaks the stream.** The `tool` branch of the
   snapshot mapper passed list content straight to AG-UI, which declares `content: str`, so the
   pydantic `ValidationError` surfaced as a `RunError` and killed the connect stream. It now
-  degrades to `""`, matching the `system` branch.
+  degrades to `""`, matching the `system` branch, and logs a `WARNING` naming the tool call
+  because the content is lost.
+- **`detect_new_tool_results` carries message extras.** The two inbound paths disagreed:
+  `agui_messages_to_langchain` gained both the error status and the extras, while
+  `detect_new_tool_results` gained only the status, so a consumer routing frontend tool results
+  through it lost the extra fields the client sent.
 
 ## [0.23.1] - 2026-08-22
 

--- a/docs/agui.md
+++ b/docs/agui.md
@@ -131,6 +131,40 @@ For redaction or value transformation, write a custom `EventMapper`.
 !!! note "Message delivery uses two channels"
     Messages reach the client via two paths simultaneously: authoritative `MessagesSnapshot` from the `message_reducer()` channel, plus real-time `TextMessageStart` / `Content` / `End` tokens. AG-UI clients reconcile them by message id.
 
+### Message field mapping
+
+`MessagesSnapshot` converts each LangChain `BaseMessage` to its AG-UI counterpart. The declared fields map like this:
+
+| LangChain | AG-UI | Direction | Notes |
+|---|---|---|---|
+| `id`, `content` | `id`, `content` | both | `AssistantMessage.content` is `None` for block content; `SystemMessage`/`ToolMessage` degrade it to `""`. |
+| `name` | `name` | both | `UserMessage`, `AssistantMessage`, `SystemMessage` only — AG-UI's `ToolMessage` declares no `name`. |
+| `AIMessage.tool_calls` | `AssistantMessage.tool_calls` | both | `args` are JSON-encoded into `function.arguments`. |
+| `ToolMessage.status` | `ToolMessage.error` | both | `status="error"` sends the content as `error`; an inbound `error` sets `status="error"`. |
+| `additional_kwargs["agui"]` | *(extra fields)* | both | Passthrough — see below. |
+
+### Passing extra data on a message
+
+AG-UI messages allow extra fields, so a client can receive structured data the protocol does not declare — a retry hint on a failure notice, for instance. Put a mapping under the reserved `additional_kwargs` key `AGUI_EXTRAS_KEY` (the literal string `"agui"`). Each entry becomes a top-level field on the AG-UI message.
+
+```python
+from langchain_core.messages import SystemMessage
+
+from langgraph_events.agui import AGUI_EXTRAS_KEY
+
+SystemMessage(
+    content="The step failed.",
+    additional_kwargs={AGUI_EXTRAS_KEY: {"failure": {"retryable": True}}},
+)
+# -> AG-UI SystemMessage(id=..., role="system", content="The step failed.",
+#                        failure={"retryable": True})
+```
+
+The mapping round-trips. `agui_messages_to_langchain` collects the extra fields an inbound AG-UI message carries back into `additional_kwargs[AGUI_EXTRAS_KEY]`.
+
+!!! warning "Only the reserved key crosses the wire"
+    Nothing else in `additional_kwargs` is forwarded. Provider metadata and internal state stay on the backend. An entry that addresses a declared AG-UI field (`content`, `toolCallId`, …) raises `ValueError` naming the key, because it would rewrite protocol data. Rename the entry, or set the field through the LangChain message.
+
 ## Connect / Reconnect
 
 `connect()` (alias `reconnect()`) emits checkpoint-backed state without running handlers — `StateSnapshot` + `MessagesSnapshot` from the checkpoint plus any pending `Interrupted` events.
@@ -336,10 +370,10 @@ Streaming-path errors propagate to the frontend as a `RUN_ERROR` event with the 
 
 ## Resume Helpers
 
-`detect_new_tool_results` covers the frontend-tool-result arm of resume. The other arm — frontend sends `Command(resume=…)` plus new chat messages — has three helpers that collapse `resume_factory` boilerplate:
+`detect_new_tool_results` covers the frontend-tool-result arm of resume. A result the client marks with `error` becomes a LangChain `ToolMessage` with `status="error"`, so the model reads the failure as a failure. The other arm — frontend sends `Command(resume=…)` plus new chat messages — has three helpers that collapse `resume_factory` boilerplate:
 
 - **`extract_resume_input(input_data)`** — pull & decode `RunAgentInput.forwarded_props["command"]["resume"]`.
-- **`agui_messages_to_langchain(messages, *, drop_invalid_tool_calls=False)`** — convert AG-UI messages (`UserMessage`, `AssistantMessage`, `SystemMessage`, `ToolMessage` — multimodal `UserMessage` content included) to LangChain `BaseMessage`. `ReasoningMessage` / `DeveloperMessage` skipped (DEBUG); `ActivityMessage` / unknown roles raise `ValueError`. With `drop_invalid_tool_calls=True`, tool calls with unparseable JSON args are dropped (WARNING).
+- **`agui_messages_to_langchain(messages, *, drop_invalid_tool_calls=False)`** — convert AG-UI messages (`UserMessage`, `AssistantMessage`, `SystemMessage`, `ToolMessage` — multimodal `UserMessage` content included) to LangChain `BaseMessage`. `ReasoningMessage` / `DeveloperMessage` skipped (DEBUG); `ActivityMessage` / unknown roles raise `ValueError`. With `drop_invalid_tool_calls=True`, tool calls with unparseable JSON args are dropped (WARNING). A `ToolMessage.error` becomes `status="error"`, and extra fields land under `additional_kwargs[AGUI_EXTRAS_KEY]` (see [Message field mapping](#message-field-mapping)).
 - **`merge_frontend_messages(input_data, checkpoint_state, *, reducer_name="messages", drop_invalid_tool_calls=True)`** — read existing messages from checkpoint, convert, merge via `add_messages` (id-based dedup; missing ids get UUIDs assigned). Returns a tuple.
 
 ```python

--- a/docs/agui.md
+++ b/docs/agui.md
@@ -137,15 +137,16 @@ For redaction or value transformation, write a custom `EventMapper`.
 
 | LangChain | AG-UI | Direction | Notes |
 |---|---|---|---|
-| `id`, `content` | `id`, `content` | both | `AssistantMessage.content` is `None` for block content; `SystemMessage`/`ToolMessage` degrade it to `""`. |
+| `id`, `content` | `id`, `content` | both | `AssistantMessage.content` is `None` for block content; `SystemMessage`/`ToolMessage` degrade it to `""`. A degraded `ToolMessage` logs a `WARNING` naming the tool call, because the content is lost. |
 | `name` | `name` | both | `UserMessage`, `AssistantMessage`, `SystemMessage` only — AG-UI's `ToolMessage` declares no `name`. |
 | `AIMessage.tool_calls` | `AssistantMessage.tool_calls` | both | `args` are JSON-encoded into `function.arguments`. |
-| `ToolMessage.status` | `ToolMessage.error` | both | `status="error"` sends the content as `error`, or the literal `"error"` when the content is empty, because a falsy `error` reads as a success; an inbound `error` sets `status="error"`. |
-| `additional_kwargs["agui"]` | *(extra fields)* | both | Passthrough — see below. |
+| `ToolMessage.status` | `ToolMessage.error` | both | Presence maps both ways. `status="error"` sends the content as `error`, or the literal `"error"` when the content is empty, because a falsy `error` reads as a success. A truthy inbound `error` sets `status="error"`. The error *text* does not come back: LangChain's `ToolMessage` has no field for it, and `content` is where a tool's failure reason belongs. |
+| *(none)* | `encrypted_value` | neither | Declared on AG-UI `BaseMessage`, `ToolMessage` and `ToolCall`. The adapter never reads it inbound and never sets it outbound, so a value the client sent is dropped. It is a declared field, so it cannot ride through the extras slot either. |
+| `additional_kwargs[AGUI_EXTRAS_KEY]` | *(extra fields)* | both | Passthrough — see below. |
 
 ### Passing extra data on a message
 
-AG-UI messages allow extra fields, so a client can receive structured data the protocol does not declare — a retry hint on a failure notice, for instance. Put a mapping under the reserved `additional_kwargs` key `AGUI_EXTRAS_KEY` (the literal string `"agui"`). Each entry becomes a top-level field on the AG-UI message.
+AG-UI messages allow extra fields, so a client can receive structured data the protocol does not declare — a retry hint on a failure notice, for instance. Put a mapping under the reserved `additional_kwargs` key `AGUI_EXTRAS_KEY` (the literal string `"langgraph_events.agui"`). Each entry becomes a top-level field on the AG-UI message. Read the constant rather than the literal — `additional_kwargs` is a shared namespace that LangChain provider integrations also write into, so the key is package-qualified.
 
 ```python
 from langchain_core.messages import SystemMessage
@@ -160,10 +161,26 @@ SystemMessage(
 #                        failure={"retryable": True})
 ```
 
-The mapping round-trips. `agui_messages_to_langchain` collects the extra fields an inbound AG-UI message carries back into `additional_kwargs[AGUI_EXTRAS_KEY]`.
+The mapping round-trips. `agui_messages_to_langchain` and `detect_new_tool_results` both collect the extra fields an inbound AG-UI message carries back into `additional_kwargs[AGUI_EXTRAS_KEY]`.
 
 !!! warning "Only the reserved key crosses the wire"
-    Nothing else in `additional_kwargs` is forwarded. Provider metadata and internal state stay on the backend. An entry that addresses a declared AG-UI field (`content`, `toolCallId`, …) raises `ValueError` naming the key, because it would rewrite protocol data. Rename the entry, or set the field through the LangChain message.
+    Nothing else in `additional_kwargs` is forwarded. Provider metadata and internal state stay on the backend.
+
+!!! warning "Inbound extras are untrusted, and they persist"
+    What the client sends arrives verbatim. It enters `additional_kwargs`, flows through `add_messages` into the checkpoint, and is served back out on the next `MessagesSnapshot` — to every client on that thread, not only the one that sent it. The adapter neither filters the keys nor inspects the values. Do not treat anything read out of the slot as trusted input, and strip or scope the slot yourself if more than one person can reach a thread.
+
+    `AGUI_EXTRAS_MAX_BYTES` (8 KiB of JSON per message) bounds how much a client can add. Extras over the cap, or extras that do not encode as JSON, are dropped with a `WARNING` naming the message. The message itself still converts.
+
+!!! note "The snapshot degrades, it never raises"
+    `MessagesSnapshot` is rebuilt from the **checkpointed** message list on every `connect()`. A raise inside that build would escape into your HTTP handler and never become a `RunError`, so one bad value would break the thread until someone edited the checkpoint. Nothing in the extras path raises. Three cases drop something and warn once per message class:
+
+    | Case | Dropped |
+    |---|---|
+    | The reserved key holds a non-mapping | The whole value |
+    | An entry key is not a string | That entry |
+    | An entry addresses a declared AG-UI field (`content`, `toolCallId`, …) | That entry, because it would rewrite protocol data |
+
+    Rename the entry, or set the field through the LangChain message.
 
 ## Connect / Reconnect
 

--- a/docs/agui.md
+++ b/docs/agui.md
@@ -140,7 +140,7 @@ For redaction or value transformation, write a custom `EventMapper`.
 | `id`, `content` | `id`, `content` | both | `AssistantMessage.content` is `None` for block content; `SystemMessage`/`ToolMessage` degrade it to `""`. |
 | `name` | `name` | both | `UserMessage`, `AssistantMessage`, `SystemMessage` only — AG-UI's `ToolMessage` declares no `name`. |
 | `AIMessage.tool_calls` | `AssistantMessage.tool_calls` | both | `args` are JSON-encoded into `function.arguments`. |
-| `ToolMessage.status` | `ToolMessage.error` | both | `status="error"` sends the content as `error`; an inbound `error` sets `status="error"`. |
+| `ToolMessage.status` | `ToolMessage.error` | both | `status="error"` sends the content as `error`, or the literal `"error"` when the content is empty, because a falsy `error` reads as a success; an inbound `error` sets `status="error"`. |
 | `additional_kwargs["agui"]` | *(extra fields)* | both | Passthrough — see below. |
 
 ### Passing extra data on a message

--- a/docs/api.md
+++ b/docs/api.md
@@ -139,6 +139,7 @@ Requires `[agui]`. See [AG-UI Adapter](agui.md).
 | Export | Type | Description |
 |---|---|---|
 | `AGUIAdapter` | Class | Map `EventGraph` streams to AG-UI protocol events |
+| `AGUI_EXTRAS_KEY` | Constant | Reserved `BaseMessage.additional_kwargs` key. Its mapping is forwarded as extra fields on the AG-UI message, and receives the client's extra fields on the way back |
 | `AGUIAdapter.stream()` / `.connect()` / `.reconnect()` | Method | Execute / rehydrate checkpoint / refresh |
 | `FrontendStateMutated` | Event | Adapter-emitted `IntegrationEvent` carrying `RunAgentInput.state` for client-state-mirror reducers |
 | `FrontendToolCallRequested` | Event | `Interrupted` subclass for handler-initiated frontend tool calls (CopilotKit `useFrontendTool`) |
@@ -148,7 +149,7 @@ Requires `[agui]`. See [AG-UI Adapter](agui.md).
 | `MapperContext` | Dataclass | Shared state (run ID, thread ID, message counter) per stream |
 | `create_starlette_response` / `encode_sse_stream` | Function | Framework-agnostic SSE wrapping |
 | `extract_resume_input` | Function | Pulls and JSON-decodes `RunAgentInput.forwarded_props["command"]["resume"]`. Returns `None` if absent or falsy |
-| `agui_messages_to_langchain` | Function | Converts AG-UI protocol messages to LangChain `BaseMessage` instances. Optional `drop_invalid_tool_calls=True` to skip tool calls whose JSON arguments fail to parse |
+| `agui_messages_to_langchain` | Function | Converts AG-UI protocol messages to LangChain `BaseMessage` instances. Maps `ToolMessage.error` to `status="error"` and extra fields to `additional_kwargs[AGUI_EXTRAS_KEY]`. Optional `drop_invalid_tool_calls=True` to skip tool calls whose JSON arguments fail to parse |
 | `merge_frontend_messages` | Function | `resume_factory` helper: reads messages from `checkpoint_state["reducers"][reducer_name]`, converts `input_data.messages`, merges via `add_messages` (id-based dedup). Returns a tuple |
 | `build_langchain_tools` / `detect_new_tool_results` | Function | Convert `RunAgentInput.tools` to OpenAI-format / extract new `ToolMessage`s from a resume request |
 

--- a/src/langgraph_events/agui/__init__.py
+++ b/src/langgraph_events/agui/__init__.py
@@ -7,8 +7,11 @@ from langgraph_events.agui._events import (
     FrontendToolCallRequested,
     InterruptedWithPayload,
 )
-from langgraph_events.agui._mappers import (
+from langgraph_events.agui._extras import (
     AGUI_EXTRAS_KEY,
+    AGUI_EXTRAS_MAX_BYTES,
+)
+from langgraph_events.agui._mappers import (
     FallbackMapper,
     FrontendToolCallRequestedMapper,
     InterruptedMapper,
@@ -38,6 +41,7 @@ from langgraph_events.agui._transport import (
 
 __all__ = [
     "AGUI_EXTRAS_KEY",
+    "AGUI_EXTRAS_MAX_BYTES",
     "AGUIAdapter",
     "AGUICustomEvent",
     "AGUISerializable",

--- a/src/langgraph_events/agui/__init__.py
+++ b/src/langgraph_events/agui/__init__.py
@@ -8,6 +8,7 @@ from langgraph_events.agui._events import (
     InterruptedWithPayload,
 )
 from langgraph_events.agui._mappers import (
+    AGUI_EXTRAS_KEY,
     FallbackMapper,
     FrontendToolCallRequestedMapper,
     InterruptedMapper,
@@ -36,6 +37,7 @@ from langgraph_events.agui._transport import (
 )
 
 __all__ = [
+    "AGUI_EXTRAS_KEY",
     "AGUIAdapter",
     "AGUICustomEvent",
     "AGUISerializable",

--- a/src/langgraph_events/agui/_extras.py
+++ b/src/langgraph_events/agui/_extras.py
@@ -1,0 +1,95 @@
+"""The reserved ``additional_kwargs`` slot for AG-UI passthrough fields.
+
+Stdlib only. The sibling modules defer their ``ag_ui`` and ``langchain``
+imports into the functions that need them, so the constants and the inbound
+collector live here rather than in ``_mappers``, which imports ``ag_ui`` at
+module level.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+AGUI_EXTRAS_KEY = "langgraph_events.agui"
+"""Reserved ``BaseMessage.additional_kwargs`` key for AG-UI passthrough fields.
+
+A consumer puts a mapping under this key on a LangChain message. Every entry
+becomes an extra field on the AG-UI message the adapter sends to the client.
+The same key receives the client's extra fields on the way back in. Nothing
+else in ``additional_kwargs`` crosses the wire.
+
+``additional_kwargs`` is a shared namespace — LangChain provider integrations
+write their own keys into it. The key is therefore package-qualified and holds
+a dot, so it is not a Python identifier and no integration can produce it as a
+keyword argument. Read the constant rather than the literal.
+"""
+
+AGUI_EXTRAS_MAX_BYTES = 8192
+"""Size cap on the extra fields one inbound AG-UI message may carry.
+
+Measured as the length of the JSON encoding of the whole extras mapping.
+An inbound message over the cap loses its extras, with a WARNING naming the
+message. The message itself still converts.
+
+8 KiB holds roughly a hundred small entries or a few paragraphs of text, which
+is the scale of the hint the field exists for. It also bounds the damage: a
+thousand-message thread with every message at the cap is 8 MB of checkpoint,
+which a checkpointer can still write. There is no lower bound that a legitimate
+hint would breach and no higher one that keeps a thread's growth bounded.
+"""
+
+
+def collect_inbound_extras(message: Any) -> dict[str, Any]:
+    """Return the ``additional_kwargs`` payload for an inbound AG-UI message.
+
+    AG-UI models allow extra fields. Whatever the client sent beyond the
+    declared schema is kept under :data:`AGUI_EXTRAS_KEY`, which is the same
+    slot the outbound mapper reads. A message with no extra fields gets an
+    empty ``additional_kwargs``.
+
+    **This is a trust boundary.** The value is whatever the client put on the
+    wire. It enters ``additional_kwargs``, flows through ``add_messages`` into
+    the checkpoint, and is served back out on the next ``MessagesSnapshot`` —
+    to every client on that thread, not only the one that sent it. The adapter
+    neither filters the keys nor inspects the values. Two consequences:
+
+    - Do not treat anything read out of this slot as trusted input.
+    - On a thread more than one person can reach, one person's data is stored
+      and served to the others. Strip or scope the slot yourself if that
+      matters.
+
+    The cap in :data:`AGUI_EXTRAS_MAX_BYTES` bounds how much a client can add
+    per message. Extras that exceed it, or that cannot be measured at all, are
+    dropped with a WARNING. Dropping rather than raising is deliberate: a raise
+    would let a client break its own resume, and the same value would arrive
+    again on every retry.
+    """
+    extra = getattr(message, "model_extra", None)
+    if not extra:
+        return {}
+    payload = dict(extra)
+    message_id = getattr(message, "id", None)
+    try:
+        size = len(json.dumps(payload))
+    except (TypeError, ValueError, RecursionError) as exc:
+        logger.warning(
+            "Dropping the extra fields on inbound AG-UI message %r — they do "
+            "not encode as JSON (%s).",
+            message_id,
+            exc,
+        )
+        return {}
+    if size > AGUI_EXTRAS_MAX_BYTES:
+        logger.warning(
+            "Dropping the extra fields on inbound AG-UI message %r — %d bytes "
+            "of JSON exceeds the %d byte cap.",
+            message_id,
+            size,
+            AGUI_EXTRAS_MAX_BYTES,
+        )
+        return {}
+    return {AGUI_EXTRAS_KEY: payload}

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
 import warnings
 from collections.abc import Mapping
 from functools import cache
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from ag_ui.core import (
     BaseEvent,
@@ -18,6 +19,7 @@ from ag_ui.core import (
     ToolCallEndEvent,
     ToolCallStartEvent,
 )
+from pydantic import BaseModel
 
 from langgraph_events._event import (
     Event,
@@ -35,12 +37,15 @@ from ._protocols import AGUICustomEvent, AGUISerializable
 
 if TYPE_CHECKING:
     from ag_ui.core import Message
-    from pydantic import BaseModel
 
     from ._context import MapperContext
 
+logger = logging.getLogger(__name__)
 
 _warned_classes: set[type] = set()
+_warned_extras: set[tuple[type, str]] = set()
+
+AGUIMessageT = TypeVar("AGUIMessageT", bound=BaseModel)
 
 AGUI_EXTRAS_KEY = "agui"
 """Reserved ``BaseMessage.additional_kwargs`` key for AG-UI passthrough fields.
@@ -99,6 +104,24 @@ def _handle_unmapped(cls: type, on_unmapped: str) -> list[BaseEvent]:
     return []
 
 
+def _warn_dropped_extras(cls: type, kind: str, detail: str) -> None:
+    """Warn once that AG-UI passthrough fields were dropped from *cls*.
+
+    *kind* is the dedupe key, not the message. It takes one of three fixed
+    values, so the dedupe set stays bounded however many bad messages arrive.
+    *detail* carries the specifics for the reader.
+    """
+    key = (cls, kind)
+    if key in _warned_extras:
+        return
+    _warned_extras.add(key)
+    warnings.warn(
+        f"Dropping AG-UI passthrough fields from a {cls.__name__}: {detail} "
+        f"The rest of the message is unchanged.",
+        stacklevel=3,
+    )
+
+
 @cache
 def _declared_names(cls: type[BaseModel]) -> frozenset[str]:
     """Return every name that already addresses a field on *cls*.
@@ -106,6 +129,10 @@ def _declared_names(cls: type[BaseModel]) -> frozenset[str]:
     An AG-UI model has ``populate_by_name=True`` with a camelCase alias
     generator, so ``tool_call_id`` and ``toolCallId`` both reach the same
     declared field. Both spellings are reserved.
+
+    ``field.alias`` is the only alias an AG-UI model sets today. A model that
+    set ``validation_alias`` or ``serialization_alias`` instead would need
+    those read here too.
     """
     names: set[str] = set()
     for name, field in cls.model_fields.items():
@@ -116,33 +143,65 @@ def _declared_names(cls: type[BaseModel]) -> frozenset[str]:
 
 
 def _build_agui_message(
-    cls: Any,
+    cls: type[AGUIMessageT],
     source: Any,
     **fields: Any,
-) -> Any:
+) -> AGUIMessageT:
     """Build an AG-UI message, adding the passthrough fields *source* carries.
 
     The passthrough fields come from ``source.additional_kwargs[AGUI_EXTRAS_KEY]``.
-    An entry that addresses a declared field would silently rewrite protocol
-    data, so a collision raises ``ValueError`` naming the key.
+
+    This function never raises. It runs inside :func:`build_messages_snapshot`,
+    which ``connect()`` calls on the **checkpointed** message list. A raise here
+    escapes the adapter's async generator into the consumer's HTTP handler and
+    never becomes a ``RUN_ERROR``, so one bad value in a checkpoint would break
+    every later connect on that thread until someone edited the checkpoint. A
+    value that cannot ride through is dropped, and warned about once per class
+    and cause. This matches the ``tool`` branch below, which degrades block
+    content rather than raising.
+
+    Three causes drop something:
+
+    - the reserved key holds a non-mapping — the whole value goes;
+    - an entry key is not a string — that entry goes, because ``**`` refuses it;
+    - an entry addresses a declared field — that entry goes, because it would
+      rewrite protocol data.
     """
     extras = getattr(source, "additional_kwargs", None) or {}
     passthrough = extras.get(AGUI_EXTRAS_KEY)
     if passthrough is None:
         return cls(**fields)
     if not isinstance(passthrough, Mapping):
-        raise ValueError(
-            f"additional_kwargs[{AGUI_EXTRAS_KEY!r}] must be a mapping of "
-            f"AG-UI message fields, got {type(passthrough).__name__}."
+        _warn_dropped_extras(
+            cls,
+            "not-a-mapping",
+            f"additional_kwargs[{AGUI_EXTRAS_KEY!r}] must be a mapping of AG-UI "
+            f"message fields, got {type(passthrough).__name__}.",
         )
-    collisions = sorted(set(passthrough) & _declared_names(cls))
+        return cls(**fields)
+
+    usable = {k: v for k, v in passthrough.items() if isinstance(k, str)}
+    unusable = [k for k in passthrough if not isinstance(k, str)]
+    if unusable:
+        _warn_dropped_extras(
+            cls,
+            "non-string-key",
+            f"an AG-UI message field name must be a string, and "
+            f"{', '.join(repr(k) for k in unusable)} is not.",
+        )
+
+    collisions = sorted(set(usable) & _declared_names(cls))
+    for name in collisions:
+        del usable[name]
     if collisions:
-        raise ValueError(
-            f"additional_kwargs[{AGUI_EXTRAS_KEY!r}] must not carry "
-            f"{', '.join(collisions)} — {cls.__name__} declares that field. "
-            f"Rename the entry, or set the field through the LangChain message."
+        _warn_dropped_extras(
+            cls,
+            "declared-field",
+            f"{cls.__name__} declares {', '.join(collisions)}, so the entry "
+            f"would rewrite protocol data. Rename the entry, or set the field "
+            f"through the LangChain message.",
         )
-    return cls(**fields, **passthrough)
+    return cls(**fields, **usable)
 
 
 def _langchain_to_agui_messages(
@@ -215,6 +274,13 @@ def _langchain_to_agui_messages(
             # has no name field. Block content has no lossless mapping, so it
             # degrades to "" rather than raising inside the snapshot build.
             content = msg.content if isinstance(msg.content, str) else ""
+            if not isinstance(msg.content, str):
+                logger.warning(
+                    "Dropping block content from tool result %s — AG-UI declares "
+                    "ToolMessage.content as a string, so there is no lossless "
+                    "mapping. The client receives an empty content.",
+                    getattr(msg, "tool_call_id", "") or msg_id,
+                )
             # An errored result must reach the client as a truthy `error`, or
             # `if (msg.error)` reads the failure as a success. The content is
             # the reason when there is one. Empty content — genuine, or block

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -51,6 +51,16 @@ The same key receives the client's extra fields on the way back in. Nothing
 else in ``additional_kwargs`` crosses the wire.
 """
 
+TOOL_ERROR_STATUS = "error"
+"""The LangChain ``ToolMessage.status`` value that marks a failed tool result.
+
+The literal doubles as the fallback for AG-UI ``ToolMessage.error``. AG-UI
+declares ``error`` as a string, and an empty string is falsy, so a client
+writing ``if (msg.error)`` reads a failed tool result as a success. An errored
+tool message with empty content therefore sends this literal. The literal is
+fixed, so it carries nothing about the tool, its arguments or its result.
+"""
+
 
 class UnmappedEventError(TypeError):
     """Raised by ``AGUIAdapter(on_unmapped="raise")`` for an event that reaches
@@ -205,6 +215,11 @@ def _langchain_to_agui_messages(
             # has no name field. Block content has no lossless mapping, so it
             # degrades to "" rather than raising inside the snapshot build.
             content = msg.content if isinstance(msg.content, str) else ""
+            # An errored result must reach the client as a truthy `error`, or
+            # `if (msg.error)` reads the failure as a success. The content is
+            # the reason when there is one. Empty content — genuine, or block
+            # content degraded above — falls back to the status literal.
+            is_error = getattr(msg, "status", None) == TOOL_ERROR_STATUS
             result.append(
                 _build_agui_message(
                     AguiToolMessage,
@@ -213,9 +228,7 @@ def _langchain_to_agui_messages(
                     role="tool",
                     content=content,
                     tool_call_id=getattr(msg, "tool_call_id", ""),
-                    error=(
-                        content if getattr(msg, "status", None) == "error" else None
-                    ),
+                    error=(content or TOOL_ERROR_STATUS) if is_error else None,
                 )
             )
     return result

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -33,6 +33,7 @@ from ._events import (
     FrontendToolCallRequested,
     InterruptedWithPayload,
 )
+from ._extras import AGUI_EXTRAS_KEY
 from ._protocols import AGUICustomEvent, AGUISerializable
 
 if TYPE_CHECKING:
@@ -46,20 +47,6 @@ _warned_classes: set[type] = set()
 _warned_extras: set[tuple[type, str]] = set()
 
 AGUIMessageT = TypeVar("AGUIMessageT", bound=BaseModel)
-
-AGUI_EXTRAS_KEY = "langgraph_events.agui"
-"""Reserved ``BaseMessage.additional_kwargs`` key for AG-UI passthrough fields.
-
-A consumer puts a mapping under this key on a LangChain message. Every entry
-becomes an extra field on the AG-UI message the adapter sends to the client.
-The same key receives the client's extra fields on the way back in. Nothing
-else in ``additional_kwargs`` crosses the wire.
-
-``additional_kwargs`` is a shared namespace — LangChain provider integrations
-write their own keys into it. The key is therefore package-qualified and holds
-a dot, so it is not a Python identifier and no integration can produce it as a
-keyword argument. Read the constant rather than the literal.
-"""
 
 TOOL_ERROR_STATUS = "error"
 """The LangChain ``ToolMessage.status`` value that marks a failed tool result.

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -47,13 +47,18 @@ _warned_extras: set[tuple[type, str]] = set()
 
 AGUIMessageT = TypeVar("AGUIMessageT", bound=BaseModel)
 
-AGUI_EXTRAS_KEY = "agui"
+AGUI_EXTRAS_KEY = "langgraph_events.agui"
 """Reserved ``BaseMessage.additional_kwargs`` key for AG-UI passthrough fields.
 
 A consumer puts a mapping under this key on a LangChain message. Every entry
 becomes an extra field on the AG-UI message the adapter sends to the client.
 The same key receives the client's extra fields on the way back in. Nothing
 else in ``additional_kwargs`` crosses the wire.
+
+``additional_kwargs`` is a shared namespace — LangChain provider integrations
+write their own keys into it. The key is therefore package-qualified and holds
+a dot, so it is not a Python identifier and no integration can produce it as a
+keyword argument. Read the constant rather than the literal.
 """
 
 TOOL_ERROR_STATUS = "error"

--- a/src/langgraph_events/agui/_mappers.py
+++ b/src/langgraph_events/agui/_mappers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import warnings
+from collections.abc import Mapping
+from functools import cache
 from typing import TYPE_CHECKING, Any
 
 from ag_ui.core import (
@@ -33,11 +35,21 @@ from ._protocols import AGUICustomEvent, AGUISerializable
 
 if TYPE_CHECKING:
     from ag_ui.core import Message
+    from pydantic import BaseModel
 
     from ._context import MapperContext
 
 
 _warned_classes: set[type] = set()
+
+AGUI_EXTRAS_KEY = "agui"
+"""Reserved ``BaseMessage.additional_kwargs`` key for AG-UI passthrough fields.
+
+A consumer puts a mapping under this key on a LangChain message. Every entry
+becomes an extra field on the AG-UI message the adapter sends to the client.
+The same key receives the client's extra fields on the way back in. Nothing
+else in ``additional_kwargs`` crosses the wire.
+"""
 
 
 class UnmappedEventError(TypeError):
@@ -77,6 +89,52 @@ def _handle_unmapped(cls: type, on_unmapped: str) -> list[BaseEvent]:
     return []
 
 
+@cache
+def _declared_names(cls: type[BaseModel]) -> frozenset[str]:
+    """Return every name that already addresses a field on *cls*.
+
+    An AG-UI model has ``populate_by_name=True`` with a camelCase alias
+    generator, so ``tool_call_id`` and ``toolCallId`` both reach the same
+    declared field. Both spellings are reserved.
+    """
+    names: set[str] = set()
+    for name, field in cls.model_fields.items():
+        names.add(name)
+        if field.alias:
+            names.add(field.alias)
+    return frozenset(names)
+
+
+def _build_agui_message(
+    cls: Any,
+    source: Any,
+    **fields: Any,
+) -> Any:
+    """Build an AG-UI message, adding the passthrough fields *source* carries.
+
+    The passthrough fields come from ``source.additional_kwargs[AGUI_EXTRAS_KEY]``.
+    An entry that addresses a declared field would silently rewrite protocol
+    data, so a collision raises ``ValueError`` naming the key.
+    """
+    extras = getattr(source, "additional_kwargs", None) or {}
+    passthrough = extras.get(AGUI_EXTRAS_KEY)
+    if passthrough is None:
+        return cls(**fields)
+    if not isinstance(passthrough, Mapping):
+        raise ValueError(
+            f"additional_kwargs[{AGUI_EXTRAS_KEY!r}] must be a mapping of "
+            f"AG-UI message fields, got {type(passthrough).__name__}."
+        )
+    collisions = sorted(set(passthrough) & _declared_names(cls))
+    if collisions:
+        raise ValueError(
+            f"additional_kwargs[{AGUI_EXTRAS_KEY!r}] must not carry "
+            f"{', '.join(collisions)} — {cls.__name__} declares that field. "
+            f"Rename the entry, or set the field through the LangChain message."
+        )
+    return cls(**fields, **passthrough)
+
+
 def _langchain_to_agui_messages(
     messages: list[Any],
 ) -> list[Message]:
@@ -94,8 +152,18 @@ def _langchain_to_agui_messages(
     for msg in messages:
         msg_type = msg.type
         msg_id = getattr(msg, "id", None) or ""
+        msg_name = getattr(msg, "name", None)
         if msg_type == "human":
-            result.append(UserMessage(id=msg_id, role="user", content=msg.content))
+            result.append(
+                _build_agui_message(
+                    UserMessage,
+                    msg,
+                    id=msg_id,
+                    role="user",
+                    content=msg.content,
+                    name=msg_name,
+                )
+            )
         elif msg_type == "ai":
             tool_calls = None
             if hasattr(msg, "tool_calls") and msg.tool_calls:
@@ -111,28 +179,43 @@ def _langchain_to_agui_messages(
                     for tc in msg.tool_calls
                 ]
             result.append(
-                AssistantMessage(
+                _build_agui_message(
+                    AssistantMessage,
+                    msg,
                     id=msg_id,
                     role="assistant",
                     content=msg.content if isinstance(msg.content, str) else None,
+                    name=msg_name,
                     tool_calls=tool_calls,
                 )
             )
         elif msg_type == "system":
             result.append(
-                SystemMessage(
+                _build_agui_message(
+                    SystemMessage,
+                    msg,
                     id=msg_id,
                     role="system",
                     content=msg.content if isinstance(msg.content, str) else "",
+                    name=msg_name,
                 )
             )
         elif msg_type == "tool":
+            # AG-UI declares tool content as a plain string, and ToolMessage
+            # has no name field. Block content has no lossless mapping, so it
+            # degrades to "" rather than raising inside the snapshot build.
+            content = msg.content if isinstance(msg.content, str) else ""
             result.append(
-                AguiToolMessage(
+                _build_agui_message(
+                    AguiToolMessage,
+                    msg,
                     id=msg_id,
                     role="tool",
-                    content=msg.content or "",
+                    content=content,
                     tool_call_id=getattr(msg, "tool_call_id", ""),
+                    error=(
+                        content if getattr(msg, "status", None) == "error" else None
+                    ),
                 )
             )
     return result

--- a/src/langgraph_events/agui/_resume.py
+++ b/src/langgraph_events/agui/_resume.py
@@ -11,6 +11,8 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from ._mappers import AGUI_EXTRAS_KEY
+
 if TYPE_CHECKING:
     from ag_ui.core import Message
     from ag_ui.core.types import RunAgentInput
@@ -18,6 +20,21 @@ if TYPE_CHECKING:
     from langchain_core.messages.tool_call import ToolCall as LCToolCall
 
 logger = logging.getLogger(__name__)
+
+
+def _agui_extras(message: Any) -> dict[str, Any]:
+    """Return the ``additional_kwargs`` payload for an inbound AG-UI message.
+
+    AG-UI models allow extra fields. Whatever the client sent beyond the
+    declared schema is kept under the reserved ``AGUI_EXTRAS_KEY``, which is
+    the same slot :func:`~langgraph_events.agui._mappers._langchain_to_agui_messages`
+    reads on the way out. A message with no extra fields gets an empty
+    ``additional_kwargs``.
+    """
+    extra = message.model_extra
+    if not extra:
+        return {}
+    return {AGUI_EXTRAS_KEY: dict(extra)}
 
 
 def agui_messages_to_langchain(  # noqa: PLR0912
@@ -29,6 +46,10 @@ def agui_messages_to_langchain(  # noqa: PLR0912
 
     Reasoning and developer messages are skipped (logged at DEBUG); activity
     and unknown roles raise ``ValueError``.
+
+    An AG-UI ``ToolMessage.error`` becomes ``ToolMessage.status="error"``.
+    Fields the client added beyond the AG-UI schema land under the reserved
+    ``additional_kwargs[AGUI_EXTRAS_KEY]`` key. See :data:`AGUI_EXTRAS_KEY`.
 
     The default ``drop_invalid_tool_calls=False`` propagates
     ``json.JSONDecodeError`` for parity with upstream ``ag-ui-langgraph`` —
@@ -68,7 +89,14 @@ def agui_messages_to_langchain(  # noqa: PLR0912
                 content = parts
             else:
                 content = m.content
-            out.append(HumanMessage(id=m.id, content=content, name=m.name))
+            out.append(
+                HumanMessage(
+                    id=m.id,
+                    content=content,
+                    name=m.name,
+                    additional_kwargs=_agui_extras(m),
+                )
+            )
         elif isinstance(m, AssistantMessage):
             tool_calls: list[LCToolCall] = []
             for tc in m.tool_calls or []:
@@ -106,13 +134,27 @@ def agui_messages_to_langchain(  # noqa: PLR0912
                     content=m.content or "",
                     tool_calls=tool_calls,
                     name=m.name,
+                    additional_kwargs=_agui_extras(m),
                 )
             )
         elif isinstance(m, AGUISystemMessage):
-            out.append(SystemMessage(id=m.id, content=m.content, name=m.name))
+            out.append(
+                SystemMessage(
+                    id=m.id,
+                    content=m.content,
+                    name=m.name,
+                    additional_kwargs=_agui_extras(m),
+                )
+            )
         elif isinstance(m, AGUIToolMessage):
             out.append(
-                ToolMessage(id=m.id, content=m.content, tool_call_id=m.tool_call_id)
+                ToolMessage(
+                    id=m.id,
+                    content=m.content,
+                    tool_call_id=m.tool_call_id,
+                    status="error" if m.error is not None else "success",
+                    additional_kwargs=_agui_extras(m),
+                )
             )
         else:
             role = getattr(m, "role", type(m).__name__)

--- a/src/langgraph_events/agui/_resume.py
+++ b/src/langgraph_events/agui/_resume.py
@@ -11,7 +11,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from ._mappers import AGUI_EXTRAS_KEY
+from ._extras import collect_inbound_extras
 
 if TYPE_CHECKING:
     from ag_ui.core import Message
@@ -20,21 +20,6 @@ if TYPE_CHECKING:
     from langchain_core.messages.tool_call import ToolCall as LCToolCall
 
 logger = logging.getLogger(__name__)
-
-
-def _agui_extras(message: Any) -> dict[str, Any]:
-    """Return the ``additional_kwargs`` payload for an inbound AG-UI message.
-
-    AG-UI models allow extra fields. Whatever the client sent beyond the
-    declared schema is kept under the reserved ``AGUI_EXTRAS_KEY``, which is
-    the same slot :func:`~langgraph_events.agui._mappers._langchain_to_agui_messages`
-    reads on the way out. A message with no extra fields gets an empty
-    ``additional_kwargs``.
-    """
-    extra = message.model_extra
-    if not extra:
-        return {}
-    return {AGUI_EXTRAS_KEY: dict(extra)}
 
 
 def agui_messages_to_langchain(  # noqa: PLR0912
@@ -49,7 +34,10 @@ def agui_messages_to_langchain(  # noqa: PLR0912
 
     A truthy AG-UI ``ToolMessage.error`` becomes ``ToolMessage.status="error"``.
     Fields the client added beyond the AG-UI schema land under the reserved
-    ``additional_kwargs[AGUI_EXTRAS_KEY]`` key. See :data:`AGUI_EXTRAS_KEY`.
+    ``additional_kwargs[AGUI_EXTRAS_KEY]`` key. Those fields are unvalidated
+    client input that reaches the checkpoint and is served back out. Read
+    :func:`~langgraph_events.agui._extras.collect_inbound_extras` before you
+    rely on them, and note the size cap in :data:`AGUI_EXTRAS_MAX_BYTES`.
 
     The default ``drop_invalid_tool_calls=False`` propagates
     ``json.JSONDecodeError`` for parity with upstream ``ag-ui-langgraph`` —
@@ -94,7 +82,7 @@ def agui_messages_to_langchain(  # noqa: PLR0912
                     id=m.id,
                     content=content,
                     name=m.name,
-                    additional_kwargs=_agui_extras(m),
+                    additional_kwargs=collect_inbound_extras(m),
                 )
             )
         elif isinstance(m, AssistantMessage):
@@ -134,7 +122,7 @@ def agui_messages_to_langchain(  # noqa: PLR0912
                     content=m.content or "",
                     tool_calls=tool_calls,
                     name=m.name,
-                    additional_kwargs=_agui_extras(m),
+                    additional_kwargs=collect_inbound_extras(m),
                 )
             )
         elif isinstance(m, AGUISystemMessage):
@@ -143,7 +131,7 @@ def agui_messages_to_langchain(  # noqa: PLR0912
                     id=m.id,
                     content=m.content,
                     name=m.name,
-                    additional_kwargs=_agui_extras(m),
+                    additional_kwargs=collect_inbound_extras(m),
                 )
             )
         elif isinstance(m, AGUIToolMessage):
@@ -156,7 +144,7 @@ def agui_messages_to_langchain(  # noqa: PLR0912
                     # The outbound mapper never sends an empty `error`, so a
                     # client that initialises `error: ""` reports no failure.
                     status="error" if m.error else "success",
-                    additional_kwargs=_agui_extras(m),
+                    additional_kwargs=collect_inbound_extras(m),
                 )
             )
         else:

--- a/src/langgraph_events/agui/_resume.py
+++ b/src/langgraph_events/agui/_resume.py
@@ -47,7 +47,7 @@ def agui_messages_to_langchain(  # noqa: PLR0912
     Reasoning and developer messages are skipped (logged at DEBUG); activity
     and unknown roles raise ``ValueError``.
 
-    An AG-UI ``ToolMessage.error`` becomes ``ToolMessage.status="error"``.
+    A truthy AG-UI ``ToolMessage.error`` becomes ``ToolMessage.status="error"``.
     Fields the client added beyond the AG-UI schema land under the reserved
     ``additional_kwargs[AGUI_EXTRAS_KEY]`` key. See :data:`AGUI_EXTRAS_KEY`.
 
@@ -152,7 +152,10 @@ def agui_messages_to_langchain(  # noqa: PLR0912
                     id=m.id,
                     content=m.content,
                     tool_call_id=m.tool_call_id,
-                    status="error" if m.error is not None else "success",
+                    # A truthy `error` marks the failure, in both directions.
+                    # The outbound mapper never sends an empty `error`, so a
+                    # client that initialises `error: ""` reports no failure.
+                    status="error" if m.error else "success",
                     additional_kwargs=_agui_extras(m),
                 )
             )

--- a/src/langgraph_events/agui/_tools.py
+++ b/src/langgraph_events/agui/_tools.py
@@ -80,8 +80,11 @@ def detect_new_tool_results(
                 # Normalize falsy ("") id to None so LangChain generates a fresh one.
                 id=getattr(msg, "id", None) or None,
                 # AG-UI reports a client-side tool failure through `error`.
-                # Without this the model reads the failure as a success.
-                status="error" if error is not None else "success",
+                # Without this the model reads the failure as a success. A
+                # truthy `error` marks the failure, in both directions: the
+                # outbound mapper never sends an empty `error`, so a client
+                # that initialises `error: ""` reports no failure.
+                status="error" if error else "success",
             )
         )
     return results

--- a/src/langgraph_events/agui/_tools.py
+++ b/src/langgraph_events/agui/_tools.py
@@ -72,12 +72,16 @@ def detect_new_tool_results(
             )
         if tc_id in existing:
             continue
+        error = getattr(msg, "error", None)
         results.append(
             LCToolMessage(
                 content=getattr(msg, "content", "") or "",
                 tool_call_id=tc_id,
                 # Normalize falsy ("") id to None so LangChain generates a fresh one.
                 id=getattr(msg, "id", None) or None,
+                # AG-UI reports a client-side tool failure through `error`.
+                # Without this the model reads the failure as a success.
+                status="error" if error is not None else "success",
             )
         )
     return results

--- a/src/langgraph_events/agui/_tools.py
+++ b/src/langgraph_events/agui/_tools.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from ._extras import collect_inbound_extras
+
 if TYPE_CHECKING:
     from ag_ui.core import RunAgentInput, Tool
     from langchain_core.messages import ToolMessage
@@ -43,6 +45,12 @@ def detect_new_tool_results(
     entry whose ``tool_call_id`` is not already present among the tool
     messages in ``checkpoint_state["messages"]``.  Handles the fresh-run
     case (``checkpoint_state is None``) by returning ``[]``.
+
+    Carries the same fields as :func:`agui_messages_to_langchain`: a truthy
+    AG-UI ``error`` becomes ``status="error"``, and the extra fields the client
+    added land under ``additional_kwargs[AGUI_EXTRAS_KEY]``. Read
+    :func:`~langgraph_events.agui._extras.collect_inbound_extras` for the trust
+    boundary that slot carries.
     """
     from langchain_core.messages import ToolMessage as LCToolMessage  # noqa: PLC0415
 
@@ -85,6 +93,7 @@ def detect_new_tool_results(
                 # outbound mapper never sends an empty `error`, so a client
                 # that initialises `error: ""` reports no failure.
                 status="error" if error else "success",
+                additional_kwargs=collect_inbound_extras(msg),
             )
         )
     return results

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -4154,6 +4154,31 @@ def describe_detect_new_tool_results():
             [out] = detect_new_tool_results(inp, {"messages": []})
             assert out.status == "success"
 
+    def when_the_agui_error_field_is_an_empty_string():
+        """A client that initialises `error: ""` reports no failure.
+
+        The outbound mapper never sends an empty `error`, because a client
+        writing `if (msg.error)` would read it as a success. Truthiness is
+        therefore the one rule that governs the field, in both directions.
+        """
+
+        def it_marks_the_langchain_message_as_a_success():
+            from ag_ui.core import ToolMessage as AguiToolMessage
+
+            inp = _make_input(
+                messages=[
+                    AguiToolMessage(
+                        id="m-1",
+                        role="tool",
+                        content="42",
+                        tool_call_id="tc-1",
+                        error="",
+                    ),
+                ],
+            )
+            [out] = detect_new_tool_results(inp, {"messages": []})
+            assert out.status == "success"
+
 
 def describe_frontend_state_mutated_event_class():
     """Shape checks for the new FrontendStateMutated event."""

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -2963,7 +2963,7 @@ def describe_system_message_conversion():
 
 
 def describe_agui_message_extras():
-    """`additional_kwargs["agui"]` rides through onto the AG-UI message."""
+    """The reserved `additional_kwargs` key rides through onto the AG-UI message."""
 
     def when_the_reserved_key_carries_a_mapping():
         async def it_forwards_each_entry_as_an_agui_message_field():
@@ -2972,7 +2972,9 @@ def describe_agui_message_extras():
                 return SystemPromptDelivered(
                     message=SystemMessage(
                         content="the step failed",
-                        additional_kwargs={"agui": {"failure": {"retryable": True}}},
+                        additional_kwargs={
+                            "langgraph_events.agui": {"failure": {"retryable": True}}
+                        },
                     )
                 )
 
@@ -2995,7 +2997,9 @@ def describe_agui_message_extras():
                         ToolMessage(
                             content="42",
                             tool_call_id="tc-1",
-                            additional_kwargs={"agui": {"latency_ms": 12}},
+                            additional_kwargs={
+                                "langgraph_events.agui": {"latency_ms": 12}
+                            },
                         ),
                     )
                 )
@@ -3043,7 +3047,10 @@ def describe_agui_message_extras():
                     message=SystemMessage(
                         content="plain",
                         additional_kwargs={
-                            "agui": {"content": "hijacked", "failure": "kept"}
+                            "langgraph_events.agui": {
+                                "content": "hijacked",
+                                "failure": "kept",
+                            }
                         },
                     )
                 )
@@ -3067,7 +3074,9 @@ def describe_agui_message_extras():
                 return SystemPromptDelivered(
                     message=SystemMessage(
                         content="plain",
-                        additional_kwargs={"agui": {"content": "hijacked"}},
+                        additional_kwargs={
+                            "langgraph_events.agui": {"content": "hijacked"}
+                        },
                     )
                 )
 
@@ -3089,7 +3098,9 @@ def describe_agui_message_extras():
                 return SystemPromptDelivered(
                     message=SystemMessage(
                         content="plain",
-                        additional_kwargs={"agui": {"content": "hijacked"}},
+                        additional_kwargs={
+                            "langgraph_events.agui": {"content": "hijacked"}
+                        },
                     )
                 )
 
@@ -3114,7 +3125,9 @@ def describe_agui_message_extras():
                         ToolMessage(
                             content="42",
                             tool_call_id="tc-1",
-                            additional_kwargs={"agui": {"toolCallId": "spoofed"}},
+                            additional_kwargs={
+                                "langgraph_events.agui": {"toolCallId": "spoofed"}
+                            },
                         ),
                     )
                 )
@@ -3139,7 +3152,9 @@ def describe_agui_message_extras():
                 return SystemPromptDelivered(
                     message=SystemMessage(
                         content="plain",
-                        additional_kwargs={"agui": {7: "numeric", "failure": "kept"}},
+                        additional_kwargs={
+                            "langgraph_events.agui": {7: "numeric", "failure": "kept"}
+                        },
                     )
                 )
 
@@ -3162,7 +3177,9 @@ def describe_agui_message_extras():
                 return SystemPromptDelivered(
                     message=SystemMessage(
                         content="plain",
-                        additional_kwargs={"agui": ["not", "a", "mapping"]},
+                        additional_kwargs={
+                            "langgraph_events.agui": ["not", "a", "mapping"]
+                        },
                     )
                 )
 
@@ -3185,7 +3202,9 @@ def describe_agui_message_extras():
                 return SystemPromptDelivered(
                     message=SystemMessage(
                         content="plain",
-                        additional_kwargs={"agui": ["not", "a", "mapping"]},
+                        additional_kwargs={
+                            "langgraph_events.agui": ["not", "a", "mapping"]
+                        },
                     )
                 )
 
@@ -3215,7 +3234,9 @@ def describe_agui_message_extras():
                 return SystemPromptDelivered(
                     message=SystemMessage(
                         content="plain",
-                        additional_kwargs={"agui": ["not", "a", "mapping"]},
+                        additional_kwargs={
+                            "langgraph_events.agui": ["not", "a", "mapping"]
+                        },
                     )
                 )
 

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -3166,6 +3166,58 @@ def describe_tool_message_status_conversion():
             assert tool_msg.error == "boom"
             assert tool_msg.content == "boom"
 
+        def when_the_content_is_empty():
+            async def it_still_sets_a_truthy_error():
+                @on(UserAsked)
+                def run_tool(event: UserAsked) -> ToolsExecuted:
+                    return ToolsExecuted(
+                        messages=(
+                            ToolMessage(
+                                content="",
+                                tool_call_id="tc-1",
+                                status="error",
+                            ),
+                        )
+                    )
+
+                graph = EventGraph([run_tool], reducers=[message_reducer()])
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="go"),
+                )
+                events = await _collect(adapter, _make_input())
+
+                snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+                [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+                assert tool_msg.error == "error"
+                assert tool_msg.content == ""
+
+        def when_the_content_is_a_block_list():
+            async def it_still_sets_a_truthy_error():
+                @on(UserAsked)
+                def run_tool(event: UserAsked) -> ToolsExecuted:
+                    return ToolsExecuted(
+                        messages=(
+                            ToolMessage(
+                                content=[{"type": "text", "text": "boom"}],
+                                tool_call_id="tc-1",
+                                status="error",
+                            ),
+                        )
+                    )
+
+                graph = EventGraph([run_tool], reducers=[message_reducer()])
+                adapter = AGUIAdapter(
+                    graph=graph,
+                    seed_factory=lambda inp: UserAsked(question="go"),
+                )
+                events = await _collect(adapter, _make_input())
+
+                snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+                [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+                assert tool_msg.error == "error"
+                assert tool_msg.content == ""
+
     def when_the_status_is_success():
         async def it_leaves_the_agui_error_field_unset():
             @on(UserAsked)

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -4200,6 +4200,63 @@ def describe_detect_new_tool_results():
             [out] = detect_new_tool_results(inp, {"messages": []})
             assert out.status == "success"
 
+    def when_the_agui_message_carries_extra_fields():
+        """The same slot `agui_messages_to_langchain` fills on the other path."""
+
+        def it_collects_them_under_the_reserved_additional_kwargs_key():
+            from ag_ui.core import ToolMessage as AguiToolMessage
+
+            inp = _make_input(
+                messages=[
+                    AguiToolMessage(
+                        id="m-1",
+                        role="tool",
+                        content="42",
+                        tool_call_id="tc-1",
+                        latency_ms=12,
+                    ),
+                ],
+            )
+            [out] = detect_new_tool_results(inp, {"messages": []})
+            assert out.additional_kwargs == {
+                "langgraph_events.agui": {"latency_ms": 12}
+            }
+
+        def when_the_extra_fields_exceed_the_cap():
+            def it_drops_them():
+                from ag_ui.core import ToolMessage as AguiToolMessage
+
+                inp = _make_input(
+                    messages=[
+                        AguiToolMessage(
+                            id="m-1",
+                            role="tool",
+                            content="42",
+                            tool_call_id="tc-1",
+                            blob="a" * 9000,
+                        ),
+                    ],
+                )
+                [out] = detect_new_tool_results(inp, {"messages": []})
+                assert out.additional_kwargs == {}
+
+    def when_the_agui_message_carries_no_extra_fields():
+        def it_leaves_additional_kwargs_empty():
+            from ag_ui.core import ToolMessage as AguiToolMessage
+
+            inp = _make_input(
+                messages=[
+                    AguiToolMessage(
+                        id="m-1",
+                        role="tool",
+                        content="42",
+                        tool_call_id="tc-1",
+                    ),
+                ],
+            )
+            [out] = detect_new_tool_results(inp, {"messages": []})
+            assert out.additional_kwargs == {}
+
 
 def describe_frontend_state_mutated_event_class():
     """Shape checks for the new FrontendStateMutated event."""

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -2962,6 +2962,255 @@ def describe_system_message_conversion():
         assert sys_msgs[0].content == "You are a helpful assistant"
 
 
+def describe_agui_message_extras():
+    """`additional_kwargs["agui"]` rides through onto the AG-UI message."""
+
+    def when_the_reserved_key_carries_a_mapping():
+        async def it_forwards_each_entry_as_an_agui_message_field():
+            @on(UserAsked)
+            def notify(event: UserAsked) -> SystemPromptDelivered:
+                return SystemPromptDelivered(
+                    message=SystemMessage(
+                        content="the step failed",
+                        additional_kwargs={"agui": {"failure": {"retryable": True}}},
+                    )
+                )
+
+            graph = EventGraph([notify], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+            assert sys_msg.model_dump()["failure"] == {"retryable": True}
+
+        async def it_forwards_on_a_tool_message():
+            @on(UserAsked)
+            def run_tool(event: UserAsked) -> ToolsExecuted:
+                return ToolsExecuted(
+                    messages=(
+                        ToolMessage(
+                            content="42",
+                            tool_call_id="tc-1",
+                            additional_kwargs={"agui": {"latency_ms": 12}},
+                        ),
+                    )
+                )
+
+            graph = EventGraph([run_tool], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+            assert tool_msg.model_dump()["latency_ms"] == 12
+
+    def when_the_reserved_key_is_absent():
+        async def it_adds_no_fields():
+            @on(UserAsked)
+            def notify(event: UserAsked) -> SystemPromptDelivered:
+                return SystemPromptDelivered(
+                    message=SystemMessage(
+                        content="plain",
+                        additional_kwargs={"internal_trace_id": "t-1"},
+                    )
+                )
+
+            graph = EventGraph([notify], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+            assert sys_msg.model_extra == {}
+
+    def when_an_entry_names_a_declared_agui_field():
+        async def it_fails_the_run_naming_the_key():
+            @on(UserAsked)
+            def notify(event: UserAsked) -> SystemPromptDelivered:
+                return SystemPromptDelivered(
+                    message=SystemMessage(
+                        content="plain",
+                        additional_kwargs={"agui": {"content": "hijacked"}},
+                    )
+                )
+
+            graph = EventGraph([notify], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            [error] = [e for e in events if e.type == EventType.RUN_ERROR]
+            assert "content" in error.message
+
+        async def it_rejects_a_camel_case_alias_of_a_declared_field():
+            @on(UserAsked)
+            def run_tool(event: UserAsked) -> ToolsExecuted:
+                return ToolsExecuted(
+                    messages=(
+                        ToolMessage(
+                            content="42",
+                            tool_call_id="tc-1",
+                            additional_kwargs={"agui": {"toolCallId": "spoofed"}},
+                        ),
+                    )
+                )
+
+            graph = EventGraph([run_tool], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            [error] = [e for e in events if e.type == EventType.RUN_ERROR]
+            assert "toolCallId" in error.message
+
+    def when_the_reserved_key_is_not_a_mapping():
+        async def it_fails_the_run():
+            @on(UserAsked)
+            def notify(event: UserAsked) -> SystemPromptDelivered:
+                return SystemPromptDelivered(
+                    message=SystemMessage(
+                        content="plain",
+                        additional_kwargs={"agui": ["not", "a", "mapping"]},
+                    )
+                )
+
+            graph = EventGraph([notify], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            [error] = [e for e in events if e.type == EventType.RUN_ERROR]
+            assert "mapping" in error.message
+
+
+def describe_message_name_forwarding():
+    """LangChain `BaseMessage.name` reaches the AG-UI message that declares it."""
+
+    def when_the_langchain_message_has_a_name():
+        async def it_forwards_the_name():
+            @on(UserAsked)
+            def reply(event: UserAsked) -> AgentReplied:
+                return AgentReplied(message=AIMessage(content="hi", name="planner"))
+
+            graph = EventGraph([reply], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [ai_msg] = [m for m in snap.messages if m.role == "assistant"]
+            assert ai_msg.name == "planner"
+
+    def when_the_langchain_message_has_no_name():
+        async def it_leaves_the_name_unset():
+            @on(UserAsked)
+            def reply(event: UserAsked) -> AgentReplied:
+                return AgentReplied(message=AIMessage(content="hi"))
+
+            graph = EventGraph([reply], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [ai_msg] = [m for m in snap.messages if m.role == "assistant"]
+            assert ai_msg.name is None
+
+
+def describe_tool_message_status_conversion():
+    """LangChain `ToolMessage.status` maps to the AG-UI `error` field."""
+
+    def when_the_status_is_error():
+        async def it_sets_the_agui_error_field():
+            @on(UserAsked)
+            def run_tool(event: UserAsked) -> ToolsExecuted:
+                return ToolsExecuted(
+                    messages=(
+                        ToolMessage(
+                            content="boom",
+                            tool_call_id="tc-1",
+                            status="error",
+                        ),
+                    )
+                )
+
+            graph = EventGraph([run_tool], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+            assert tool_msg.error == "boom"
+            assert tool_msg.content == "boom"
+
+    def when_the_status_is_success():
+        async def it_leaves_the_agui_error_field_unset():
+            @on(UserAsked)
+            def run_tool(event: UserAsked) -> ToolsExecuted:
+                return ToolsExecuted(
+                    messages=(ToolMessage(content="42", tool_call_id="tc-1"),)
+                )
+
+            graph = EventGraph([run_tool], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+            assert tool_msg.error is None
+
+    def when_the_content_is_a_block_list():
+        async def it_still_builds_the_snapshot():
+            @on(UserAsked)
+            def run_tool(event: UserAsked) -> ToolsExecuted:
+                return ToolsExecuted(
+                    messages=(
+                        ToolMessage(
+                            content=[{"type": "text", "text": "42"}],
+                            tool_call_id="tc-1",
+                        ),
+                    )
+                )
+
+            graph = EventGraph([run_tool], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            assert not [e for e in events if e.type == EventType.RUN_ERROR]
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+            assert tool_msg.content == ""
+
+
 def describe_multiple_custom_reducers():
     """StateSnapshot tracks changes across multiple non-message reducers."""
 
@@ -3651,6 +3900,41 @@ def describe_detect_new_tool_results():
 
             with pytest.raises(ValueError, match=r"tool_call_id"):
                 detect_new_tool_results(inp, {"messages": []})
+
+    def when_the_agui_message_reports_an_error():
+        def it_marks_the_langchain_message_as_an_error():
+            from ag_ui.core import ToolMessage as AguiToolMessage
+
+            inp = _make_input(
+                messages=[
+                    AguiToolMessage(
+                        id="m-1",
+                        role="tool",
+                        content="boom",
+                        tool_call_id="tc-1",
+                        error="boom",
+                    ),
+                ],
+            )
+            [out] = detect_new_tool_results(inp, {"messages": []})
+            assert out.status == "error"
+
+    def when_the_agui_message_reports_no_error():
+        def it_marks_the_langchain_message_as_a_success():
+            from ag_ui.core import ToolMessage as AguiToolMessage
+
+            inp = _make_input(
+                messages=[
+                    AguiToolMessage(
+                        id="m-1",
+                        role="tool",
+                        content="42",
+                        tool_call_id="tc-1",
+                    ),
+                ],
+            )
+            [out] = detect_new_tool_results(inp, {"messages": []})
+            assert out.status == "success"
 
 
 def describe_frontend_state_mutated_event_class():

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -36,7 +36,7 @@ from langgraph_events.agui import (
     build_langchain_tools,
     detect_new_tool_results,
 )
-from langgraph_events.agui._mappers import _warned_classes
+from langgraph_events.agui._mappers import _warned_classes, _warned_extras
 
 # ---------------------------------------------------------------------------
 # Test event classes
@@ -3034,7 +3034,34 @@ def describe_agui_message_extras():
             assert sys_msg.model_extra == {}
 
     def when_an_entry_names_a_declared_agui_field():
-        async def it_fails_the_run_naming_the_key():
+        """The declared field wins — the entry would rewrite protocol data."""
+
+        async def it_drops_the_entry_and_keeps_the_rest():
+            @on(UserAsked)
+            def notify(event: UserAsked) -> SystemPromptDelivered:
+                return SystemPromptDelivered(
+                    message=SystemMessage(
+                        content="plain",
+                        additional_kwargs={
+                            "agui": {"content": "hijacked", "failure": "kept"}
+                        },
+                    )
+                )
+
+            graph = EventGraph([notify], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            assert not [e for e in events if e.type == EventType.RUN_ERROR]
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+            assert sys_msg.content == "plain"
+            assert sys_msg.model_extra == {"failure": "kept"}
+
+        async def it_warns_naming_the_key():
             @on(UserAsked)
             def notify(event: UserAsked) -> SystemPromptDelivered:
                 return SystemPromptDelivered(
@@ -3049,10 +3076,35 @@ def describe_agui_message_extras():
                 graph=graph,
                 seed_factory=lambda inp: UserAsked(question="go"),
             )
-            events = await _collect(adapter, _make_input())
+            _warned_extras.clear()
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                await _collect(adapter, _make_input())
 
-            [error] = [e for e in events if e.type == EventType.RUN_ERROR]
-            assert "content" in error.message
+            assert [x for x in w if "content" in str(x.message)]
+
+        async def it_warns_once_for_the_repeated_drop():
+            @on(UserAsked)
+            def notify(event: UserAsked) -> SystemPromptDelivered:
+                return SystemPromptDelivered(
+                    message=SystemMessage(
+                        content="plain",
+                        additional_kwargs={"agui": {"content": "hijacked"}},
+                    )
+                )
+
+            graph = EventGraph([notify], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            _warned_extras.clear()
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                await _collect(adapter, _make_input())
+                await _collect(adapter, _make_input())
+
+            assert len([x for x in w if "content" in str(x.message)]) == 1
 
         async def it_rejects_a_camel_case_alias_of_a_declared_field():
             @on(UserAsked)
@@ -3074,11 +3126,37 @@ def describe_agui_message_extras():
             )
             events = await _collect(adapter, _make_input())
 
-            [error] = [e for e in events if e.type == EventType.RUN_ERROR]
-            assert "toolCallId" in error.message
+            assert not [e for e in events if e.type == EventType.RUN_ERROR]
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+            assert tool_msg.tool_call_id == "tc-1"
+            assert tool_msg.model_extra == {}
+
+    def when_an_entry_key_is_not_a_string():
+        async def it_drops_the_entry_and_keeps_the_rest():
+            @on(UserAsked)
+            def notify(event: UserAsked) -> SystemPromptDelivered:
+                return SystemPromptDelivered(
+                    message=SystemMessage(
+                        content="plain",
+                        additional_kwargs={"agui": {7: "numeric", "failure": "kept"}},
+                    )
+                )
+
+            graph = EventGraph([notify], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            assert not [e for e in events if e.type == EventType.RUN_ERROR]
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+            assert sys_msg.model_extra == {"failure": "kept"}
 
     def when_the_reserved_key_is_not_a_mapping():
-        async def it_fails_the_run():
+        async def it_drops_the_value():
             @on(UserAsked)
             def notify(event: UserAsked) -> SystemPromptDelivered:
                 return SystemPromptDelivered(
@@ -3095,8 +3173,75 @@ def describe_agui_message_extras():
             )
             events = await _collect(adapter, _make_input())
 
-            [error] = [e for e in events if e.type == EventType.RUN_ERROR]
-            assert "mapping" in error.message
+            assert not [e for e in events if e.type == EventType.RUN_ERROR]
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+            assert sys_msg.content == "plain"
+            assert sys_msg.model_extra == {}
+
+        async def it_warns_naming_the_type_it_got():
+            @on(UserAsked)
+            def notify(event: UserAsked) -> SystemPromptDelivered:
+                return SystemPromptDelivered(
+                    message=SystemMessage(
+                        content="plain",
+                        additional_kwargs={"agui": ["not", "a", "mapping"]},
+                    )
+                )
+
+            graph = EventGraph([notify], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            _warned_extras.clear()
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                await _collect(adapter, _make_input())
+
+            assert [x for x in w if "list" in str(x.message)]
+
+    def when_a_bad_reserved_key_is_already_in_the_checkpoint():
+        """`build_messages_snapshot` runs on every `connect()`.
+
+        A raise inside it escapes the async generator into the consumer's
+        HTTP handler and never becomes a RUN_ERROR. The bad value sits in
+        the checkpoint, so the thread would raise forever.
+        """
+
+        async def it_still_serves_the_connect_snapshot():
+            @on(UserAsked)
+            def notify(event: UserAsked) -> SystemPromptDelivered:
+                return SystemPromptDelivered(
+                    message=SystemMessage(
+                        content="plain",
+                        additional_kwargs={"agui": ["not", "a", "mapping"]},
+                    )
+                )
+
+            graph = EventGraph(
+                [notify],
+                checkpointer=MemorySaver(),
+                reducers=[message_reducer()],
+            )
+            await graph.ainvoke(
+                UserAsked(question="go"),
+                config={"configurable": {"thread_id": "t-poisoned"}},
+            )
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="unused"),
+            )
+
+            events = [
+                event
+                async for event in adapter.connect(_make_input(thread_id="t-poisoned"))
+            ]
+
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+            assert sys_msg.content == "plain"
+            assert sys_msg.model_extra == {}
 
 
 def describe_message_name_forwarding():
@@ -3261,6 +3406,27 @@ def describe_tool_message_status_conversion():
             snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
             [tool_msg] = [m for m in snap.messages if m.role == "tool"]
             assert tool_msg.content == ""
+
+        async def it_logs_a_warning_naming_the_tool_call(caplog):
+            @on(UserAsked)
+            def run_tool(event: UserAsked) -> ToolsExecuted:
+                return ToolsExecuted(
+                    messages=(
+                        ToolMessage(
+                            content=[{"type": "text", "text": "42"}],
+                            tool_call_id="tc-dropped",
+                        ),
+                    )
+                )
+
+            graph = EventGraph([run_tool], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            await _collect(adapter, _make_input())
+
+            assert any("tc-dropped" in r.message for r in caplog.records)
 
 
 def describe_multiple_custom_reducers():

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -33,6 +33,7 @@ from langgraph_events.agui import (
     InterruptedWithPayload,
     MapperContext,
     UnmappedEventError,
+    agui_messages_to_langchain,
     build_langchain_tools,
     detect_new_tool_results,
 )
@@ -3015,6 +3016,52 @@ def describe_agui_message_extras():
             [tool_msg] = [m for m in snap.messages if m.role == "tool"]
             assert tool_msg.model_dump()["latency_ms"] == 12
 
+        async def it_forwards_on_a_user_message():
+            @on(UserAsked)
+            def echo(event: UserAsked) -> UserSent:
+                return UserSent(
+                    message=HumanMessage(
+                        content="hello",
+                        additional_kwargs={
+                            "langgraph_events.agui": {"source": "voice"}
+                        },
+                    )
+                )
+
+            graph = EventGraph([echo], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [user_msg] = [m for m in snap.messages if m.role == "user"]
+            assert user_msg.model_dump()["source"] == "voice"
+
+        async def it_forwards_on_an_assistant_message():
+            @on(UserAsked)
+            def reply(event: UserAsked) -> AgentReplied:
+                return AgentReplied(
+                    message=AIMessage(
+                        content="hi",
+                        additional_kwargs={
+                            "langgraph_events.agui": {"confidence": 0.9}
+                        },
+                    )
+                )
+
+            graph = EventGraph([reply], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [ai_msg] = [m for m in snap.messages if m.role == "assistant"]
+            assert ai_msg.model_dump()["confidence"] == 0.9
+
     def when_the_reserved_key_is_absent():
         async def it_adds_no_fields():
             @on(UserAsked)
@@ -3090,7 +3137,7 @@ def describe_agui_message_extras():
                 warnings.simplefilter("always")
                 await _collect(adapter, _make_input())
 
-            assert [x for x in w if "content" in str(x.message)]
+            assert [x for x in w if "declares content" in str(x.message)]
 
         async def it_warns_once_for_the_repeated_drop():
             @on(UserAsked)
@@ -3115,7 +3162,7 @@ def describe_agui_message_extras():
                 await _collect(adapter, _make_input())
                 await _collect(adapter, _make_input())
 
-            assert len([x for x in w if "content" in str(x.message)]) == 1
+            assert len([x for x in w if "declares content" in str(x.message)]) == 1
 
         async def it_rejects_a_camel_case_alias_of_a_declared_field():
             @on(UserAsked)
@@ -3265,11 +3312,50 @@ def describe_agui_message_extras():
             assert sys_msg.model_extra == {}
 
 
+def describe_agui_message_extras_round_trip():
+    """A client's extra fields come back out on the next snapshot."""
+
+    def when_an_inbound_message_carries_extra_fields():
+        async def it_returns_them_to_the_client_unchanged():
+            from ag_ui.core import ToolMessage as AguiToolMessage
+
+            carried: list[Any] = []
+
+            def seed(inp: RunAgentInput) -> UserAsked:
+                carried.extend(agui_messages_to_langchain(inp.messages))
+                return UserAsked(question="go")
+
+            @on(UserAsked)
+            def replay(event: UserAsked) -> ToolsExecuted:
+                return ToolsExecuted(messages=tuple(carried))
+
+            graph = EventGraph([replay], reducers=[message_reducer()])
+            adapter = AGUIAdapter(graph=graph, seed_factory=seed)
+            events = await _collect(
+                adapter,
+                _make_input(
+                    messages=[
+                        AguiToolMessage(
+                            id="m-1",
+                            role="tool",
+                            content="42",
+                            tool_call_id="tc-1",
+                            latency_ms=12,
+                        )
+                    ]
+                ),
+            )
+
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+            assert tool_msg.model_dump()["latency_ms"] == 12
+
+
 def describe_message_name_forwarding():
     """LangChain `BaseMessage.name` reaches the AG-UI message that declares it."""
 
     def when_the_langchain_message_has_a_name():
-        async def it_forwards_the_name():
+        async def it_forwards_the_name_on_an_assistant_message():
             @on(UserAsked)
             def reply(event: UserAsked) -> AgentReplied:
                 return AgentReplied(message=AIMessage(content="hi", name="planner"))
@@ -3284,6 +3370,40 @@ def describe_message_name_forwarding():
             snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
             [ai_msg] = [m for m in snap.messages if m.role == "assistant"]
             assert ai_msg.name == "planner"
+
+        async def it_forwards_the_name_on_a_user_message():
+            @on(UserAsked)
+            def echo(event: UserAsked) -> UserSent:
+                return UserSent(message=HumanMessage(content="hi", name="alice"))
+
+            graph = EventGraph([echo], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [user_msg] = [m for m in snap.messages if m.role == "user"]
+            assert user_msg.name == "alice"
+
+        async def it_forwards_the_name_on_a_system_message():
+            @on(UserAsked)
+            def notify(event: UserAsked) -> SystemPromptDelivered:
+                return SystemPromptDelivered(
+                    message=SystemMessage(content="rules", name="policy")
+                )
+
+            graph = EventGraph([notify], reducers=[message_reducer()])
+            adapter = AGUIAdapter(
+                graph=graph,
+                seed_factory=lambda inp: UserAsked(question="go"),
+            )
+            events = await _collect(adapter, _make_input())
+
+            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
+            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+            assert sys_msg.name == "policy"
 
     def when_the_langchain_message_has_no_name():
         async def it_leaves_the_name_unset():

--- a/tests/test_agui_resume.py
+++ b/tests/test_agui_resume.py
@@ -273,6 +273,28 @@ def describe_agui_messages_to_langchain():
                 "langgraph_events.agui": {"failure": {"retryable": True}}
             }
 
+    def when_message_carries_more_extra_data_than_the_cap_allows():
+        """Inbound extras are client input that reaches the checkpoint.
+
+        Without a cap a client can grow a thread's checkpoint without bound.
+        """
+
+        def it_drops_them():
+            msg = AGUISystemMessage(id="s1", content="x", blob="a" * 9000)
+            [out] = agui_messages_to_langchain([msg])
+            assert out.additional_kwargs == {}
+
+        def it_logs_a_warning_naming_the_message(caplog):
+            msg = AGUISystemMessage(id="s-oversized", content="x", blob="a" * 9000)
+            agui_messages_to_langchain([msg])
+            assert any("s-oversized" in r.message for r in caplog.records)
+
+    def when_an_extra_value_cannot_be_measured():
+        def it_drops_them():
+            msg = AGUISystemMessage(id="s1", content="x", blob=object())
+            [out] = agui_messages_to_langchain([msg])
+            assert out.additional_kwargs == {}
+
     def when_message_carries_no_extra_fields():
         def it_leaves_additional_kwargs_empty():
             msg = AGUISystemMessage(id="s1", content="x")

--- a/tests/test_agui_resume.py
+++ b/tests/test_agui_resume.py
@@ -228,12 +228,30 @@ def describe_agui_messages_to_langchain():
             assert out.content == "42"
             assert out.tool_call_id == "tc1"
 
-        def it_does_not_propagate_error_field():
-            msg = AGUIToolMessage(
-                id="tm1", content="42", tool_call_id="tc1", error="boom"
-            )
+        def it_defaults_status_to_success():
+            msg = AGUIToolMessage(id="tm1", content="42", tool_call_id="tc1")
             [out] = agui_messages_to_langchain([msg])
-            assert getattr(out, "status", None) != "error"
+            assert out.status == "success"
+
+        def when_the_error_field_is_set():
+            def it_maps_the_error_field_to_an_error_status():
+                msg = AGUIToolMessage(
+                    id="tm1", content="42", tool_call_id="tc1", error="boom"
+                )
+                [out] = agui_messages_to_langchain([msg])
+                assert out.status == "error"
+
+    def when_message_carries_extra_fields():
+        def it_collects_them_under_the_reserved_additional_kwargs_key():
+            msg = AGUISystemMessage(id="s1", content="x", failure={"retryable": True})
+            [out] = agui_messages_to_langchain([msg])
+            assert out.additional_kwargs == {"agui": {"failure": {"retryable": True}}}
+
+    def when_message_carries_no_extra_fields():
+        def it_leaves_additional_kwargs_empty():
+            msg = AGUISystemMessage(id="s1", content="x")
+            [out] = agui_messages_to_langchain([msg])
+            assert out.additional_kwargs == {}
 
     def when_role_is_reasoning():
         def it_skips_silently():

--- a/tests/test_agui_resume.py
+++ b/tests/test_agui_resume.py
@@ -241,6 +241,15 @@ def describe_agui_messages_to_langchain():
                 [out] = agui_messages_to_langchain([msg])
                 assert out.status == "error"
 
+            def when_the_content_is_empty():
+                def it_still_maps_to_an_error_status():
+                    msg = AGUIToolMessage(
+                        id="tm1", content="", tool_call_id="tc1", error="error"
+                    )
+                    [out] = agui_messages_to_langchain([msg])
+                    assert out.status == "error"
+                    assert out.content == ""
+
     def when_message_carries_extra_fields():
         def it_collects_them_under_the_reserved_additional_kwargs_key():
             msg = AGUISystemMessage(id="s1", content="x", failure={"retryable": True})

--- a/tests/test_agui_resume.py
+++ b/tests/test_agui_resume.py
@@ -250,6 +250,21 @@ def describe_agui_messages_to_langchain():
                     assert out.status == "error"
                     assert out.content == ""
 
+        def when_the_error_field_is_an_empty_string():
+            """A client that initialises `error: ""` reports no failure.
+
+            The outbound mapper never sends an empty `error`, because a client
+            writing `if (msg.error)` would read it as a success. Truthiness is
+            therefore the one rule that governs the field, in both directions.
+            """
+
+            def it_maps_to_a_success_status():
+                msg = AGUIToolMessage(
+                    id="tm1", content="42", tool_call_id="tc1", error=""
+                )
+                [out] = agui_messages_to_langchain([msg])
+                assert out.status == "success"
+
     def when_message_carries_extra_fields():
         def it_collects_them_under_the_reserved_additional_kwargs_key():
             msg = AGUISystemMessage(id="s1", content="x", failure={"retryable": True})

--- a/tests/test_agui_resume.py
+++ b/tests/test_agui_resume.py
@@ -269,7 +269,9 @@ def describe_agui_messages_to_langchain():
         def it_collects_them_under_the_reserved_additional_kwargs_key():
             msg = AGUISystemMessage(id="s1", content="x", failure={"retryable": True})
             [out] = agui_messages_to_langchain([msg])
-            assert out.additional_kwargs == {"agui": {"failure": {"retryable": True}}}
+            assert out.additional_kwargs == {
+                "langgraph_events.agui": {"failure": {"retryable": True}}
+            }
 
     def when_message_carries_no_extra_fields():
         def it_leaves_additional_kwargs_empty():


### PR DESCRIPTION
Two small fixes in the AG-UI adapter. Both are about data the adapter silently throws away.

## Problem 1 — you cannot attach anything to a message

`_langchain_to_agui_messages` converts LangChain messages to AG-UI messages. It copies `id`, `role`, `content` (and tool call fields), and **drops everything else on the floor**.

So if you want to tag a message with structured data — say a notice that reports a failure, carrying whether it can be retried — there is no way to get it to the browser. The information exists on the backend, the AG-UI models accept extra fields (`extra="allow"`), and the browser would receive them fine. The converter is the only thing in the way.

**Fix:** a reserved key in LangChain's `additional_kwargs`, exported as `AGUI_EXTRAS_KEY` (`"agui"`).

```python
SystemMessage(content="…", additional_kwargs={"agui": {"failure": {"retryable": True}}})
# arrives as: {id, role, content, failure: {retryable: true}}
```

It round-trips: an inbound message's extra fields are collected back under the same key.

Two guards, both raising with the offending key named:
- an entry that would overwrite a declared AG-UI field, checked against **names and camelCase aliases** (`populate_by_name=True` means `toolCallId` would otherwise silently clobber `tool_call_id`)
- a non-mapping value

**Why this and not the alternatives.** Forwarding the whole of `additional_kwargs` was rejected because providers write their own keys into it (`refusal`, `function_call`, …), so backend state would leak to the browser by accident. An adapter-level allow-list was rejected because it puts the policy in the constructor, far from the message it governs — and `build_messages_snapshot` is a free function, so adapter state would have to be threaded through it.

## Problem 2 — a failed tool is reported to the model as a success

AG-UI's `ToolMessage` has `error?: string`. LangChain's has `status: "success" | "error"`. They mean the same thing, and **we drop the mapping in both directions**.

The consequence is not cosmetic. A client executes a tool, the tool fails, the client says so — and the model is told it succeeded.

Upstream hit the same thing: [ag-ui#2226](https://github.com/ag-ui-protocol/ag-ui/issues/2226), fixed in their PR #2263. That fix covered their `ag_ui_langgraph` adapter (which this library replaces) and only the inbound half. This does both directions.

**Fix:** `status == "error"` maps out to `error`; an inbound `error` maps to `status="error"`. The check is `is not None`, not truthiness, so `error=""` round-trips.

## Two things fixed alongside

**A crash.** The `tool` branch was not defensive about block content, unlike its siblings. A `ToolMessage` with list content raised inside `build_messages_snapshot` and killed the connect stream. AG-UI declares `content: str`, so there is no lossless mapping — degrading beats killing the stream.

**`name` did not round-trip.** The inbound direction read it; the outbound never wrote it. Now forwarded for user, assistant and system messages. AG-UI's `ToolMessage` declares no `name`, so tool messages are unchanged.

## Compatibility

**No serialization impact.** No `Event` class changed shape, so no serde migration and no risk to live checkpoints.

`ToolMessage.status` is an existing LangChain field already defaulting to `"success"`, so payloads are byte-identical unless there is a real error. `additional_kwargs` gains the `"agui"` key only when a client actually sends extra fields.

**No version bump in this PR.** `scripts/release.py` owns version strings; this adds `[Unreleased]` entries only. Note it is a semver **minor**, so it lands in **0.24.0** — outside the current consumer pin `>=0.23.1,<0.24.0`, which will need to widen.

## One thing that wants a second opinion

`tests/test_agui_resume.py` had a test named `it_does_not_propagate_error_field`, which **pinned the dropped mapping as intended behaviour**. I inverted it. Nothing in the repo explained why that assertion existed, so I read it as pinning the omission rather than a deliberate decision. If it was deliberate, this PR is wrong and I would like to know why.

## Checks

- `pytest` — **1163 passed, 1 skipped**, 11 new tests
- `mypy --strict` — clean, 41 files
- `ruff check` / `ruff format --check` — clean
- full `pre-commit run --all-files` — all 9 hooks pass, coverage **96%**

Every test was written failing first.