### PR TITLE
fix: bind a cross-namespace Command subclass's own handler (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `previously`, so a policy can never become a dataclass field serialized into every checkpoint
     — but the guard cannot tell a policy from a payload field of the same name. Rename the field.
 
+### Fixed
+
+- **A `Command` subclassing a `Command` in another namespace now binds its own handler.** The
+  child's `handle()` was silently ignored and the parent's ran instead — the graph built,
+  dispatched, and produced the parent's outcome with no warning. `Command.__init_subclass__`
+  returned early for any subclass whose parent already carried a stamped `__namespace__`, skipping
+  the public-method scan that sets `__command_handler__` along with the nesting validation the
+  early return was meant to waive. Whether the parent was stamped yet was pure class-creation
+  ordering: `__set_name__` stamps `__namespace__` only once the enclosing `Namespace` body
+  finishes, so a child in the *same* namespace bound its handler correctly while a child in a
+  different one did not. The two concerns are now separated — an inheriting subclass still skips
+  the nesting check (its parent carries the namespace), but the handler scan always runs. Commands
+  inheriting across namespaces are consequently subject to the same single-public-method rule as
+  any other command, and a child with no public method of its own still inherits its parent's
+  handler. `raises`/`invariants`/`retry` keep inheriting through the MRO; `previously` stays
+  un-inherited; command privacy still admits a child emitting its parent's private outcomes.
+
 ## [0.24.0] - 2026-08-23
 
 ### Added

--- a/src/langgraph_events/_event.py
+++ b/src/langgraph_events/_event.py
@@ -446,9 +446,14 @@ class Command(Event, _event_base=True, metaclass=_NestedEventMeta):
         for name in _RESERVED_MODIFIERS:
             if any(f.name == name for f in dc_fields(cls)):
                 raise _reserved_modifier_error(cls, name)
