### PR TITLE
test: compile-check python fences in every published doc (#129)

### DIFF
--- a/tests/test_docs_code_fences.py
+++ b/tests/test_docs_code_fences.py
@@ -56,13 +56,11 @@ MIN_TOTAL_FENCES = 60
 
 def _doc_files() -> list[str]:
     """Return repo-relative paths of every published Markdown doc."""
-    out: list[str] = []
-    for path in sorted(DOCS_ROOT.rglob("*.md")):
-        parent_parts = path.relative_to(DOCS_ROOT).parts[:-1]
-        if EXCLUDED_DIRS.intersection(parent_parts):
-            continue
-        out.append(path.relative_to(REPO_ROOT).as_posix())
-    return out
+    return [
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in sorted(DOCS_ROOT.rglob("*.md"))
+        if EXCLUDED_DIRS.isdisjoint(path.relative_to(DOCS_ROOT).parts[:-1])
+    ]
 
 
 DOC_FILES = _doc_files()

--- a/tests/test_docs_code_fences.py
+++ b/tests/test_docs_code_fences.py
@@ -1,21 +1,71 @@
-"""Compile every ```python fence in migrating.md and concepts.md.
+"""Compile every ```python fence in the published docs.
 
 A previous revision advertised ``NamespaceModel.mermaid(view="structure")`` in
 three docs — the method never accepted a ``view`` argument, so users hit a
 ``TypeError`` on first call. Compilation alone catches syntax and
 indentation errors; runtime mismatches still slip through, but this is a
 cheap first net and keeps the cost linear in the number of fences.
+
+Files are discovered by glob rather than listed by hand. An explicit list let
+``docs/control-flow.md`` ship 8 unchecked fences for as long as nobody
+remembered to extend it (issue #129); a glob means a new doc is covered the
+moment it lands.
+
+The bar is ``compile()``, not ``exec()``. Prose examples are deliberately
+elliptical — ``...`` bodies and undefined names like ``upstream_rate_limited()``
+are correct for a doc and must keep passing. Two accommodations follow from
+treating fences as prose rather than modules:
+
+* Fences nested in a MkDocs admonition (``!!! tip``) are indented by the
+  Markdown, so the source is dedented before compiling. ``textwrap.dedent``
+  strips only the *common* prefix, so a genuinely misindented fence still fails.
+* Snippets are written REPL-style, with ``await`` / ``async for`` at top level
+  rather than wrapped in a throwaway ``async def main()``. Compiling with
+  ``PyCF_ALLOW_TOP_LEVEL_AWAIT`` applies the same bar an async REPL does, and
+  narrows nothing else.
 """
 
 from __future__ import annotations
 
+import ast
 import re
+import textwrap
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_ROOT = REPO_ROOT / "docs"
 FENCE_RE = re.compile(r"```python\r?\n(.*?)```", re.DOTALL)
+
+# Kept out of the built site by ``exclude_docs`` in mkdocs.yml. These are dated
+# design specs — a historical record of a decision, not documentation users can
+# follow — so the published site defines this test's scope. Freezing a snapshot
+# dated 2026-07-27 into something a future compiler must keep accepting would
+# falsify the record; "it no longer compiles" is the wrong reason to edit one.
+EXCLUDED_DIRS = frozenset({"superpowers"})
+
+# Floors, not exact counts: doc churn must not require touching this test, but a
+# broken glob or a mangled FENCE_RE would drive both to zero and quietly turn
+# every parametrised case into a no-op. That vacuity is the one failure mode the
+# hand-written list at least made visible, so it is asserted explicitly below.
+# Measured at the time of writing: 12 files, 71 fences.
+MIN_DOC_FILES = 10
+MIN_TOTAL_FENCES = 60
+
+
+def _doc_files() -> list[str]:
+    """Return repo-relative paths of every published Markdown doc."""
+    out: list[str] = []
+    for path in sorted(DOCS_ROOT.rglob("*.md")):
+        parent_parts = path.relative_to(DOCS_ROOT).parts[:-1]
+        if EXCLUDED_DIRS.intersection(parent_parts):
+            continue
+        out.append(path.relative_to(REPO_ROOT).as_posix())
+    return out
+
+
+DOC_FILES = _doc_files()
 
 
 def _fenced_python(md_path: Path) -> list[tuple[int, str]]:
@@ -24,18 +74,31 @@ def _fenced_python(md_path: Path) -> list[tuple[int, str]]:
     out: list[tuple[int, str]] = []
     for match in FENCE_RE.finditer(text):
         line = text.count("\n", 0, match.start()) + 1
-        out.append((line, match.group(1)))
+        out.append((line, textwrap.dedent(match.group(1))))
     return out
 
 
 def describe_docs_code_fences():
-    @pytest.mark.parametrize(
-        "md_relpath",
-        ["docs/concepts.md", "docs/reflection.md"],
-    )
+    @pytest.mark.parametrize("md_relpath", DOC_FILES)
     def it_compiles_every_python_fence(md_relpath: str) -> None:
-        md_path = REPO_ROOT / md_relpath
-        fences = _fenced_python(md_path)
-        assert fences, f"no python fences found in {md_relpath}"
-        for line, source in fences:
-            compile(source, f"{md_relpath}:{line}", "exec")
+        # A doc with no python fences (patterns.md, checkpointer-evolution.md —
+        # their autogen blocks are mermaid and text tabs) passes vacuously here;
+        # the corpus guard below is what proves the suite is not vacuous overall.
+        for line, source in _fenced_python(REPO_ROOT / md_relpath):
+            compile(
+                source,
+                f"{md_relpath}:{line}",
+                "exec",
+                flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT,
+            )
+
+    def it_discovers_a_substantial_corpus_to_check():
+        total = sum(len(_fenced_python(REPO_ROOT / rel)) for rel in DOC_FILES)
+        assert len(DOC_FILES) >= MIN_DOC_FILES, (
+            f"discovered only {len(DOC_FILES)} docs under {DOCS_ROOT}; "
+            "the glob is broken and the fence check is running on almost nothing"
+        )
+        assert total >= MIN_TOTAL_FENCES, (
+            f"found only {total} python fences across {len(DOC_FILES)} docs; "
+            "FENCE_RE has likely stopped matching and every case above is a no-op"
+        )


### PR DESCRIPTION
Closes #129.

## Why

`tests/test_docs_code_fences.py` compiles every ```python fence in the docs it is pointed at — but its parametrised list named only `docs/concepts.md` and `docs/reflection.md`. Everything else shipped unchecked, including the 8 fences in `docs/control-flow.md`.

## What

Coverage goes from **2 files / 15 fences → 12 files / 71 fences**, and the file list is now a glob over `docs/**/*.md` rather than a literal list — because a literal list is the exact mechanism that let this happen. A new doc is now checked automatically.

Four files failed on first contact. All four turned out to be **harness** limitations, not docs bugs, so the extractor was fixed rather than the prose rewritten:

- **Indented fences** (`agui.md`, `event-migrations.md`) — nested inside MkDocs admonitions (`!!! tip`), so Markdown indents them 4 spaces and the regex captured the indentation. Now `textwrap.dedent`ed; dedent strips only the *common* prefix, so a genuinely misindented fence still fails.
- **Top-level `await` / `async for`** (`agui.md`, `getting-started.md`, `streaming.md`) — REPL-style snippets. Compiling with `ast.PyCF_ALLOW_TOP_LEVEL_AWAIT` applies exactly the bar an async REPL applies and narrows nothing else. Wrapping them in a throwaway `async def main()` would have added noise for readers with no benefit.

`checkpointer-evolution.md` and `patterns.md` have zero python fences (their autogen blocks are mermaid and text tabs) and are skipped rather than special-cased.

## The failure mode a glob introduces

A literal list fails loudly when wrong; a glob **fails open** — point it at the wrong root and you get zero cases, all green. So `it_discovers_a_substantial_corpus_to_check` asserts floors of 10 files / 60 fences (against actuals of 12 / 71). Floors, not exact counts, so ordinary doc churn never touches the test, but a broken glob or a mangled regex drives either to zero and trips it.

`docs/superpowers/` is excluded, honouring mkdocs.yml's `exclude_docs`. Its 2 fences do compile today, so this is a decision on principle: a dated design spec is a historical record, not something a user can follow, and the right response to it breaking would be "it's a frozen snapshot", not "amend the spec to satisfy a compiler".

## Bar

`compile()` only — syntax, not undefined names. Several snippets are deliberately elliptical (`...`, undefined helpers) and that is the right bar for prose examples. Verified the relaxed harness still rejects missing colons, unbalanced parens, bad kwargs, unexpected indents, and unindent mismatches; and that an injected broken fence is reported against the offending file by name.

## Verification

`pytest` 1246 passed / 1 skipped · `ruff check` + `format --check` clean · `mypy src/` clean · `validate_tests.py` 33/33 · `generate_mermaid.py --check` clean.

No CHANGELOG entry: no docs content changed and no user-visible error existed to fix. The diff is one test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)