### PR TITLE
fix: stamp _raises/_invariants unconditionally so a removed declaration cannot persist (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `previously`, so a policy can never become a dataclass field serialized into every checkpoint
     — but the guard cannot tell a policy from a payload field of the same name. Rename the field.
 
+### Fixed
+
+- **Removing a `Command`'s `raises` or `invariants` no longer leaves the old contract enforced.**
+  `@on()` stamped `_raises` and `_invariants` onto the handler function only when the value was
+  non-empty. Because `EventGraph(...)` re-stamps every inline `Command` handler from its class
+  attributes on each build, deleting a declaration between two builds in the same process left the
+  earlier stamp in place: the second graph kept turning the removed exception into `HandlerRaised`
+  instead of letting it propagate, kept evaluating the removed invariant, and kept demanding a
+  catcher for a type nobody declares. Both are now stamped unconditionally, matching `previously`
+  and `retry`. `node_name` stays conditional on purpose — it has no class-level declaration surface,
+  so an unconditional stamp would erase an explicit `@on(node_name=...)` pin rather than refresh it.
+
 ## [0.24.0] - 2026-08-23
 
 ### Added

--- a/src/langgraph_events/_handler.py
+++ b/src/langgraph_events/_handler.py
@@ -270,27 +270,22 @@ def _build_on_decorator(
         fn._event_types = event_types  # type: ignore[attr-defined]
         if field_matchers:
             fn._field_matchers = dict(field_matchers)  # type: ignore[attr-defined]
-        # Unconditional, all four: inline command handlers are re-stamped on
-        # every EventGraph build from class-level declarations
-        # (``raises`` / ``invariants`` / ``previously`` / ``retry``), and each
-        # build must reflect the class's *current* declarations — a
-        # conditional stamp would let a stale value from an earlier build keep
-        # a removed alias, contract, or policy alive. Their falsy values
-        # (``()``, ``()``, ``()``, ``None``) match the defaults
-        # ``extract_handler_meta`` reads them with, so an always-present empty
-        # stamp is equivalent to no stamp for every consumer.
+        # Unconditional, all four: every EventGraph build re-stamps inline
+        # command handlers from the class's *current* ``raises`` /
+        # ``invariants`` / ``previously`` / ``retry``, so a conditional stamp
+        # would let an earlier build's value keep a since-removed contract,
+        # alias, or policy alive. Their falsy values match the defaults
+        # ``extract_handler_meta`` reads them with, so an empty stamp is
+        # indistinguishable from no stamp for every consumer.
         fn._raises = raises_tuple  # type: ignore[attr-defined]
         fn._invariants = invariants_tuple  # type: ignore[attr-defined]
         fn._previous_names = previous_names  # type: ignore[attr-defined]
         fn._retry = retry  # type: ignore[attr-defined]
-        # ``_node_name`` stays conditional, deliberately. It is the one stamp
-        # with no class-level declaration surface: ``Command`` has no
-        # ``node_name`` modifier and ``_expand_command_handlers`` never
-        # forwards one, so there is no declaration to remove and no stale
-        # value to correct. Stamping it unconditionally would therefore not
-        # "reflect the current declaration" — it would erase an explicit
-        # ``@on(node_name=...)`` pin on every rebuild, the identity that keeps
-        # interrupted checkpoints resumable across a rename.
+        # ``node_name`` has no class-level declaration to re-stamp from (see
+        # ``extract_handler_meta``), so there is no stale value to correct and
+        # an unconditional stamp would only erase an explicit
+        # ``@on(node_name=...)`` pin — the identity that keeps interrupted
+        # checkpoints resumable across a rename.
         if node_name is not None:
             fn._node_name = node_name  # type: ignore[attr-defined]
         return fn

--- a/src/langgraph_events/_handler.py
+++ b/src/langgraph_events/_handler.py
@@ -270,21 +270,29 @@ def _build_on_decorator(
         fn._event_types = event_types  # type: ignore[attr-defined]
         if field_matchers:
             fn._field_matchers = dict(field_matchers)  # type: ignore[attr-defined]
-        if raises_tuple:
-            fn._raises = raises_tuple  # type: ignore[attr-defined]
-        if invariants_tuple:
-            fn._invariants = invariants_tuple  # type: ignore[attr-defined]
+        # Unconditional, all four: inline command handlers are re-stamped on
+        # every EventGraph build from class-level declarations
+        # (``raises`` / ``invariants`` / ``previously`` / ``retry``), and each
+        # build must reflect the class's *current* declarations — a
+        # conditional stamp would let a stale value from an earlier build keep
+        # a removed alias, contract, or policy alive. Their falsy values
+        # (``()``, ``()``, ``()``, ``None``) match the defaults
+        # ``extract_handler_meta`` reads them with, so an always-present empty
+        # stamp is equivalent to no stamp for every consumer.
+        fn._raises = raises_tuple  # type: ignore[attr-defined]
+        fn._invariants = invariants_tuple  # type: ignore[attr-defined]
+        fn._previous_names = previous_names  # type: ignore[attr-defined]
+        fn._retry = retry  # type: ignore[attr-defined]
+        # ``_node_name`` stays conditional, deliberately. It is the one stamp
+        # with no class-level declaration surface: ``Command`` has no
+        # ``node_name`` modifier and ``_expand_command_handlers`` never
+        # forwards one, so there is no declaration to remove and no stale
+        # value to correct. Stamping it unconditionally would therefore not
+        # "reflect the current declaration" — it would erase an explicit
+        # ``@on(node_name=...)`` pin on every rebuild, the identity that keeps
+        # interrupted checkpoints resumable across a rename.
         if node_name is not None:
             fn._node_name = node_name  # type: ignore[attr-defined]
-        # Unconditional: inline command handlers are re-stamped on every
-        # EventGraph build, and each build must reflect the class's *current*
-        # ``previously`` declaration — a conditional stamp would let a stale
-        # value from an earlier build keep a removed alias alive.
-        fn._previous_names = previous_names  # type: ignore[attr-defined]
-        # Unconditional for the same reason as ``_previous_names`` above: a
-        # conditional stamp would keep a policy alive after it was removed
-        # from the Command between two EventGraph builds.
-        fn._retry = retry  # type: ignore[attr-defined]
         return fn
 
     return decorator

--- a/tests/test_command_handle.py
+++ b/tests/test_command_handle.py
@@ -14,8 +14,11 @@ from langgraph_events import (
     DomainEvent,
     EventGraph,
     EventLog,
+    HandlerRaised,
     IntegrationEvent,
     Interrupted,
+    Invariant,
+    InvariantViolated,
     Namespace,
     Reducer,
     Scatter,
@@ -385,8 +388,6 @@ def describe_Command_handle():
     def describe_class_level_modifiers():
         def when_invariants_set_as_class_attribute():
             def it_evaluates_the_predicate_at_dispatch():
-                from langgraph_events import Invariant, InvariantViolated
-
                 class _BlockedInv(Invariant):
                     pass
 
@@ -410,8 +411,6 @@ def describe_Command_handle():
                     # Each build must reflect the class's current declaration
                     # — a stale ``_invariants`` stamp from an earlier build
                     # must not keep evaluating a removed predicate.
-                    from langgraph_events import Invariant, InvariantViolated
-
                     class _StaleInv(Invariant):
                         pass
 
@@ -436,8 +435,6 @@ def describe_Command_handle():
 
         def when_invariants_inherited_from_a_parent_command():
             def it_evaluates_the_inherited_predicate():
-                from langgraph_events import Invariant, InvariantViolated
-
                 class _BlockedInheritedInv(Invariant):
                     pass
 
@@ -464,8 +461,6 @@ def describe_Command_handle():
 
         def when_raises_set_as_class_attribute():
             def it_routes_the_exception_to_HandlerRaised():
-                from langgraph_events import HandlerRaised
-
                 class _BoomError(Exception):
                     pass
 
@@ -492,8 +487,6 @@ def describe_Command_handle():
                     # Each build must reflect the class's current declaration
                     # — a stale ``_raises`` stamp from an earlier build must
                     # not keep catching an exception nobody declares.
-                    from langgraph_events import HandlerRaised
-
                     class _StaleBoomError(Exception):
                         pass
 

--- a/tests/test_command_handle.py
+++ b/tests/test_command_handle.py
@@ -405,6 +405,35 @@ def describe_Command_handle():
                 assert log.has(InvariantViolated)
                 assert not log.has(_InlineInv.Cmd.Done)
 
+            def when_the_declaration_is_removed_between_builds():
+                def it_stops_evaluating_the_predicate():
+                    # Each build must reflect the class's current declaration
+                    # — a stale ``_invariants`` stamp from an earlier build
+                    # must not keep evaluating a removed predicate.
+                    from langgraph_events import Invariant, InvariantViolated
+
+                    class _StaleInv(Invariant):
+                        pass
+
+                    class _StaleInvariants(Namespace):
+                        class Cmd(Command):
+                            invariants: ClassVar = {_StaleInv: lambda log: False}
+
+                            class Done(DomainEvent):
+                                pass
+
+                            def handle(self) -> _StaleInvariants.Cmd.Done:
+                                return _StaleInvariants.Cmd.Done()
+
+                    first = EventGraph([_StaleInvariants.Cmd])
+                    assert first.invoke(_StaleInvariants.Cmd()).has(InvariantViolated)
+                    del _StaleInvariants.Cmd.invariants
+                    log = EventGraph([_StaleInvariants.Cmd]).invoke(
+                        _StaleInvariants.Cmd()
+                    )
+                    assert not log.has(InvariantViolated)
+                    assert log.has(_StaleInvariants.Cmd.Done)
+
         def when_invariants_inherited_from_a_parent_command():
             def it_evaluates_the_inherited_predicate():
                 from langgraph_events import Invariant, InvariantViolated
@@ -457,6 +486,37 @@ def describe_Command_handle():
                 graph = EventGraph([_InlineRaises.Cmd, catch])
                 log = graph.invoke(_InlineRaises.Cmd())
                 assert log.has(HandlerRaised)
+
+            def when_the_declaration_is_removed_between_builds():
+                def it_stops_routing_the_exception_to_HandlerRaised():
+                    # Each build must reflect the class's current declaration
+                    # — a stale ``_raises`` stamp from an earlier build must
+                    # not keep catching an exception nobody declares.
+                    from langgraph_events import HandlerRaised
+
+                    class _StaleBoomError(Exception):
+                        pass
+
+                    class _StaleRaises(Namespace):
+                        class Cmd(Command):
+                            raises: ClassVar = (_StaleBoomError,)
+
+                            class Done(DomainEvent):
+                                pass
+
+                            def handle(self) -> _StaleRaises.Cmd.Done:
+                                raise _StaleBoomError("nope")
+
+                    @on(HandlerRaised, exception=_StaleBoomError)
+                    def catch(event: HandlerRaised) -> None:
+                        return None
+
+                    first = EventGraph([_StaleRaises.Cmd, catch])
+                    assert first.invoke(_StaleRaises.Cmd()).has(HandlerRaised)
+                    del _StaleRaises.Cmd.raises
+                    second = EventGraph([_StaleRaises.Cmd, catch])
+                    with pytest.raises(_StaleBoomError, match="nope"):
+                        second.invoke(_StaleRaises.Cmd())
 
         def when_raises_is_declared_as_a_dataclass_field():
             def it_rejects_at_class_creation():


### PR DESCRIPTION
Closes #128.

## Why

`@on()`'s decorator stamped three pieces of metadata onto the function **conditionally**:

```python
if raises_tuple:    fn._raises = raises_tuple
if invariants_tuple: fn._invariants = invariants_tuple
if node_name is not None: fn._node_name = node_name
```

For an inline `Command` handler that is a live bug. `_expand_command_handlers` re-runs `on(...)` against the same function object on **every** `EventGraph(...)` build, so a falsy new value never overwrites the old stamp. Remove a declaration between two builds in one process and the second graph keeps enforcing a contract the class no longer declares.

```
build 1 — meta.raises: [(Boom,)]
after del, getattr(NS.Cmd, 'raises', ()): ()
build 2 — meta.raises: [(Boom,)]   <-- STALE
```

`invariants` behaves identically. The framework keeps catching exceptions the Command no longer declares, keeps evaluating a removed invariant, and `_verify_raises_coverage` keeps demanding a catcher for a type nobody declares.

This is a known-shaped bug: `_previous_names` had it and was fixed by stamping unconditionally, with the reasoning recorded inline. `_retry` follows the fixed pattern. These two did not.

## What

`_raises` and `_invariants` now stamp unconditionally, joining `_previous_names` and `_retry` under one shared rationale comment. Their falsy values are `()`, and `extract_handler_meta` already reads them with a matching default, so an always-present empty tuple is equivalent for every consumer — verified, not assumed.

## `_node_name` deliberately left conditional

Investigated as instructed, and the conclusion is that it should NOT change — for a stronger reason than "unsafe":

1. **The failure mode is unreachable.** `_RESERVED_MODIFIERS` is `("previously", "raises", "invariants", "retry")` — there is no `node_name` class-level modifier, and `_expand_command_handlers` hard-codes its `on(...)` call without one. The re-stamp always passes `None`, never a "current declaration", so the issue's test shape (remove the attribute, rebuild) cannot even be written for it.
2. **Unconditional writing is a strict loss.** For a handler carrying a pin, the pin currently survives and yields `meta.name == "pinned_identity"`; simulating an unconditional stamp drops it to `"handle"`. It would also let the outer decorator of a stacked `@on` erase an inner pin — and for a non-inline handler `node_name == name`, so that erasure *is* the checkpoint identity.

A comment at the stamp site now records why it stays conditional. The same reasoning applies to `_field_matchers`, so the comment does not claim `_node_name` is uniquely exempt.

## Scope

Only bites when the same Command class is registered into two graphs in one process with a declaration changed in between — rare in application code, plausible in tests and notebooks, and silently wrong when it happens.

## Verification

`pytest` 1237 passed / 1 skipped · `ruff check` + `format --check` clean · `mypy src/` clean · `validate_tests.py` 33/33 · `generate_mermaid.py --check` clean.

Two regression tests, both asserted at the API boundary (build → `del` the class attribute → rebuild → invoke), both verified red first for the right reason.

## Review order

Independent, but shares `tests/test_command_handle.py` with #127. This PR's cleanup commit hoists function-local imports to the module block that #127's new test still carries locally — harmless, but whichever lands second wants a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)