-        if _inherits_namespace(cls):
-            return
-        if not _is_nested_in_class(cls):
+        # Inheriting an already-validated Command waives the *nesting* check
+        # (the parent carries the namespace) — but not the handler scan below.
+        # Skipping both used to mean a child declared in a different namespace
+        # than its parent silently kept the parent's handler, while a child in
+        # the same namespace bound its own; the difference was pure class-
+        # creation ordering (``__set_name__`` stamps ``__namespace__`` only
+        # once the enclosing Namespace body finishes), not a decision. See #127.
+        if not _inherits_namespace(cls) and not _is_nested_in_class(cls):
             raise TypeError(
                 f"Command {cls.__name__!r} must be nested inside a Namespace "
                 f"subclass, e.g. "

--- a/tests/test_command_handle.py
+++ b/tests/test_command_handle.py
@@ -297,6 +297,58 @@ class _Lineage(Namespace):
             return _Lineage.Parent.Done()
 
 
+class _CrossBoomError(Exception):
+    pass
+
+
+# Cross-namespace inheritance. ``_Lineage`` above inherits within one
+# namespace, where the parent's ``__namespace__`` is not stamped yet while the
+# shared class body runs. Here the parent namespace is fully built first, so
+# the child subclasses an already-stamped Command — the path that used to skip
+# the handler scan and silently keep the parent's handler (issue #127).
+class _Upstream(Namespace):
+    class Parent(Command):
+        previously: ClassVar = ("legacy_upstream",)
+
+        class Done(DomainEvent):
+            note: str = ""
+
+        def handle(self) -> _Upstream.Parent.Done:
+            return _Upstream.Parent.Done(note="parent")
+
+
+class _Downstream(Namespace):
+    class Child(_Upstream.Parent):
+        def handle(self) -> _Upstream.Parent.Done:
+            return _Upstream.Parent.Done(note="child")
+
+    class Extended(_Upstream.Parent):
+        class Extra(DomainEvent):
+            pass
+
+        def handle(self) -> _Downstream.Extended.Extra:
+            return _Downstream.Extended.Extra()
+
+
+# ``raises`` is a behavioral contract read through the MRO; the child below
+# inherits it across the namespace boundary and raises from its own handler.
+class _UpstreamRaises(Namespace):
+    class Parent(Command):
+        raises: ClassVar = (_CrossBoomError,)
+
+        class Done(DomainEvent):
+            pass
+
+        def handle(self) -> _UpstreamRaises.Parent.Done:
+            return _UpstreamRaises.Parent.Done()
+
+
+class _DownstreamRaises(Namespace):
+    class Child(_UpstreamRaises.Parent):
+        def handle(self) -> _UpstreamRaises.Parent.Done:
+            raise _CrossBoomError("nope")
+
+
 def describe_Command_handle():
 
     def describe_class_creation():
@@ -382,6 +434,47 @@ def describe_Command_handle():
                 log = graph.invoke(_Helped.Cmd())
                 assert log.latest(_Helped.Cmd.Done).note == "ok"
 
+        def when_command_subclasses_a_command_in_another_namespace():
+            # The parent is already stamped with its own ``__namespace__`` by
+            # the time the child's class body runs; the child must still bind
+            # its own handler rather than silently keeping the parent's.
+
+            def it_stamps_the_childs_own_handler():
+                assert (
+                    _Downstream.Child.__command_handler__
+                    is _Downstream.Child.__dict__["handle"]
+                )
+
+            def it_dispatches_the_childs_handler():
+                graph = EventGraph([_Downstream.Child])
+                log = graph.invoke(_Downstream.Child())
+                assert log.latest(_Upstream.Parent.Done).note == "child"
+
+            def it_resolves_outcomes_from_the_parent_namespace():
+                assert _Downstream.Child.Outcomes is _Upstream.Parent.Done
+
+        def when_a_cross_namespace_child_adds_an_outcome():
+
+            def it_synthesises_a_fresh_outcomes_alias():
+                assert _Downstream.Extended.Outcomes is _Downstream.Extended.Extra
+
+            def it_dispatches_to_the_added_outcome():
+                graph = EventGraph([_Downstream.Extended])
+                log = graph.invoke(_Downstream.Extended())
+                assert log.has(_Downstream.Extended.Extra)
+
+        def when_a_subclass_is_not_nested_in_a_namespace():
+            # Inheriting a Command that already carries a namespace keeps the
+            # nesting requirement waived — only the handler scan is restored.
+
+            def it_skips_the_nesting_check():
+                class _Detached(_Upstream.Parent):
+                    pass
+
+                assert (
+                    _Detached.__command_handler__ is _Upstream.Parent.__dict__["handle"]
+                )
+
     def describe_class_level_modifiers():
         def when_invariants_set_as_class_attribute():
             def it_evaluates_the_predicate_at_dispatch():
@@ -457,6 +550,19 @@ def describe_Command_handle():
                 graph = EventGraph([_InlineRaises.Cmd, catch])
                 log = graph.invoke(_InlineRaises.Cmd())
                 assert log.has(HandlerRaised)
+
+        def when_raises_inherited_from_a_parent_in_another_namespace():
+            def it_routes_the_exception_to_HandlerRaised():
+                from langgraph_events import HandlerRaised
+
+                @on(HandlerRaised, exception=_CrossBoomError)
+                def catch_cross(event: HandlerRaised) -> None:
+                    return None
+
+                graph = EventGraph([_DownstreamRaises.Child, catch_cross])
+                log = graph.invoke(_DownstreamRaises.Child())
+                assert log.has(HandlerRaised)
+                assert not log.has(_UpstreamRaises.Parent.Done)
 
         def when_raises_is_declared_as_a_dataclass_field():
             def it_rejects_at_class_creation():
@@ -765,6 +871,18 @@ def describe_Command_handle():
                 assert aliases == {
                     "_Lineage.Parent": ("legacy_save",),
                     "_Lineage.Child": (),
+                }
+
+        def when_a_parent_command_lives_in_another_namespace():
+            # Same rule across namespaces — and registering both proves the
+            # child's handler is its own function, not an alias of the
+            # parent's (which would trip the duplicate-binding build error).
+            def it_is_not_inherited_by_a_subclass():
+                metas = EventGraph([_Upstream.Parent, _Downstream.Child])._handler_metas
+                aliases = {m.node_name: m.previous_names for m in metas}
+                assert aliases == {
+                    "_Upstream.Parent": ("legacy_upstream",),
+                    "_Downstream.Child": (),
                 }
 
     def describe_EventGraph_registration():

--- a/tests/test_command_handle.py
+++ b/tests/test_command_handle.py
@@ -308,8 +308,6 @@ class _CrossBoomError(Exception):
 # the handler scan and silently keep the parent's handler (issue #127).
 class _Upstream(Namespace):
     class Parent(Command):
-        previously: ClassVar = ("legacy_upstream",)
-
         class Done(DomainEvent):
             note: str = ""
 
@@ -453,10 +451,13 @@ def describe_Command_handle():
             def it_resolves_outcomes_from_the_parent_namespace():
                 assert _Downstream.Child.Outcomes is _Upstream.Parent.Done
 
-        def when_a_cross_namespace_child_adds_an_outcome():
+            def it_registers_alongside_its_parent():
+                # Sharing one handler function across two Commands trips the
+                # duplicate-binding build error; pre-fix the child held the
+                # parent's function, so registering both blew up.
+                EventGraph([_Upstream.Parent, _Downstream.Child])  # no raise
 
-            def it_synthesises_a_fresh_outcomes_alias():
-                assert _Downstream.Extended.Outcomes is _Downstream.Extended.Extra
+        def when_a_cross_namespace_child_adds_an_outcome():
 
             def it_dispatches_to_the_added_outcome():
                 graph = EventGraph([_Downstream.Extended])
@@ -871,18 +872,6 @@ def describe_Command_handle():
                 assert aliases == {
                     "_Lineage.Parent": ("legacy_save",),
                     "_Lineage.Child": (),
-                }
-
-        def when_a_parent_command_lives_in_another_namespace():
-            # Same rule across namespaces — and registering both proves the
-            # child's handler is its own function, not an alias of the
-            # parent's (which would trip the duplicate-binding build error).
-            def it_is_not_inherited_by_a_subclass():
-                metas = EventGraph([_Upstream.Parent, _Downstream.Child])._handler_metas
-                aliases = {m.node_name: m.previous_names for m in metas}
-                assert aliases == {
-                    "_Upstream.Parent": ("legacy_upstream",),
-                    "_Downstream.Child": (),
                 }
 
     def describe_EventGraph_registration():


### PR DESCRIPTION
Closes #127.

## Why

A `Command` subclassing a `Command` in a **different namespace** silently kept the parent's handler. The child's own `handle` was never called — no error, no warning; the graph built, dispatched, and produced the parent's outcome.

```
Child own __dict__ has handle:          True
Child.__command_handler__.__qualname__: Inh.Parent.handle   <- parent's
Child.__dict__['__command_handler__']:  ABSENT
```

Same-namespace inheritance worked fine, which is what hid it.

## Root cause

`Command.__init_subclass__` did:

```python
if _inherits_namespace(cls):
    return
if not _is_nested_in_class(cls):
    raise TypeError(...)
```

The early return exists to waive the **nesting check** for an inheriting subclass — the parent already carries the namespace. But it also skipped the public-method scan below it, which is what stamps `cls.__command_handler__`.

`_inherits_namespace` is true when any base already has `__namespace__` stamped, and `__namespace__` is stamped by `_NestedEventMeta.__set_name__` — which runs only *after* the enclosing Namespace body finishes. So:

- **same namespace** — during the parent's Namespace body, `Parent.__namespace__` isn't stamped yet → false → scan runs → child binds its own handler.
- **different namespace** — the parent's namespace is fully built → true → early return → child never binds.

Pure class-creation ordering, not a decision.

## The fix

```python
if not _inherits_namespace(cls) and not _is_nested_in_class(cls):
    raise TypeError(...)
```

Separates the two concerns: an inheriting subclass skips the *nesting validation* and nothing else. Cross-namespace children now take the identical code path to same-namespace ones rather than a namespace-dependent branch.

## Knock-ons, verified

`invariants` and `retry` still inherit via MRO; `previously` stays own-`__dict__` only; command privacy holds both directions (a child emitting its parent's private outcome builds, a third command's does not); the `__command_handler__` duplicate-binding guard still fires; outcomes resolve, including a child that adds one.

Two user-visible consequences, accepted rather than special-cased: a cross-namespace child is now subject to the single-public-method rule and to `_validate_handle_signature`. Both were previously skipped for it, and both are the same-namespace behaviour.

## Coverage

I checked the regression is genuinely pinned rather than trusting the test names — reverting the one-line fix fails **5 tests**.

Two tests were dropped in the follow-up cleanup commit as provable duplicates (`Outcomes` synthesis walks the MRO, `previously` reads `h.__dict__`; both are namespace-blind, and both are already covered in `test_command_privacy.py` / the `_Lineage` tests). The unique part of one — that parent and child can now be registered together without tripping the duplicate-binding error, which is the build failure #127 actually produced — was kept as `it_registers_alongside_its_parent`.

## Verification

`pytest` 1242 passed / 1 skipped · `ruff check` + `format --check` clean · `mypy src/` clean · `validate_tests.py` 33/33 · `generate_mermaid.py --check` clean.

## Review order

Independent of the other open PRs, but shares `tests/test_command_handle.py` with #128 — whichever lands second may want a look. No textual conflict today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)