### PR TITLE
refactor(tests): dedupe the three large test files and make the jscpd gate honest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,15 @@ repos:
       - id: jscpd
         name: jscpd
         language: system
-        entry: npx jscpd src/ tests/ --min-tokens 30 --min-lines 2 --threshold 5
+        # Version pinned and --max-size explicit on purpose. jscpd defaulted
+        # --max-size to 100kb for years, which silently skipped test_agui.py,
+        # test_event_graph.py and test_serde.py -- the three files that carried
+        # ~89% of the duplication -- so this gate reported ~4% while the real
+        # figure was 11.6%. A bare `npx jscpd` also re-resolves to whatever
+        # version is newest, so the gate could change behaviour with no commit.
+        # Skipped files are not reported, so the failure mode is silent: keep
+        # --max-size comfortably above the largest file under src/ and tests/.
+        entry: npx jscpd@5.0.16 src/ tests/ --min-tokens 30 --min-lines 2 --threshold 5 --max-size 5mb
         types: [python]
         pass_filenames: false
         require_serial: true

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -13,6 +13,7 @@ from ag_ui.core import (
     EventType,
     RunAgentInput,
 )
+from ag_ui.core import ToolMessage as AguiToolMessage
 from langchain_core.language_models.fake_chat_models import FakeListChatModel
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langgraph.checkpoint.memory import MemorySaver
@@ -185,25 +186,25 @@ class NameOnlyEvent(IntegrationEvent):
         return "custom.name"
 
 
-class StepA(IntegrationEvent):
+class ValuedEvent(IntegrationEvent):
+    """Base for the value-only integration events used below."""
+
     value: str = ""
 
     def agui_dict(self) -> dict[str, Any]:
         return {"value": self.value}
 
 
-class StepB(IntegrationEvent):
-    value: str = ""
-
-    def agui_dict(self) -> dict[str, Any]:
-        return {"value": self.value}
+class StepA(ValuedEvent):
+    pass
 
 
-class FocusLogged(IntegrationEvent):
-    value: str = ""
+class StepB(ValuedEvent):
+    pass
 
-    def agui_dict(self) -> dict[str, Any]:
-        return {"value": self.value}
+
+class FocusLogged(ValuedEvent):
+    pass
 
 
 class FocusEcho(IntegrationEvent):
@@ -214,6 +215,74 @@ class FocusEcho(IntegrationEvent):
     """
 
     value: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Shared handlers
+#
+# The plain, content-only handlers that most scenarios below only need as
+# something for the adapter to run.  Scenario-specific handlers stay inline.
+# ---------------------------------------------------------------------------
+
+
+@on(UserAsked)
+def reply(event: UserAsked) -> AgentReplied:
+    return AgentReplied(message=AIMessage(content="ok"))
+
+
+@on(UserAsked)
+def reply_hi(event: UserAsked) -> AgentReplied:
+    return AgentReplied(message=AIMessage(content="hi"))
+
+
+@on(UserAsked)
+def reply_hello(event: UserAsked) -> AgentReplied:
+    return AgentReplied(message=AIMessage(content="hello"))
+
+
+@on(UserAsked)
+def reply_done(event: UserAsked) -> AgentReplied:
+    return AgentReplied(message=AIMessage(content="done"))
+
+
+@on(UserAsked)
+def ask_approval(event: UserAsked) -> ApprovalRequested:
+    return ApprovalRequested(draft="needs approval")
+
+
+@on(UserAsked)
+def ask_ok(event: UserAsked) -> ApprovalRequested:
+    return ApprovalRequested(draft="ok?")
+
+
+@on(UserAsked)
+def ask_draft(event: UserAsked) -> ApprovalRequested:
+    return ApprovalRequested(draft="draft")
+
+
+@on(UserAsked)
+def ask_pending(event: UserAsked) -> ApprovalRequested:
+    return ApprovalRequested(draft="pending")
+
+
+@on(UserAsked)
+def ask_ship(event: UserAsked) -> ApprovalRequested:
+    return ApprovalRequested(draft="ship it?")
+
+
+@on(UserAsked)
+def ask_plain_interrupt(event: UserAsked) -> PlainInterrupt:
+    return PlainInterrupt()
+
+
+@on(ApprovalGiven)
+def approve(event: ApprovalGiven) -> AgentReplied:
+    return AgentReplied(message=AIMessage(content="Approved!"))
+
+
+@on(ApprovalGiven)
+def finish(event: ApprovalGiven) -> AgentReplied:
+    return AgentReplied(message=AIMessage(content="done"))
 
 
 # ---------------------------------------------------------------------------
@@ -244,6 +313,236 @@ async def _collect(adapter: AGUIAdapter, input_data: RunAgentInput) -> list[Base
 
 def _types(events: list[BaseEvent]) -> list[EventType]:
     return [e.type for e in events]
+
+
+def _ask(question: str = "go") -> Any:
+    """Seed factory producing ``UserAsked(question=...)``."""
+    return lambda inp: UserAsked(question=question)
+
+
+def _config(thread_id: str) -> dict[str, Any]:
+    """The LangGraph runnable config for ``thread_id``."""
+    return {"configurable": {"thread_id": thread_id}}
+
+
+def _graph(*handlers: Any, **overrides: Any) -> EventGraph:
+    """``EventGraph`` with the ``message_reducer()`` these tests always install."""
+    overrides.setdefault("reducers", [message_reducer()])
+    return EventGraph(list(handlers), **overrides)
+
+
+def _adapter(graph: Any, **overrides: Any) -> AGUIAdapter:
+    """``AGUIAdapter`` seeded with ``UserAsked(question="go")`` by default."""
+    overrides.setdefault("seed_factory", _ask())
+    return AGUIAdapter(graph=graph, **overrides)
+
+
+async def _stream(
+    graph: Any,
+    input_data: RunAgentInput | None = None,
+    **overrides: Any,
+) -> list[BaseEvent]:
+    """Drain ``stream`` on the default adapter for ``graph``."""
+    return await _collect(_adapter(graph, **overrides), input_data or _make_input())
+
+
+async def _resume(
+    graph: Any,
+    input_data: RunAgentInput,
+    **overrides: Any,
+) -> list[BaseEvent]:
+    """Stream the resume branch: an unused seed plus an ``ApprovalGiven`` resume."""
+    overrides.setdefault("seed_factory", _ask("unused"))
+    overrides.setdefault("resume_factory", lambda inp: ApprovalGiven(approved=True))
+    return await _stream(graph, input_data, **overrides)
+
+
+async def _stream_warnings(graph: Any, runs: int = 1, **overrides: Any) -> list[Any]:
+    """Stream ``graph`` ``runs`` times on one adapter; return the warnings raised."""
+    adapter = _adapter(graph, **overrides)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        for _ in range(runs):
+            await _collect(adapter, _make_input())
+    return list(caught)
+
+
+async def _connect(
+    graph: Any,
+    input_data: RunAgentInput | None = None,
+    **overrides: Any,
+) -> list[BaseEvent]:
+    """Drain ``connect`` on the default adapter for ``graph``."""
+    adapter = _adapter(graph, **overrides)
+    return [event async for event in adapter.connect(input_data or _make_input())]
+
+
+def _emitting(message: Any) -> Any:
+    """A handler emitting ``message`` through the ``MessageEvent`` for its type."""
+
+    @on(UserAsked)
+    def emit_system(event: UserAsked) -> SystemPromptDelivered:
+        return SystemPromptDelivered(message=message)
+
+    @on(UserAsked)
+    def emit_human(event: UserAsked) -> UserSent:
+        return UserSent(message=message)
+
+    @on(UserAsked)
+    def emit_tool(event: UserAsked) -> ToolsExecuted:
+        return ToolsExecuted(messages=(message,))
+
+    @on(UserAsked)
+    def emit_ai(event: UserAsked) -> AgentReplied:
+        return AgentReplied(message=message)
+
+    if isinstance(message, SystemMessage):
+        return emit_system
+    if isinstance(message, HumanMessage):
+        return emit_human
+    if isinstance(message, ToolMessage):
+        return emit_tool
+    return emit_ai
+
+
+async def _emit(message: Any, **overrides: Any) -> list[BaseEvent]:
+    """Stream a one-handler graph whose only output is ``message``."""
+    return await _stream(_graph(_emitting(message)), **overrides)
+
+
+def _llm_replier(*responses: str) -> Any:
+    """A ``UserAsked`` handler streaming ``responses`` from a fake chat model."""
+    llm = FakeListChatModel(responses=list(responses), sleep=0)
+
+    @on(UserAsked)
+    async def stream_reply(event: UserAsked, messages: list[Any]) -> AgentReplied:
+        response = await llm.ainvoke([*messages, HumanMessage(content=event.question)])
+        return AgentReplied(message=response)
+
+    return stream_reply
+
+
+def _agui_tool_message(**fields: Any) -> AguiToolMessage:
+    """An inbound AG-UI tool message; ``fields`` override the defaults."""
+    defaults: dict[str, Any] = {
+        "id": "m-1",
+        "role": "tool",
+        "content": "42",
+        "tool_call_id": "tc-1",
+    }
+    defaults.update(fields)
+    return AguiToolMessage(**defaults)
+
+
+def _tool_input(**fields: Any) -> RunAgentInput:
+    """``RunAgentInput`` carrying a single inbound AG-UI tool message."""
+    return _make_input(messages=[_agui_tool_message(**fields)])
+
+
+def _patch_astream(monkeypatch: Any, target: Any, *frames: Any) -> list[dict[str, Any]]:
+    """Stub ``target.astream_events`` to yield ``frames``; return recorded kwargs."""
+    calls: list[dict[str, Any]] = []
+
+    async def fake_astream_events(
+        seed: Any,
+        *,
+        include_reducers: Any,
+        include_llm_tokens: Any,
+        include_custom_events: Any,
+        config: Any,
+    ) -> Any:
+        del seed
+        calls.append(
+            {
+                "include_reducers": include_reducers,
+                "include_llm_tokens": include_llm_tokens,
+                "include_custom_events": include_custom_events,
+                "config": config,
+            }
+        )
+        for frame in frames:
+            yield frame
+
+    monkeypatch.setattr(target, "astream_events", fake_astream_events)
+    return calls
+
+
+def _task_mapper(name: str, key: str) -> Any:
+    """A mapper claiming ``TaskCreated`` as the custom AG-UI event ``name``."""
+
+    class TaskMapper:
+        def map(self, event: Any, ctx: Any) -> Any:
+            if isinstance(event, TaskCreated):
+                return [
+                    CustomEvent(
+                        type=EventType.CUSTOM,
+                        name=name,
+                        value={key: event.title},
+                    )
+                ]
+            return None
+
+    return TaskMapper()
+
+
+def _chat_model_end(run_id: str, message: AIMessage) -> dict[str, Any]:
+    """A raw LangChain ``on_chat_model_end`` stream event."""
+    return {"event": "on_chat_model_end", "run_id": run_id, "data": {"output": message}}
+
+
+def _patch_compiled_astream(monkeypatch: Any, graph: Any, *events: Any) -> None:
+    """Stub ``graph.compiled.astream_events`` to yield raw LangChain ``events``."""
+
+    async def fake_astream(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        for event in events:
+            yield event
+
+    monkeypatch.setattr(graph.compiled, "astream_events", fake_astream)
+
+
+_TOOL_CALL_TRIPLE = [
+    EventType.TOOL_CALL_START,
+    EventType.TOOL_CALL_ARGS,
+    EventType.TOOL_CALL_END,
+]
+
+
+def _tool_call_types(events: list[BaseEvent]) -> list[EventType]:
+    """The ``TOOL_CALL_*`` event types in ``events``, in emission order."""
+    return [e.type for e in events if e.type in _TOOL_CALL_TRIPLE]
+
+
+def _of_type(events: list[BaseEvent], event_type: EventType) -> list[Any]:
+    return [e for e in events if e.type == event_type]
+
+
+def _custom(events: list[BaseEvent], name: str) -> list[Any]:
+    return [e for e in _of_type(events, EventType.CUSTOM) if e.name == name]
+
+
+def _snapshots(events: list[BaseEvent]) -> list[Any]:
+    return _of_type(events, EventType.MESSAGES_SNAPSHOT)
+
+
+def _last_snapshot(events: list[BaseEvent]) -> Any:
+    snapshots = _snapshots(events)
+    assert len(snapshots) >= 1
+    return snapshots[-1]
+
+
+def _snapshot_messages(events: list[BaseEvent]) -> list[Any]:
+    """Messages of the final ``MESSAGES_SNAPSHOT`` (asserting one was emitted)."""
+    return list(_last_snapshot(events).messages)
+
+
+def _by_role(messages: list[Any], role: str) -> list[Any]:
+    return [m for m in messages if m.role == role]
+
+
+def _roled(events: list[BaseEvent], role: str) -> list[Any]:
+    """Messages with ``role`` in the final ``MESSAGES_SNAPSHOT``."""
+    return _by_role(_snapshot_messages(events), role)
 
 
 # ---------------------------------------------------------------------------
@@ -307,15 +606,11 @@ def describe_AGUIAdapter():
                     message=AIMessage(content=f"Answer to: {event.question}")
                 )
 
-            return EventGraph([reply], reducers=[message_reducer()])
+            return _graph(reply)
 
         def when_default_configuration():
             async def it_emits_run_started_and_finished(simple_graph):
-                adapter = AGUIAdapter(
-                    graph=simple_graph,
-                    seed_factory=lambda inp: UserAsked(question="hi"),
-                )
-                events = await _collect(adapter, _make_input())
+                events = await _stream(simple_graph, seed_factory=_ask("hi"))
 
                 assert events[0].type == EventType.RUN_STARTED
                 assert events[0].thread_id == "thread-1"
@@ -324,18 +619,9 @@ def describe_AGUIAdapter():
                 assert events[-1].thread_id == "thread-1"
 
             async def it_delivers_ai_messages_via_snapshot(simple_graph):
-                adapter = AGUIAdapter(
-                    graph=simple_graph,
-                    seed_factory=lambda inp: UserAsked(question="hello"),
-                )
-                events = await _collect(adapter, _make_input())
+                events = await _stream(simple_graph, seed_factory=_ask("hello"))
 
-                msg_snapshots = [
-                    e for e in events if e.type == EventType.MESSAGES_SNAPSHOT
-                ]
-                assert len(msg_snapshots) >= 1
-                last_snap = msg_snapshots[-1]
-                ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+                ai_msgs = _roled(events, "assistant")
                 assert len(ai_msgs) >= 1
                 assert "Answer to: hello" in ai_msgs[-1].content
 
@@ -355,49 +641,25 @@ def describe_AGUIAdapter():
                         )
                     )
 
-                graph = EventGraph([call_tool], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="search"),
-                )
-                events = await _collect(adapter, _make_input())
+                graph = _graph(call_tool)
+                events = await _stream(graph, seed_factory=_ask("search"))
 
-                msg_snapshots = [
-                    e for e in events if e.type == EventType.MESSAGES_SNAPSHOT
-                ]
-                assert len(msg_snapshots) >= 1
-                last_snap = msg_snapshots[-1]
-                ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+                ai_msgs = _roled(events, "assistant")
                 assert len(ai_msgs) >= 1
                 assert len(ai_msgs[-1].tool_calls) == 1
                 assert ai_msgs[-1].tool_calls[0].id == "tc-1"
                 assert ai_msgs[-1].tool_calls[0].function.name == "search"
 
             async def it_delivers_tool_results_via_snapshot():
-                @on(UserAsked)
-                def run_tools(event: UserAsked) -> ToolsExecuted:
-                    return ToolsExecuted(
-                        messages=(
-                            ToolMessage(
-                                content="result-1",
-                                tool_call_id="tc-1",
-                            ),
-                        )
-                    )
-
-                graph = EventGraph([run_tools], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="run"),
+                events = await _emit(
+                    ToolMessage(
+                        content="result-1",
+                        tool_call_id="tc-1",
+                    ),
+                    seed_factory=_ask("run"),
                 )
-                events = await _collect(adapter, _make_input())
 
-                msg_snapshots = [
-                    e for e in events if e.type == EventType.MESSAGES_SNAPSHOT
-                ]
-                assert len(msg_snapshots) >= 1
-                last_snap = msg_snapshots[-1]
-                tool_msgs = [m for m in last_snap.messages if m.role == "tool"]
+                tool_msgs = _roled(events, "tool")
                 assert len(tool_msgs) >= 1
                 assert tool_msgs[0].content == "result-1"
 
@@ -411,20 +673,12 @@ def describe_AGUIAdapter():
                         )
                     )
 
-                graph = EventGraph([reply_tool_result], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="mixed"),
-                )
-                events = await _collect(adapter, _make_input())
+                graph = _graph(reply_tool_result)
+                events = await _stream(graph, seed_factory=_ask("mixed"))
 
-                msg_snapshots = [
-                    e for e in events if e.type == EventType.MESSAGES_SNAPSHOT
-                ]
-                assert len(msg_snapshots) >= 1
-                last_snap = msg_snapshots[-1]
-                ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
-                tool_msgs = [m for m in last_snap.messages if m.role == "tool"]
+                last_snap = _last_snapshot(events)
+                ai_msgs = _by_role(last_snap.messages, "assistant")
+                tool_msgs = _by_role(last_snap.messages, "tool")
                 assert any("I used a tool" in m.content for m in ai_msgs)
                 assert len(tool_msgs) >= 1
                 assert tool_msgs[0].content == "tool output"
@@ -434,22 +688,10 @@ def describe_AGUIAdapter():
                 def ask_approval(event: UserAsked) -> ApprovalRequested:
                     return ApprovalRequested(draft="draft text")
 
-                graph = EventGraph(
-                    [ask_approval],
-                    checkpointer=MemorySaver(),
-                    reducers=[message_reducer()],
-                )
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="approve?"),
-                )
-                events = await _collect(adapter, _make_input())
+                graph = _graph(ask_approval, checkpointer=MemorySaver())
+                events = await _stream(graph, seed_factory=_ask("approve?"))
 
-                custom_events = [
-                    e
-                    for e in events
-                    if e.type == EventType.CUSTOM and e.name == "interrupted"
-                ]
+                custom_events = _custom(events, "interrupted")
                 assert len(custom_events) == 1
                 assert custom_events[0].value["draft"] == "draft text"
 
@@ -462,34 +704,20 @@ def describe_AGUIAdapter():
                 def handle_approval(event: ApprovalGiven) -> AgentReplied:
                     return AgentReplied(message=AIMessage(content="Approved!"))
 
-                graph = EventGraph(
-                    [ask_approval, handle_approval],
-                    checkpointer=MemorySaver(),
-                    reducers=[message_reducer()],
+                graph = _graph(
+                    ask_approval, handle_approval, checkpointer=MemorySaver()
                 )
 
                 # First run — triggers interrupt
-                config = {"configurable": {"thread_id": "thread-resume"}}
+                config = _config("thread-resume")
                 # Run directly to create interrupt checkpoint
                 await graph.ainvoke(UserAsked(question="approve?"), config=config)
 
                 # Resume run
-                adapter_resume = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="unused"),
-                    resume_factory=lambda inp: ApprovalGiven(approved=True),
-                )
-                events = await _collect(
-                    adapter_resume,
-                    _make_input(thread_id="thread-resume"),
-                )
+                events = await _resume(graph, _make_input(thread_id="thread-resume"))
 
                 # Resumed events should be suppressed
-                resumed_custom = [
-                    e
-                    for e in events
-                    if e.type == EventType.CUSTOM and e.name == "Resumed"
-                ]
+                resumed_custom = _custom(events, "Resumed")
                 assert len(resumed_custom) == 0
 
             async def it_maps_unknown_events_to_custom_events():
@@ -497,18 +725,10 @@ def describe_AGUIAdapter():
                 def create_task(event: UserAsked) -> TaskCreated:
                     return TaskCreated(title="new task")
 
-                graph = EventGraph([create_task], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="task"),
-                )
-                events = await _collect(adapter, _make_input())
+                graph = _graph(create_task)
+                events = await _stream(graph, seed_factory=_ask("task"))
 
-                custom_events = [
-                    e
-                    for e in events
-                    if e.type == EventType.CUSTOM and e.name == "TaskCreated"
-                ]
+                custom_events = _custom(events, "TaskCreated")
                 assert len(custom_events) == 1
                 assert custom_events[0].value["title"] == "new task"
 
@@ -517,39 +737,19 @@ def describe_AGUIAdapter():
                 def blow_up(event: ErrorTrigger) -> None:
                     raise RuntimeError("boom")
 
-                graph = EventGraph([blow_up], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: ErrorTrigger(),
-                )
-                events = await _collect(adapter, _make_input())
+                graph = _graph(blow_up)
+                events = await _stream(graph, seed_factory=lambda inp: ErrorTrigger())
 
                 assert events[0].type == EventType.RUN_STARTED
-                error_events = [e for e in events if e.type == EventType.RUN_ERROR]
+                error_events = _of_type(events, EventType.RUN_ERROR)
                 assert len(error_events) == 1
                 assert "boom" in error_events[0].message
                 # RunFinished should NOT appear after error
                 assert events[-1].type == EventType.RUN_ERROR
 
             async def it_streams_text_message_content_during_llm_calls():
-                llm = FakeListChatModel(responses=["stream me"], sleep=0)
-
-                @on(UserAsked)
-                async def stream_reply(
-                    event: UserAsked,
-                    messages: list[Any],
-                ) -> AgentReplied:
-                    response = await llm.ainvoke(
-                        [*messages, HumanMessage(content=event.question)]
-                    )
-                    return AgentReplied(message=response)
-
-                graph = EventGraph([stream_reply], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
-                )
-                events = await _collect(adapter, _make_input())
+                graph = _graph(_llm_replier("stream me"))
+                events = await _stream(graph)
 
                 text_events = [
                     e
@@ -576,21 +776,14 @@ def describe_AGUIAdapter():
                 def emit_plain(event: UserAsked) -> PlainEvent:
                     return PlainEvent(value="hello")
 
-                graph = EventGraph([emit_plain], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
-                )
+                graph = _graph(emit_plain)
+                adapter = _adapter(graph)
                 _warned_classes.discard(PlainEvent)
                 with warnings.catch_warnings(record=True) as w:
                     warnings.simplefilter("always")
                     events = await _collect(adapter, _make_input())
 
-                custom_events = [
-                    e
-                    for e in events
-                    if e.type == EventType.CUSTOM and e.name == "PlainEvent"
-                ]
+                custom_events = _custom(events, "PlainEvent")
                 assert len(custom_events) == 0
                 assert any("PlainEvent" in str(warning.message) for warning in w)
 
@@ -599,18 +792,10 @@ def describe_AGUIAdapter():
                 def create_task(event: UserAsked) -> TaskCreated:
                     return TaskCreated(title="with dict")
 
-                graph = EventGraph([create_task], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
-                )
-                events = await _collect(adapter, _make_input())
+                graph = _graph(create_task)
+                events = await _stream(graph)
 
-                custom_events = [
-                    e
-                    for e in events
-                    if e.type == EventType.CUSTOM and e.name == "TaskCreated"
-                ]
+                custom_events = _custom(events, "TaskCreated")
                 assert len(custom_events) == 1
                 assert custom_events[0].value == {"title": "with dict"}
 
@@ -623,11 +808,8 @@ def describe_AGUIAdapter():
                 def step2(event: NoDict1) -> NoDict2:
                     return NoDict2(x=2)
 
-                graph = EventGraph([step1, step2], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
-                )
+                graph = _graph(step1, step2)
+                adapter = _adapter(graph)
                 _warned_classes.discard(NoDict1)
                 _warned_classes.discard(NoDict2)
                 with warnings.catch_warnings(record=True) as w:
@@ -650,25 +832,15 @@ def describe_AGUIAdapter():
                 def emit_dict(event: PlainEvent) -> TaskCreated:
                     return TaskCreated(title="ok")
 
-                graph = EventGraph(
-                    [emit_plain, emit_dict], reducers=[message_reducer()]
-                )
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
-                    on_unmapped="ignore",
-                )
+                graph = _graph(emit_plain, emit_dict)
+                adapter = _adapter(graph, on_unmapped="ignore")
                 _warned_classes.discard(PlainEvent)
                 with warnings.catch_warnings(record=True) as w:
                     warnings.simplefilter("always")
                     events = await _collect(adapter, _make_input())
 
                 assert not any("PlainEvent" in str(x.message) for x in w)
-                serialized = [
-                    e
-                    for e in events
-                    if e.type == EventType.CUSTOM and e.name == "TaskCreated"
-                ]
+                serialized = _custom(events, "TaskCreated")
                 assert len(serialized) == 1
                 assert serialized[0].value == {"title": "ok"}
 
@@ -677,12 +849,8 @@ def describe_AGUIAdapter():
                 def emit_plain(event: UserAsked) -> PlainEvent:
                     return PlainEvent(value="hi")
 
-                graph = EventGraph([emit_plain], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
-                    on_unmapped="raise",
-                )
+                graph = _graph(emit_plain)
+                adapter = _adapter(graph, on_unmapped="raise")
                 with pytest.raises(UnmappedEventError, match="PlainEvent"):
                     await _collect(adapter, _make_input())
 
@@ -690,20 +858,8 @@ def describe_AGUIAdapter():
                 assert issubclass(UnmappedEventError, TypeError)
 
             async def it_applies_to_interrupted_mapper_ignore():
-                @on(UserAsked)
-                def ask(event: UserAsked) -> PlainInterrupt:
-                    return PlainInterrupt()
-
-                graph = EventGraph(
-                    [ask],
-                    checkpointer=MemorySaver(),
-                    reducers=[message_reducer()],
-                )
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
-                    on_unmapped="ignore",
-                )
+                graph = _graph(ask_plain_interrupt, checkpointer=MemorySaver())
+                adapter = _adapter(graph, on_unmapped="ignore")
                 _warned_classes.discard(PlainInterrupt)
                 with warnings.catch_warnings(record=True) as w:
                     warnings.simplefilter("always")
@@ -717,73 +873,31 @@ def describe_AGUIAdapter():
                 )
 
             async def it_applies_to_interrupted_mapper_raise():
-                @on(UserAsked)
-                def ask(event: UserAsked) -> PlainInterrupt:
-                    return PlainInterrupt()
-
-                graph = EventGraph(
-                    [ask],
-                    checkpointer=MemorySaver(),
-                    reducers=[message_reducer()],
-                )
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
-                    on_unmapped="raise",
-                )
+                graph = _graph(ask_plain_interrupt, checkpointer=MemorySaver())
+                adapter = _adapter(graph, on_unmapped="raise")
                 with pytest.raises(UnmappedEventError, match="PlainInterrupt"):
                     await _collect(adapter, _make_input())
 
             def it_rejects_invalid_policy_value(simple_graph):
                 with pytest.raises(ValueError, match="on_unmapped"):
-                    AGUIAdapter(
-                        graph=simple_graph,
-                        seed_factory=lambda inp: UserAsked(question="go"),
-                        on_unmapped="silent",  # type: ignore[arg-type]
-                    )
+                    _adapter(simple_graph, on_unmapped="silent")
 
         def when_include_reducers():
             async def it_emits_state_snapshot():
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="hello"))
+                graph = _graph(reply_hello)
+                events = await _stream(graph, seed_factory=_ask("hi"))
 
-                graph = EventGraph(
-                    [reply],
-                    reducers=[message_reducer()],
-                )
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="hi"),
-                )
-                events = await _collect(adapter, _make_input())
-
-                snapshots = [e for e in events if e.type == EventType.STATE_SNAPSHOT]
+                snapshots = _of_type(events, EventType.STATE_SNAPSHOT)
                 assert len(snapshots) >= 1
                 # Snapshot should not duplicate dedicated messages channel
                 assert "messages" not in snapshots[-1].snapshot
 
             async def it_excludes_messages_from_state_snapshot():
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="hello"))
+                graph = _graph(reply_hello)
+                events = await _stream(graph, seed_factory=_ask("hi"))
 
-                graph = EventGraph(
-                    [reply],
-                    reducers=[message_reducer()],
-                )
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="hi"),
-                )
-                events = await _collect(adapter, _make_input())
-
-                state_snapshots = [
-                    e for e in events if e.type == EventType.STATE_SNAPSHOT
-                ]
-                message_snapshots = [
-                    e for e in events if e.type == EventType.MESSAGES_SNAPSHOT
-                ]
+                state_snapshots = _of_type(events, EventType.STATE_SNAPSHOT)
+                message_snapshots = _of_type(events, EventType.MESSAGES_SNAPSHOT)
 
                 assert len(state_snapshots) >= 1
                 assert all(
@@ -795,26 +909,10 @@ def describe_AGUIAdapter():
 
         def when_messages_reducer_present():
             async def it_emits_messages_snapshot():
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="hello"))
+                graph = _graph(reply_hello)
+                events = await _stream(graph, seed_factory=_ask("hi"))
 
-                graph = EventGraph(
-                    [reply],
-                    reducers=[message_reducer()],
-                )
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="hi"),
-                )
-                events = await _collect(adapter, _make_input())
-
-                msg_snapshots = [
-                    e for e in events if e.type == EventType.MESSAGES_SNAPSHOT
-                ]
-                assert len(msg_snapshots) >= 1
-                # Should contain converted messages
-                last_snap = msg_snapshots[-1]
+                last_snap = _last_snapshot(events)
                 assert isinstance(last_snap.messages, list)
                 assert len(last_snap.messages) >= 1
 
@@ -824,15 +922,14 @@ def describe_AGUIAdapter():
                 def blow_up(event: ErrorTrigger) -> None:
                     raise RuntimeError("boom")
 
-                graph = EventGraph([blow_up], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
+                graph = _graph(blow_up)
+                events = await _stream(
+                    graph,
                     seed_factory=lambda inp: ErrorTrigger(),
                     error_message="Something went wrong. Please try again.",
                 )
-                events = await _collect(adapter, _make_input())
 
-                error_events = [e for e in events if e.type == EventType.RUN_ERROR]
+                error_events = _of_type(events, EventType.RUN_ERROR)
                 assert len(error_events) == 1
                 assert (
                     error_events[0].message == "Something went wrong. Please try again."
@@ -840,23 +937,12 @@ def describe_AGUIAdapter():
 
         def when_messages_unchanged():
             async def it_skips_redundant_messages_snapshots():
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="hello"))
-
                 @on(AgentReplied)
                 def followup(event: AgentReplied) -> TaskCreated:
                     return TaskCreated(title="no new messages")
 
-                graph = EventGraph(
-                    [reply, followup],
-                    reducers=[message_reducer()],
-                )
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="hi"),
-                )
-                events = await _collect(adapter, _make_input())
+                graph = _graph(reply_hello, followup)
+                events = await _stream(graph, seed_factory=_ask("hi"))
 
                 state_count = sum(
                     1 for e in events if e.type == EventType.STATE_SNAPSHOT
@@ -885,26 +971,20 @@ def describe_AGUIAdapter():
                         message=AIMessage(content="draft v2", id="msg-ai")
                     )
 
-                graph = EventGraph(
-                    [draft, revise],
-                    reducers=[message_reducer()],
-                )
-                adapter = AGUIAdapter(
-                    graph=graph,
+                graph = _graph(draft, revise)
+                events = await _stream(
+                    graph,
                     seed_factory=lambda inp: DraftUserSent(
                         message=HumanMessage(content="go")
                     ),
                 )
-                events = await _collect(adapter, _make_input())
 
-                msg_snapshots = [
-                    e for e in events if e.type == EventType.MESSAGES_SNAPSHOT
-                ]
+                msg_snapshots = _of_type(events, EventType.MESSAGES_SNAPSHOT)
                 # Must have at least 2: one after draft, one after revise
                 assert len(msg_snapshots) >= 2
                 # The last snapshot must contain the REVISED content
                 last_snap = msg_snapshots[-1]
-                ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+                ai_msgs = _by_role(last_snap.messages, "assistant")
                 assert len(ai_msgs) == 1
                 assert ai_msgs[0].content == "draft v2"
 
@@ -944,20 +1024,10 @@ def describe_AGUIAdapter():
                         )
                     )
 
-                graph = EventGraph(
-                    [draft, revise],
-                    reducers=[message_reducer()],
-                )
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
-                    include_reducers=True,
-                )
-                events = await _collect(adapter, _make_input())
+                graph = _graph(draft, revise)
+                events = await _stream(graph, include_reducers=True)
 
-                msg_snapshots = [
-                    e for e in events if e.type == EventType.MESSAGES_SNAPSHOT
-                ]
+                msg_snapshots = _of_type(events, EventType.MESSAGES_SNAPSHOT)
                 # Must have at least 2: one after draft, one after revise
                 assert len(msg_snapshots) >= 2
 
@@ -995,28 +1065,14 @@ def describe_AGUIAdapter():
                         )
                     )
 
-                graph = EventGraph(
-                    [reply],
-                    reducers=[message_reducer()],
-                )
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
-                    include_reducers=True,
-                )
-                events = await _collect(adapter, _make_input())
+                graph = _graph(reply)
+                events = await _stream(graph, include_reducers=True)
 
                 # Must not crash — no RUN_ERROR
-                error_events = [e for e in events if e.type == EventType.RUN_ERROR]
+                error_events = _of_type(events, EventType.RUN_ERROR)
                 assert len(error_events) == 0
 
-                msg_snapshots = [
-                    e for e in events if e.type == EventType.MESSAGES_SNAPSHOT
-                ]
-                assert len(msg_snapshots) >= 1
-
-                last_snap = msg_snapshots[-1]
-                ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+                ai_msgs = _roled(events, "assistant")
                 assert len(ai_msgs) == 1
                 # List content not representable as str → None
                 assert ai_msgs[0].content is None
@@ -1038,15 +1094,8 @@ def describe_AGUIAdapter():
                 back to the application.
                 """
 
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="hi"))
-
-                graph = EventGraph([reply], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="hi"),
-                )
+                graph = _graph(reply_hi)
+                adapter = _adapter(graph, seed_factory=_ask("hi"))
 
                 # Reset the one-time warning cache so this test is
                 # order-independent.
@@ -1092,26 +1141,16 @@ def describe_AGUIAdapter():
                             )
                         ]
 
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="hi"))
-
-                graph = EventGraph([reply], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="hi"),
-                    mappers=[PauseMapper()],
+                graph = _graph(reply_hi)
+                adapter = _adapter(
+                    graph, seed_factory=_ask("hi"), mappers=[PauseMapper()]
                 )
 
                 events: list[BaseEvent] = []
                 async for event in adapter.stream(_make_input(), deadline=0.0):
                     events.append(event)
 
-                paused = [
-                    e
-                    for e in events
-                    if e.type == EventType.CUSTOM and e.name == "run.paused"
-                ]
+                paused = _custom(events, "run.paused")
                 assert len(paused) == 1, (
                     f"expected 1 run.paused CustomEvent via the user "
                     f"mapper, got {len(paused)}"
@@ -1124,15 +1163,8 @@ def describe_AGUIAdapter():
                 early break needed in the adapter.
                 """
 
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="hi"))
-
-                graph = EventGraph([reply], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="hi"),
-                )
+                graph = _graph(reply_hi)
+                adapter = _adapter(graph, seed_factory=_ask("hi"))
 
                 events: list[BaseEvent] = []
                 async for event in adapter.stream(_make_input(), deadline=0.0):
@@ -1142,64 +1174,30 @@ def describe_AGUIAdapter():
 
     def describe_custom_mappers():
         async def it_allows_user_mapper_to_claim_events():
-            class TaskMapper:
-                def map(self, event, ctx):
-                    if isinstance(event, TaskCreated):
-                        return [
-                            CustomEvent(
-                                type=EventType.CUSTOM,
-                                name="task.created",
-                                value={"title": event.title},
-                            )
-                        ]
-                    return None
-
             @on(UserAsked)
             def create_task(event: UserAsked) -> TaskCreated:
                 return TaskCreated(title="my task")
 
-            graph = EventGraph([create_task], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="create"),
-                mappers=[TaskMapper()],
+            graph = _graph(create_task)
+            events = await _stream(
+                graph,
+                seed_factory=_ask("create"),
+                mappers=[_task_mapper("task.created", "title")],
             )
-            events = await _collect(adapter, _make_input())
 
-            custom = [
-                e
-                for e in events
-                if e.type == EventType.CUSTOM and e.name == "task.created"
-            ]
+            custom = _custom(events, "task.created")
             assert len(custom) == 1
             assert custom[0].value["title"] == "my task"
 
         async def it_user_mapper_before_fallback():
             """User mappers run before FallbackMapper, claiming events first."""
 
-            class TaskMapper:
-                def map(self, event, ctx):
-                    if isinstance(event, TaskCreated):
-                        return [
-                            CustomEvent(
-                                type=EventType.CUSTOM,
-                                name="custom.task",
-                                value={"t": event.title},
-                            )
-                        ]
-                    return None
-
             @on(UserAsked)
             def create_task(event: UserAsked) -> TaskCreated:
                 return TaskCreated(title="test")
 
-            graph = EventGraph([create_task], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-                mappers=[TaskMapper()],
-            )
-            events = await _collect(adapter, _make_input())
+            graph = _graph(create_task)
+            events = await _stream(graph, mappers=[_task_mapper("custom.task", "t")])
 
             # Should see custom.task (user mapper), not TaskCreated (fallback)
             task_events = [
@@ -1214,44 +1212,24 @@ def describe_AGUIAdapter():
     def describe_resume():
         def when_resume_factory_available():
             async def it_uses_resume_factory():
-                @on(UserAsked)
-                def ask(event: UserAsked) -> ApprovalRequested:
-                    return ApprovalRequested(draft="draft")
-
                 @on(ApprovalGiven)
                 def approve(event: ApprovalGiven) -> AgentReplied:
                     return AgentReplied(message=AIMessage(content="Done!"))
 
-                graph = EventGraph(
-                    [ask, approve],
-                    checkpointer=MemorySaver(),
-                    reducers=[message_reducer()],
-                )
+                graph = _graph(ask_draft, approve, checkpointer=MemorySaver())
 
                 # Create the interrupt
-                config = {"configurable": {"thread_id": "t-resume-factory"}}
+                config = _config("t-resume-factory")
                 await graph.ainvoke(UserAsked(question="go"), config=config)
 
                 # Resume via adapter
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="unused"),
-                    resume_factory=lambda inp: ApprovalGiven(approved=True),
-                )
-                events = await _collect(
-                    adapter, _make_input(thread_id="t-resume-factory")
-                )
+                events = await _resume(graph, _make_input(thread_id="t-resume-factory"))
 
                 assert events[0].type == EventType.RUN_STARTED
                 assert events[-1].type == EventType.RUN_FINISHED
 
                 # Should contain message from the approve handler
-                msg_snapshots = [
-                    e for e in events if e.type == EventType.MESSAGES_SNAPSHOT
-                ]
-                assert len(msg_snapshots) >= 1
-                last_snap = msg_snapshots[-1]
-                ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+                ai_msgs = _roled(events, "assistant")
                 assert any("Done!" in m.content for m in ai_msgs)
 
             async def it_streams_resume_events():
@@ -1263,70 +1241,34 @@ def describe_AGUIAdapter():
                 def approve(event: ApprovalGiven) -> TaskCreated:
                     return TaskCreated(title="approved task")
 
-                graph = EventGraph(
-                    [ask, approve],
-                    checkpointer=MemorySaver(),
-                    reducers=[message_reducer()],
-                )
+                graph = _graph(ask, approve, checkpointer=MemorySaver())
 
-                config = {"configurable": {"thread_id": "t-stream-resume"}}
+                config = _config("t-stream-resume")
                 await graph.ainvoke(UserAsked(question="go"), config=config)
 
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="unused"),
-                    resume_factory=lambda inp: ApprovalGiven(approved=True),
-                )
-                events = await _collect(
-                    adapter, _make_input(thread_id="t-stream-resume")
-                )
+                events = await _resume(graph, _make_input(thread_id="t-stream-resume"))
 
                 # Should have TaskCreated as a custom event
-                custom = [
-                    e
-                    for e in events
-                    if e.type == EventType.CUSTOM and e.name == "TaskCreated"
-                ]
+                custom = _custom(events, "TaskCreated")
                 assert len(custom) == 1
                 assert custom[0].value["title"] == "approved task"
 
             async def it_does_not_emit_interrupted_during_successful_resume():
-                @on(UserAsked)
-                def ask(event: UserAsked) -> ApprovalRequested:
-                    return ApprovalRequested(draft="needs approval")
-
-                @on(ApprovalGiven)
-                def approve(event: ApprovalGiven) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="Approved!"))
-
-                graph = EventGraph(
-                    [ask, approve],
-                    checkpointer=MemorySaver(),
-                    reducers=[message_reducer()],
-                )
+                graph = _graph(ask_approval, approve, checkpointer=MemorySaver())
 
                 # Create the interrupt
-                config = {"configurable": {"thread_id": "t-no-stale-interrupt"}}
+                config = _config("t-no-stale-interrupt")
                 await graph.ainvoke(UserAsked(question="go"), config=config)
 
                 # Resume — should complete successfully
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="unused"),
-                    resume_factory=lambda inp: ApprovalGiven(approved=True),
-                )
-                events = await _collect(
-                    adapter, _make_input(thread_id="t-no-stale-interrupt")
+                events = await _resume(
+                    graph, _make_input(thread_id="t-no-stale-interrupt")
                 )
 
                 assert events[-1].type == EventType.RUN_FINISHED
 
                 # No "interrupted" CustomEvents should appear during successful resume
-                interrupted_events = [
-                    e
-                    for e in events
-                    if e.type == EventType.CUSTOM and e.name == "interrupted"
-                ]
+                interrupted_events = _custom(events, "interrupted")
                 assert len(interrupted_events) == 0
 
             async def it_emits_new_interrupted_event_created_during_resume():
@@ -1338,33 +1280,20 @@ def describe_AGUIAdapter():
                 def request_persona_review(event: ApprovalGiven) -> ApprovalRequested:
                     return ApprovalRequested(draft="persona review")
 
-                graph = EventGraph(
-                    [ask, request_persona_review],
-                    checkpointer=MemorySaver(),
-                    reducers=[message_reducer()],
-                )
+                graph = _graph(ask, request_persona_review, checkpointer=MemorySaver())
 
                 # First run creates an interrupt.
-                config = {"configurable": {"thread_id": "t-resume-new-interrupt"}}
+                config = _config("t-resume-new-interrupt")
                 await graph.ainvoke(UserAsked(question="go"), config=config)
 
                 # Resume creates a new interrupt, which is suppressed
                 # in-stream and must be detected from the post-stream
                 # checkpoint read.
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="unused"),
-                    resume_factory=lambda inp: ApprovalGiven(approved=True),
-                )
-                events = await _collect(
-                    adapter, _make_input(thread_id="t-resume-new-interrupt")
+                events = await _resume(
+                    graph, _make_input(thread_id="t-resume-new-interrupt")
                 )
 
-                interrupted_events = [
-                    e
-                    for e in events
-                    if e.type == EventType.CUSTOM and e.name == "interrupted"
-                ]
+                interrupted_events = _custom(events, "interrupted")
                 assert len(interrupted_events) == 1
                 assert interrupted_events[0].value["draft"] == "persona review"
                 assert events[-1].type == EventType.RUN_FINISHED
@@ -1374,38 +1303,10 @@ def describe_AGUIAdapter():
                 async def it_skips_post_stream_checkpoint_read(
                     monkeypatch,
                 ):
-                    @on(UserAsked)
-                    def reply(event: UserAsked) -> AgentReplied:
-                        return AgentReplied(message=AIMessage(content="ok"))
-
-                    graph = EventGraph(
-                        [reply],
-                        checkpointer=MemorySaver(),
-                        reducers=[message_reducer()],
-                    )
-                    adapter = AGUIAdapter(
-                        graph=graph,
-                        seed_factory=lambda inp: UserAsked(question="go"),
-                    )
+                    graph = _graph(reply, checkpointer=MemorySaver())
+                    adapter = _adapter(graph)
 
                     called = {"checkpoint": 0}
-
-                    async def fake_astream_events(
-                        seed,
-                        *,
-                        include_reducers,
-                        include_llm_tokens,
-                        include_custom_events,
-                        config,
-                    ):
-                        del (
-                            seed,
-                            include_reducers,
-                            include_llm_tokens,
-                            include_custom_events,
-                            config,
-                        )
-                        yield ApprovalRequested(draft="stream-first")
 
                     original_aget_state = graph.compiled.aget_state
 
@@ -1413,42 +1314,26 @@ def describe_AGUIAdapter():
                         called["checkpoint"] += 1
                         return await original_aget_state(config)
 
-                    monkeypatch.setattr(
+                    _patch_astream(
+                        monkeypatch,
                         adapter._graph,
-                        "astream_events",
-                        fake_astream_events,
+                        ApprovalRequested(draft="stream-first"),
                     )
                     monkeypatch.setattr(graph.compiled, "aget_state", count_aget_state)
                     events = await _collect(
                         adapter, _make_input(thread_id="t-stream-int")
                     )
 
-                    interrupted_events = [
-                        e
-                        for e in events
-                        if e.type == EventType.CUSTOM and e.name == "interrupted"
-                    ]
+                    interrupted_events = _custom(events, "interrupted")
                     assert len(interrupted_events) == 1
                     assert called["checkpoint"] == 1
 
             async def it_passes_checkpoint_state_to_resume_factory():
                 seen_state: dict[str, Any] = {}
 
-                @on(UserAsked)
-                def ask(event: UserAsked) -> ApprovalRequested:
-                    return ApprovalRequested(draft="needs approval")
+                graph = _graph(ask_approval, approve, checkpointer=MemorySaver())
 
-                @on(ApprovalGiven)
-                def approve(event: ApprovalGiven) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="Approved!"))
-
-                graph = EventGraph(
-                    [ask, approve],
-                    checkpointer=MemorySaver(),
-                    reducers=[message_reducer()],
-                )
-
-                config = {"configurable": {"thread_id": "t-resume-state"}}
+                config = _config("t-resume-state")
                 await graph.ainvoke(UserAsked(question="go"), config=config)
 
                 def resume_state(
@@ -1459,13 +1344,11 @@ def describe_AGUIAdapter():
                         seen_state.update(checkpoint_state)
                     return ApprovalGiven(approved=True)
 
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="unused"),
+                events = await _stream(
+                    graph,
+                    _make_input(thread_id="t-resume-state"),
+                    seed_factory=_ask("unused"),
                     resume_factory=resume_state,
-                )
-                events = await _collect(
-                    adapter, _make_input(thread_id="t-resume-state")
                 )
 
                 assert events[-1].type == EventType.RUN_FINISHED
@@ -1478,52 +1361,33 @@ def describe_AGUIAdapter():
     def describe_init():
         def when_resume_factory_missing_checkpointer():
             def it_raises():
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="hi"))
-
-                graph = EventGraph(
-                    [reply], reducers=[message_reducer()]
-                )  # no checkpointer
+                graph = _graph(reply_hi)  # no checkpointer
                 with pytest.raises(
                     ValueError, match="resume_factory requires a checkpointer"
                 ):
-                    AGUIAdapter(
-                        graph=graph,
-                        seed_factory=lambda inp: UserAsked(question="hi"),
+                    _adapter(
+                        graph,
+                        seed_factory=_ask("hi"),
                         resume_factory=lambda inp: ApprovalGiven(approved=True),
                     )
 
         def when_graph_has_no_message_reducer():
             async def it_raises():
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="hi"))
-
-                graph = EventGraph([reply])
+                graph = EventGraph([reply_hi])
                 with pytest.raises(ValueError, match="message_reducer"):
-                    AGUIAdapter(
-                        graph=graph,
-                        seed_factory=lambda inp: UserAsked(question="hi"),
-                    )
+                    _adapter(graph, seed_factory=_ask("hi"))
 
         def when_include_reducers_false():
             @pytest.mark.asyncio
             async def it_auto_includes_messages():
                 """include_reducers=False is overridden to include messages."""
 
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="auto-included"))
-
-                graph = EventGraph([reply], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="hi"),
+                events = await _emit(
+                    AIMessage(content="auto-included"),
+                    seed_factory=_ask("hi"),
                     include_reducers=False,
                 )
-                events = await _collect(adapter, _make_input())
-                snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+                snapshots = _of_type(events, EventType.MESSAGES_SNAPSHOT)
                 assert len(snapshots) >= 1
 
         def when_include_reducers_list_excludes_messages():
@@ -1531,18 +1395,12 @@ def describe_AGUIAdapter():
             async def it_auto_adds_messages():
                 """include_reducers=['other'] auto-adds 'messages'."""
 
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="list-fix"))
-
-                graph = EventGraph([reply], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="hi"),
+                events = await _emit(
+                    AIMessage(content="list-fix"),
+                    seed_factory=_ask("hi"),
                     include_reducers=["nonexistent"],
                 )
-                events = await _collect(adapter, _make_input())
-                snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+                snapshots = _of_type(events, EventType.MESSAGES_SNAPSHOT)
                 assert len(snapshots) >= 1
 
         def when_include_reducers_is_malformed():
@@ -1550,32 +1408,18 @@ def describe_AGUIAdapter():
                 """Garbage values (int, dict, callable, etc.) fail loudly at
                 init, not silently as empty snapshots at runtime."""
 
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="ok"))
-
-                graph = EventGraph([reply], reducers=[message_reducer()])
+                graph = _graph(reply)
                 with pytest.raises(TypeError, match="include_reducers"):
-                    AGUIAdapter(
-                        graph=graph,
-                        seed_factory=lambda inp: UserAsked(question="hi"),
-                        include_reducers=42,  # type: ignore[arg-type]
-                    )
+                    _adapter(graph, seed_factory=_ask("hi"), include_reducers=42)
 
             def it_rejects_a_callable():
                 """Bare callables aren't a supported include_reducers shape —
                 use the list[str] allow-list form."""
 
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="ok"))
-
-                graph = EventGraph([reply], reducers=[message_reducer()])
+                graph = _graph(reply)
                 with pytest.raises(TypeError, match="include_reducers"):
-                    AGUIAdapter(
-                        graph=graph,
-                        seed_factory=lambda inp: UserAsked(question="hi"),
-                        include_reducers=lambda r: r,  # type: ignore[arg-type]
+                    _adapter(
+                        graph, seed_factory=_ask("hi"), include_reducers=lambda r: r
                     )
 
     def describe_seed_factory():
@@ -1590,21 +1434,15 @@ def describe_AGUIAdapter():
             def reply(event: UserAsked) -> AgentReplied:
                 return AgentReplied(message=AIMessage(content=event.question))
 
-            graph = EventGraph([reply], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=tracking_factory,
-            )
+            graph = _graph(reply)
+            adapter = _adapter(graph, seed_factory=tracking_factory)
             input_data = _make_input(thread_id="t-seed")
             events = await _collect(adapter, input_data)
 
             assert len(received_inputs) == 1
             assert received_inputs[0].thread_id == "t-seed"
 
-            msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
-            assert len(msg_snapshots) >= 1
-            last_snap = msg_snapshots[-1]
-            ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+            ai_msgs = _roled(events, "assistant")
             assert any("from factory" in m.content for m in ai_msgs)
 
 
@@ -1652,52 +1490,26 @@ def describe_interrupt_detection():
         def ask_approval(event: UserAsked) -> ApprovalRequested:
             return ApprovalRequested(draft="needs review")
 
-        graph = EventGraph(
-            [ask_approval],
-            checkpointer=MemorySaver(),
-            reducers=[message_reducer()],
-        )
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="check"),
-        )
-        events = await _collect(adapter, _make_input())
+        graph = _graph(ask_approval, checkpointer=MemorySaver())
+        events = await _stream(graph, seed_factory=_ask("check"))
 
-        interrupted_events = [
-            e for e in events if e.type == EventType.CUSTOM and e.name == "interrupted"
-        ]
+        interrupted_events = _custom(events, "interrupted")
         assert len(interrupted_events) == 1
         assert interrupted_events[0].value["draft"] == "needs review"
 
 
 def describe_resume_reducers():
     async def it_emits_state_snapshot_during_resume():
-        @on(UserAsked)
-        def ask(event: UserAsked) -> ApprovalRequested:
-            return ApprovalRequested(draft="draft")
+        graph = _graph(ask_draft, approve, checkpointer=MemorySaver())
 
-        @on(ApprovalGiven)
-        def approve(event: ApprovalGiven) -> AgentReplied:
-            return AgentReplied(message=AIMessage(content="Approved!"))
-
-        graph = EventGraph(
-            [ask, approve],
-            checkpointer=MemorySaver(),
-            reducers=[message_reducer()],
-        )
-
-        config = {"configurable": {"thread_id": "t-resume-reducers"}}
+        config = _config("t-resume-reducers")
         await graph.ainvoke(UserAsked(question="go"), config=config)
 
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="unused"),
-            resume_factory=lambda inp: ApprovalGiven(approved=True),
-            include_reducers=True,
+        events = await _resume(
+            graph, _make_input(thread_id="t-resume-reducers"), include_reducers=True
         )
-        events = await _collect(adapter, _make_input(thread_id="t-resume-reducers"))
 
-        snapshots = [e for e in events if e.type == EventType.STATE_SNAPSHOT]
+        snapshots = _of_type(events, EventType.STATE_SNAPSHOT)
         assert len(snapshots) >= 1
 
 
@@ -1712,64 +1524,33 @@ def describe_connect():
         def when_existing_thread():
 
             async def it_replays_state_from_checkpoint():
-                @on(UserAsked)
-                def ask(event: UserAsked) -> ApprovalRequested:
-                    return ApprovalRequested(draft="pending")
-
-                graph = EventGraph(
-                    [ask],
-                    checkpointer=MemorySaver(),
-                    reducers=[message_reducer()],
-                )
+                graph = _graph(ask_pending, checkpointer=MemorySaver())
                 await graph.ainvoke(
                     UserAsked(question="go"),
-                    config={"configurable": {"thread_id": "t-connect"}},
+                    config=_config("t-connect"),
                 )
 
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="unused"),
+                events = await _connect(
+                    graph,
+                    _make_input(thread_id="t-connect"),
+                    seed_factory=_ask("unused"),
                 )
-                events = [
-                    event
-                    async for event in adapter.connect(
-                        _make_input(thread_id="t-connect")
-                    )
-                ]
 
                 assert any(e.type == EventType.STATE_SNAPSHOT for e in events)
                 assert any(e.type == EventType.MESSAGES_SNAPSHOT for e in events)
-                interrupted = [
-                    e
-                    for e in events
-                    if e.type == EventType.CUSTOM and e.name == "interrupted"
-                ]
+                interrupted = _custom(events, "interrupted")
                 assert len(interrupted) == 1
                 assert interrupted[0].value["draft"] == "pending"
 
         def when_new_thread():
 
             async def it_emits_empty_snapshots():
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="ok"))
-
-                graph = EventGraph(
-                    [reply],
-                    checkpointer=MemorySaver(),
-                    reducers=[message_reducer()],
+                graph = _graph(reply, checkpointer=MemorySaver())
+                events = await _connect(
+                    graph,
+                    _make_input(thread_id="brand-new-thread"),
+                    seed_factory=_ask("unused"),
                 )
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="unused"),
-                )
-
-                events = [
-                    event
-                    async for event in adapter.connect(
-                        _make_input(thread_id="brand-new-thread")
-                    )
-                ]
                 assert len(events) == 2
                 assert events[0].type == EventType.STATE_SNAPSHOT
                 assert events[0].snapshot == {}
@@ -1779,17 +1560,8 @@ def describe_connect():
     def when_no_checkpointer():
 
         async def it_emits_empty_snapshots():
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph([reply], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="unused"),
-            )
-
-            events = [event async for event in adapter.connect(_make_input())]
+            graph = _graph(reply)
+            events = await _connect(graph, seed_factory=_ask("unused"))
             assert len(events) == 2
             assert events[0].type == EventType.STATE_SNAPSHOT
             assert events[0].snapshot == {}
@@ -1799,18 +1571,10 @@ def describe_connect():
     def when_forwarded_props():
 
         async def it_passes_config_to_aget_state(monkeypatch):
-            @on(UserAsked)
-            def ask(event: UserAsked) -> ApprovalRequested:
-                return ApprovalRequested(draft="pending")
-
-            graph = EventGraph(
-                [ask],
-                checkpointer=MemorySaver(),
-                reducers=[message_reducer()],
-            )
+            graph = _graph(ask_pending, checkpointer=MemorySaver())
             await graph.ainvoke(
                 UserAsked(question="go"),
-                config={"configurable": {"thread_id": "t-connect-config"}},
+                config=_config("t-connect-config"),
             )
 
             captured: list[dict[str, Any]] = []
@@ -1822,24 +1586,19 @@ def describe_connect():
 
             monkeypatch.setattr(graph.compiled, "aget_state", capture_aget_state)
 
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="unused"),
+            events = await _connect(
+                graph,
+                _make_input(
+                    thread_id="t-connect-config",
+                    forwarded_props={
+                        "langgraph_config": {
+                            "recursion_limit": 13,
+                            "configurable": {"tenant_id": "acme"},
+                        }
+                    },
+                ),
+                seed_factory=_ask("unused"),
             )
-            events = [
-                event
-                async for event in adapter.connect(
-                    _make_input(
-                        thread_id="t-connect-config",
-                        forwarded_props={
-                            "langgraph_config": {
-                                "recursion_limit": 13,
-                                "configurable": {"tenant_id": "acme"},
-                            }
-                        },
-                    )
-                )
-            ]
 
             assert len(captured) == 1
             assert captured[0]["recursion_limit"] == 13
@@ -1865,34 +1624,25 @@ def describe_connect():
                 fn=lambda e: e.question or SKIP,
             )
 
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="hi"))
-
-            graph = EventGraph(
-                [reply],
+            graph = _graph(
+                reply_hi,
                 checkpointer=MemorySaver(),
                 reducers=[message_reducer(), focus],
             )
-            config = {"configurable": {"thread_id": "t-connect-no-events-leak"}}
+            config = _config("t-connect-no-events-leak")
             await graph.ainvoke(UserAsked(question="scene-7"), config=config)
 
             # Sanity: the checkpoint really does carry a non-empty audit log.
             checkpoint_events = graph.get_state(config).events
             assert len(checkpoint_events) >= 1
 
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="unused"),
+            events = await _connect(
+                graph,
+                _make_input(thread_id="t-connect-no-events-leak"),
+                seed_factory=_ask("unused"),
             )
-            events = [
-                event
-                async for event in adapter.connect(
-                    _make_input(thread_id="t-connect-no-events-leak")
-                )
-            ]
 
-            state_snapshots = [e for e in events if e.type == EventType.STATE_SNAPSHOT]
+            state_snapshots = _of_type(events, EventType.STATE_SNAPSHOT)
             assert len(state_snapshots) == 1
             snapshot = state_snapshots[0].snapshot
             # The internal audit log must NOT leak to the client.
@@ -1905,36 +1655,12 @@ def describe_connect():
 
 def describe_config_passthrough():
     def _setup_stream_capture(monkeypatch):
-        @on(UserAsked)
-        def reply(event: UserAsked) -> AgentReplied:
-            return AgentReplied(message=AIMessage(content="ok"))
-
-        graph = EventGraph([reply], reducers=[message_reducer()])
-        captured: list[dict[str, Any]] = []
-
-        async def fake_astream_events(
-            seed,
-            *,
-            include_reducers,
-            include_llm_tokens,
-            include_custom_events,
-            config,
-        ):
-            del seed, include_reducers, include_llm_tokens, include_custom_events
-            captured.append(config)
-            if False:  # pragma: no cover
-                yield None
-
-        monkeypatch.setattr(graph, "astream_events", fake_astream_events)
-
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="go"),
-        )
-        return adapter, captured
+        graph = _graph(reply)
+        calls = _patch_astream(monkeypatch, graph)
+        return _adapter(graph), calls
 
     async def it_forwards_langgraph_config_from_forwarded_props(monkeypatch):
-        adapter, captured = _setup_stream_capture(monkeypatch)
+        adapter, calls = _setup_stream_capture(monkeypatch)
         input_data = _make_input(
             thread_id="t-config",
             forwarded_props={
@@ -1949,13 +1675,13 @@ def describe_config_passthrough():
 
         assert events[0].type == EventType.RUN_STARTED
         assert events[-1].type == EventType.RUN_FINISHED
-        assert len(captured) == 1
-        assert captured[0]["recursion_limit"] == 7
-        assert captured[0]["configurable"]["tenant_id"] == "acme"
-        assert captured[0]["configurable"]["thread_id"] == "t-config"
+        assert len(calls) == 1
+        assert calls[0]["config"]["recursion_limit"] == 7
+        assert calls[0]["config"]["configurable"]["tenant_id"] == "acme"
+        assert calls[0]["config"]["configurable"]["thread_id"] == "t-config"
 
     async def it_forwards_config_key_from_forwarded_props(monkeypatch):
-        adapter, captured = _setup_stream_capture(monkeypatch)
+        adapter, calls = _setup_stream_capture(monkeypatch)
         input_data = _make_input(
             thread_id="t-config-key",
             forwarded_props={
@@ -1973,14 +1699,14 @@ def describe_config_passthrough():
 
         assert events[0].type == EventType.RUN_STARTED
         assert events[-1].type == EventType.RUN_FINISHED
-        assert len(captured) == 1
-        assert captured[0]["recursion_limit"] == 9
-        assert captured[0]["configurable"]["tenant_id"] == "acme"
+        assert len(calls) == 1
+        assert calls[0]["config"]["recursion_limit"] == 9
+        assert calls[0]["config"]["configurable"]["tenant_id"] == "acme"
         # Request thread_id wins over forwarded config thread_id.
-        assert captured[0]["configurable"]["thread_id"] == "t-config-key"
+        assert calls[0]["config"]["configurable"]["thread_id"] == "t-config-key"
 
     async def it_accepts_top_level_langgraph_config_shape(monkeypatch):
-        adapter, captured = _setup_stream_capture(monkeypatch)
+        adapter, calls = _setup_stream_capture(monkeypatch)
         input_data = _make_input(
             thread_id="t-top-level",
             forwarded_props={
@@ -1996,13 +1722,13 @@ def describe_config_passthrough():
 
         assert events[0].type == EventType.RUN_STARTED
         assert events[-1].type == EventType.RUN_FINISHED
-        assert len(captured) == 1
-        assert captured[0]["recursion_limit"] == 11
-        assert captured[0]["configurable"]["tenant_id"] == "top-level-tenant"
-        assert captured[0]["configurable"]["thread_id"] == "t-top-level"
+        assert len(calls) == 1
+        assert calls[0]["config"]["recursion_limit"] == 11
+        assert calls[0]["config"]["configurable"]["tenant_id"] == "top-level-tenant"
+        assert calls[0]["config"]["configurable"]["thread_id"] == "t-top-level"
 
     async def it_ignores_unrecognized_forwarded_props(monkeypatch):
-        adapter, captured = _setup_stream_capture(monkeypatch)
+        adapter, calls = _setup_stream_capture(monkeypatch)
         input_data = _make_input(
             thread_id="t-default-config",
             forwarded_props={"foo": "bar"},
@@ -2012,55 +1738,24 @@ def describe_config_passthrough():
 
         assert events[0].type == EventType.RUN_STARTED
         assert events[-1].type == EventType.RUN_FINISHED
-        assert len(captured) == 1
-        assert captured[0]["configurable"]["thread_id"] == "t-default-config"
-        assert "foo" not in captured[0]
+        assert len(calls) == 1
+        assert calls[0]["config"]["configurable"]["thread_id"] == "t-default-config"
+        assert "foo" not in calls[0]["config"]
 
 
 def describe_custom_event_passthrough():
     async def it_maps_state_snapshot_frame_to_state_snapshot(monkeypatch):
         from langgraph_events.stream import StateSnapshotFrame
 
-        @on(UserAsked)
-        def reply(event: UserAsked) -> AgentReplied:
-            return AgentReplied(message=AIMessage(content="ok"))
-
-        graph = EventGraph([reply], reducers=[message_reducer()])
-        calls: list[dict[str, Any]] = []
-
-        async def fake_astream_events(
-            seed,
-            *,
-            include_reducers,
-            include_llm_tokens,
-            include_custom_events,
-            config,
-        ):
-            calls.append(
-                {
-                    "include_reducers": include_reducers,
-                    "include_llm_tokens": include_llm_tokens,
-                    "include_custom_events": include_custom_events,
-                }
-            )
-            del (
-                seed,
-                include_reducers,
-                include_llm_tokens,
-                include_custom_events,
-                config,
-            )
-            yield StateSnapshotFrame(data={"messages": [], "step": "draft"})
-
-        monkeypatch.setattr(graph, "astream_events", fake_astream_events)
-
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="go"),
+        graph = _graph(reply)
+        calls = _patch_astream(
+            monkeypatch,
+            graph,
+            StateSnapshotFrame(data={"messages": [], "step": "draft"}),
         )
 
-        events = await _collect(adapter, _make_input())
-        snapshots = [e for e in events if e.type == EventType.STATE_SNAPSHOT]
+        events = await _stream(graph)
+        snapshots = _of_type(events, EventType.STATE_SNAPSHOT)
 
         assert len(calls) == 1
         assert calls[0]["include_llm_tokens"] is True
@@ -2072,45 +1767,18 @@ def describe_custom_event_passthrough():
         from langgraph_events._custom_event import STATE_SNAPSHOT_EVENT_NAME
         from langgraph_events.stream import CustomEventFrame
 
-        @on(UserAsked)
-        def reply(event: UserAsked) -> AgentReplied:
-            return AgentReplied(message=AIMessage(content="ok"))
-
-        graph = EventGraph([reply], reducers=[message_reducer()])
-
-        async def fake_astream_events(
-            seed,
-            *,
-            include_reducers,
-            include_llm_tokens,
-            include_custom_events,
-            config,
-        ):
-            del (
-                seed,
-                include_reducers,
-                include_llm_tokens,
-                include_custom_events,
-                config,
-            )
-            yield CustomEventFrame(
+        graph = _graph(reply)
+        _patch_astream(
+            monkeypatch,
+            graph,
+            CustomEventFrame(
                 name=STATE_SNAPSHOT_EVENT_NAME,
                 data={"messages": [], "step": "draft"},
-            )
-
-        monkeypatch.setattr(graph, "astream_events", fake_astream_events)
-
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="go"),
+            ),
         )
 
-        events = await _collect(adapter, _make_input())
-        custom_events = [
-            e
-            for e in events
-            if e.type == EventType.CUSTOM and e.name == STATE_SNAPSHOT_EVENT_NAME
-        ]
+        events = await _stream(graph)
+        custom_events = _custom(events, STATE_SNAPSHOT_EVENT_NAME)
 
         assert len(custom_events) == 1
         assert custom_events[0].value == {"messages": [], "step": "draft"}
@@ -2118,42 +1786,13 @@ def describe_custom_event_passthrough():
     async def it_maps_custom_event_frame_to_custom_event(monkeypatch):
         from langgraph_events.stream import CustomEventFrame
 
-        @on(UserAsked)
-        def reply(event: UserAsked) -> AgentReplied:
-            return AgentReplied(message=AIMessage(content="ok"))
-
-        graph = EventGraph([reply], reducers=[message_reducer()])
-
-        async def fake_astream_events(
-            seed,
-            *,
-            include_reducers,
-            include_llm_tokens,
-            include_custom_events,
-            config,
-        ):
-            del (
-                seed,
-                include_reducers,
-                include_llm_tokens,
-                include_custom_events,
-                config,
-            )
-            yield CustomEventFrame(name="tool.progress", data={"pct": 80})
-
-        monkeypatch.setattr(graph, "astream_events", fake_astream_events)
-
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="go"),
+        graph = _graph(reply)
+        _patch_astream(
+            monkeypatch, graph, CustomEventFrame(name="tool.progress", data={"pct": 80})
         )
 
-        events = await _collect(adapter, _make_input())
-        custom_events = [
-            e
-            for e in events
-            if e.type == EventType.CUSTOM and e.name == "tool.progress"
-        ]
+        events = await _stream(graph)
+        custom_events = _custom(events, "tool.progress")
 
         assert len(custom_events) == 1
         assert custom_events[0].value == {"pct": 80}
@@ -2165,13 +1804,8 @@ def describe_async_checkpoint_reads():
         def ask(event: UserAsked) -> ApprovalRequested:
             return ApprovalRequested(draft="needs review")
 
-        graph = EventGraph(
-            [ask], checkpointer=MemorySaver(), reducers=[message_reducer()]
-        )
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="go"),
-        )
+        graph = _graph(ask, checkpointer=MemorySaver())
+        adapter = _adapter(graph)
 
         called = {"sync": False}
 
@@ -2183,9 +1817,7 @@ def describe_async_checkpoint_reads():
         events = await _collect(adapter, _make_input(thread_id="t-async-state"))
 
         assert called["sync"] is False
-        interrupted = [
-            e for e in events if e.type == EventType.CUSTOM and e.name == "interrupted"
-        ]
+        interrupted = _custom(events, "interrupted")
         assert len(interrupted) == 1
 
 
@@ -2198,23 +1830,14 @@ def describe_seed_factory_state():
                 received_states.append(state)
                 return UserAsked(question="from stateful")
 
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph(
-                [reply], checkpointer=MemorySaver(), reducers=[message_reducer()]
-            )
+            graph = _graph(reply, checkpointer=MemorySaver())
             # Create a thread with state
             await graph.ainvoke(
                 UserAsked(question="first"),
-                config={"configurable": {"thread_id": "t-seed-state"}},
+                config=_config("t-seed-state"),
             )
 
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=stateful_factory,
-            )
+            adapter = _adapter(graph, seed_factory=stateful_factory)
             await _collect(adapter, _make_input(thread_id="t-seed-state"))
 
             assert len(received_states) == 1
@@ -2232,16 +1855,8 @@ def describe_seed_factory_state():
 
     def when_single_arg_seed_factory():
         async def it_accepts_single_arg_factory():
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph([reply], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="simple"),
-            )
-            events = await _collect(adapter, _make_input())
+            graph = _graph(reply)
+            events = await _stream(graph, seed_factory=_ask("simple"))
 
             assert events[0].type == EventType.RUN_STARTED
             assert events[-1].type == EventType.RUN_FINISHED
@@ -2254,15 +1869,8 @@ def describe_seed_factory_state():
                 received_states.append(state)
                 return UserAsked(question="no cp")
 
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph([reply], reducers=[message_reducer()])  # no checkpointer
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=stateful_factory,
-            )
+            graph = _graph(reply)  # no checkpointer
+            adapter = _adapter(graph, seed_factory=stateful_factory)
             await _collect(adapter, _make_input())
 
             assert len(received_states) == 1
@@ -2279,23 +1887,17 @@ def describe_interrupt_replay():
                 call_count["n"] += 1
                 return ApprovalRequested(draft="pending")
 
-            graph = EventGraph(
-                [ask],
-                checkpointer=MemorySaver(),
-                reducers=[message_reducer()],
-            )
+            graph = _graph(ask, checkpointer=MemorySaver())
             # Create interrupted thread
             await graph.ainvoke(
                 UserAsked(question="go"),
-                config={"configurable": {"thread_id": "t-gate"}},
+                config=_config("t-gate"),
             )
             initial_calls = call_count["n"]
 
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="retry"),
+            events = await _stream(
+                graph, _make_input(thread_id="t-gate"), seed_factory=_ask("retry")
             )
-            events = await _collect(adapter, _make_input(thread_id="t-gate"))
 
             # Handler should NOT have been called again
             assert call_count["n"] == initial_calls
@@ -2303,37 +1905,18 @@ def describe_interrupt_replay():
             assert events[0].type == EventType.RUN_STARTED
             assert events[-1].type == EventType.RUN_FINISHED
             assert any(e.type == EventType.STATE_SNAPSHOT for e in events)
-            interrupted = [
-                e
-                for e in events
-                if e.type == EventType.CUSTOM and e.name == "interrupted"
-            ]
+            interrupted = _custom(events, "interrupted")
             assert len(interrupted) == 1
             assert interrupted[0].value["draft"] == "pending"
 
     def when_not_interrupted():
         async def it_executes_normally():
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="done"))
-
-            graph = EventGraph(
-                [reply],
-                checkpointer=MemorySaver(),
-                reducers=[message_reducer()],
-            )
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            events = await _collect(adapter, _make_input(thread_id="t-gate-clean"))
+            graph = _graph(reply_done, checkpointer=MemorySaver())
+            events = await _stream(graph, _make_input(thread_id="t-gate-clean"))
 
             assert events[0].type == EventType.RUN_STARTED
             assert events[-1].type == EventType.RUN_FINISHED
-            msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
-            assert len(msg_snapshots) >= 1
-            last_snap = msg_snapshots[-1]
-            ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+            ai_msgs = _roled(events, "assistant")
             assert any("done" in m.content for m in ai_msgs)
 
 
@@ -2344,18 +1927,10 @@ def describe_AGUICustomEvent():
             def emit(event: UserAsked) -> NamedEvent:
                 return NamedEvent(data="hello")
 
-            graph = EventGraph([emit], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            events = await _collect(adapter, _make_input())
+            graph = _graph(emit)
+            events = await _stream(graph)
 
-            custom = [
-                e
-                for e in events
-                if e.type == EventType.CUSTOM and e.name == "custom.named"
-            ]
+            custom = _custom(events, "custom.named")
             assert len(custom) == 1
             assert custom[0].value == {"data": "hello"}
 
@@ -2365,19 +1940,11 @@ def describe_AGUICustomEvent():
             def emit(event: UserAsked) -> TaskCreated:
                 return TaskCreated(title="fallback")
 
-            graph = EventGraph([emit], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            events = await _collect(adapter, _make_input())
+            graph = _graph(emit)
+            events = await _stream(graph)
 
             # Should use class name, not agui_event_name
-            custom = [
-                e
-                for e in events
-                if e.type == EventType.CUSTOM and e.name == "TaskCreated"
-            ]
+            custom = _custom(events, "TaskCreated")
             assert len(custom) == 1
 
 
@@ -2391,39 +1958,20 @@ def describe_connect_frontend_tool_interrupt():
                 tool_call_id="tc-connect-1",
             )
 
-        graph = EventGraph(
-            [request],
-            reducers=[message_reducer()],
-            checkpointer=MemorySaver(),
-        )
+        graph = _graph(request, checkpointer=MemorySaver())
         await graph.ainvoke(
             AskConfirm(prompt="Ship v1?"),
-            config={"configurable": {"thread_id": "t-connect-fe"}},
+            config=_config("t-connect-fe"),
         )
 
-        adapter = AGUIAdapter(
-            graph=graph,
+        events = await _connect(
+            graph,
+            _make_input(thread_id="t-connect-fe"),
             seed_factory=lambda inp: AskConfirm(prompt="unused"),
         )
-        events = [
-            e async for e in adapter.connect(_make_input(thread_id="t-connect-fe"))
-        ]
 
-        triple = [
-            e.type
-            for e in events
-            if e.type
-            in (
-                EventType.TOOL_CALL_START,
-                EventType.TOOL_CALL_ARGS,
-                EventType.TOOL_CALL_END,
-            )
-        ]
-        assert triple == [
-            EventType.TOOL_CALL_START,
-            EventType.TOOL_CALL_ARGS,
-            EventType.TOOL_CALL_END,
-        ]
+        triple = _tool_call_types(events)
+        assert triple == _TOOL_CALL_TRIPLE
         start = next(e for e in events if e.type == EventType.TOOL_CALL_START)
         args_ev = next(e for e in events if e.type == EventType.TOOL_CALL_ARGS)
         assert start.tool_call_id == "tc-connect-1"
@@ -2438,34 +1986,20 @@ def describe_connect_frontend_tool_interrupt():
 
 def describe_connect_completed_thread():
     async def it_emits_state_and_messages():
-        @on(UserAsked)
-        def reply(event: UserAsked) -> AgentReplied:
-            return AgentReplied(message=AIMessage(content="done"))
-
-        graph = EventGraph(
-            [reply],
-            checkpointer=MemorySaver(),
-            reducers=[message_reducer()],
-        )
+        graph = _graph(reply_done, checkpointer=MemorySaver())
         await graph.ainvoke(
             UserAsked(question="go"),
-            config={"configurable": {"thread_id": "t-completed"}},
+            config=_config("t-completed"),
         )
 
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="unused"),
+        events = await _connect(
+            graph, _make_input(thread_id="t-completed"), seed_factory=_ask("unused")
         )
-        events = [
-            e async for e in adapter.connect(_make_input(thread_id="t-completed"))
-        ]
 
         assert any(e.type == EventType.STATE_SNAPSHOT for e in events)
         assert any(e.type == EventType.MESSAGES_SNAPSHOT for e in events)
         # No interrupt — thread completed successfully
-        interrupted = [
-            e for e in events if e.type == EventType.CUSTOM and e.name == "interrupted"
-        ]
+        interrupted = _custom(events, "interrupted")
         assert len(interrupted) == 0
 
 
@@ -2477,22 +2011,15 @@ def describe_agui_event_name_edge_cases():
             def emit(event: UserAsked) -> NameOnlyEvent:
                 return NameOnlyEvent(data="test")
 
-            graph = EventGraph([emit], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
+            graph = _graph(emit)
+            adapter = _adapter(graph)
             _warned_classes.discard(NameOnlyEvent)
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
                 events = await _collect(adapter, _make_input())
 
             # Not AGUISerializable → suppressed with warning
-            custom = [
-                e
-                for e in events
-                if e.type == EventType.CUSTOM and e.name == "custom.name"
-            ]
+            custom = _custom(events, "custom.name")
             assert len(custom) == 0
             assert any("NameOnlyEvent" in str(x.message) for x in w)
 
@@ -2503,22 +2030,19 @@ def describe_multi_seed_factory():
         def reply(event: UserAsked) -> AgentReplied:
             return AgentReplied(message=AIMessage(content=f"Re: {event.question}"))
 
-        graph = EventGraph([reply], reducers=[message_reducer()])
-        adapter = AGUIAdapter(
-            graph=graph,
+        graph = _graph(reply)
+        events = await _stream(
+            graph,
             seed_factory=lambda inp: [
                 UserAsked(question="first"),
                 UserAsked(question="second"),
             ],
         )
-        events = await _collect(adapter, _make_input())
 
         assert events[0].type == EventType.RUN_STARTED
         assert events[-1].type == EventType.RUN_FINISHED
         # Both seeds should produce replies
-        msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
-        assert len(msg_snapshots) >= 1
-        last_snap = msg_snapshots[-1]
+        last_snap = _last_snapshot(events)
         all_content = " ".join(
             m.content for m in last_snap.messages if m.role == "assistant"
         )
@@ -2529,26 +2053,10 @@ def describe_multi_seed_factory():
 def describe_llm_streaming_single_start():
     async def it_emits_text_message_start_exactly_once():
         """LLM streaming emits exactly one TEXT_MESSAGE_START per call."""
-        llm = FakeListChatModel(responses=["dedup me"], sleep=0)
+        graph = _graph(_llm_replier("dedup me"))
+        events = await _stream(graph)
 
-        @on(UserAsked)
-        async def stream_reply(
-            event: UserAsked,
-            messages: list[Any],
-        ) -> AgentReplied:
-            response = await llm.ainvoke(
-                [*messages, HumanMessage(content=event.question)]
-            )
-            return AgentReplied(message=response)
-
-        graph = EventGraph([stream_reply], reducers=[message_reducer()])
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="go"),
-        )
-        events = await _collect(adapter, _make_input())
-
-        starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+        starts = _of_type(events, EventType.TEXT_MESSAGE_START)
         # Exactly one start — from LLM streaming
         assert len(starts) == 1
 
@@ -2556,10 +2064,6 @@ def describe_llm_streaming_single_start():
 def describe_llm_streaming_on_resume():
     async def it_streams_tokens_during_resume():
         llm = FakeListChatModel(responses=["resumed reply"], sleep=0)
-
-        @on(UserAsked)
-        def ask(event: UserAsked) -> ApprovalRequested:
-            return ApprovalRequested(draft="needs approval")
 
         @on(ApprovalGiven)
         async def approve(
@@ -2569,23 +2073,15 @@ def describe_llm_streaming_on_resume():
             response = await llm.ainvoke([*messages, HumanMessage(content="approved")])
             return AgentReplied(message=response)
 
-        graph = EventGraph(
-            [ask, approve],
-            checkpointer=MemorySaver(),
-            reducers=[message_reducer()],
-        )
+        graph = _graph(ask_approval, approve, checkpointer=MemorySaver())
         await graph.ainvoke(
             UserAsked(question="go"),
-            config={"configurable": {"thread_id": "t-llm-resume"}},
+            config=_config("t-llm-resume"),
         )
 
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="unused"),
-            resume_factory=lambda inp: ApprovalGiven(approved=True),
-            include_reducers=True,
+        events = await _resume(
+            graph, _make_input(thread_id="t-llm-resume"), include_reducers=True
         )
-        events = await _collect(adapter, _make_input(thread_id="t-llm-resume"))
 
         assert events[0].type == EventType.RUN_STARTED
         assert events[-1].type == EventType.RUN_FINISHED
@@ -2629,34 +2125,14 @@ def describe_snapshot_uses_langchain_ids():
 
     async def it_uses_langchain_ids_not_streaming_ids():
         """Snapshot AI message keeps its LangChain ID, not the streaming msg-N ID."""
-        llm = FakeListChatModel(responses=["hello"], sleep=0)
+        graph = _graph(_llm_replier("hello"))
+        events = await _stream(graph, include_reducers=True)
 
-        @on(UserAsked)
-        async def stream_reply(
-            event: UserAsked,
-            messages: list[Any],
-        ) -> AgentReplied:
-            response = await llm.ainvoke(
-                [*messages, HumanMessage(content=event.question)]
-            )
-            return AgentReplied(message=response)
-
-        graph = EventGraph([stream_reply], reducers=[message_reducer()])
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="go"),
-            include_reducers=True,
-        )
-        events = await _collect(adapter, _make_input())
-
-        starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+        starts = _of_type(events, EventType.TEXT_MESSAGE_START)
         assert len(starts) == 1
         stream_msg_id = starts[0].message_id
 
-        msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
-        assert len(msg_snapshots) >= 1
-        last_snap = msg_snapshots[-1]
-        ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+        ai_msgs = _roled(events, "assistant")
         assert len(ai_msgs) >= 1
         # Snapshot uses LangChain ID, NOT the streaming ID
         assert ai_msgs[-1].id != stream_msg_id
@@ -2674,25 +2150,22 @@ def describe_snapshot_uses_langchain_ids():
             response = await llm.ainvoke(messages)
             return AgentReplied(message=response)
 
-        graph = EventGraph([stream_reply], reducers=[message_reducer()])
-        adapter = AGUIAdapter(
-            graph=graph,
+        graph = _graph(stream_reply)
+        events = await _stream(
+            graph,
             seed_factory=lambda inp: UserSent(
                 message=HumanMessage(content="hello", id="human-1")
             ),
             include_reducers=True,
         )
-        events = await _collect(adapter, _make_input())
 
-        msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
-        assert len(msg_snapshots) >= 1
-        last_snap = msg_snapshots[-1]
+        last_snap = _last_snapshot(events)
 
-        human_msgs = [m for m in last_snap.messages if m.role == "user"]
+        human_msgs = _by_role(last_snap.messages, "user")
         assert len(human_msgs) >= 1
         assert human_msgs[0].id == "human-1"
 
-        ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+        ai_msgs = _by_role(last_snap.messages, "assistant")
         assert len(ai_msgs) >= 1
         # AI message uses LangChain ID, not streaming ID
         assert not ai_msgs[-1].id.startswith("msg-")
@@ -2719,20 +2192,15 @@ def describe_snapshot_uses_langchain_ids():
             response = await llm.ainvoke([*messages, HumanMessage(content="follow up")])
             return FollowUpReply(message=response)
 
-        graph = EventGraph([first_reply, second_reply], reducers=[message_reducer()])
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="go"),
-            include_reducers=True,
-        )
-        events = await _collect(adapter, _make_input())
+        graph = _graph(first_reply, second_reply)
+        events = await _stream(graph, include_reducers=True)
 
-        starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+        starts = _of_type(events, EventType.TEXT_MESSAGE_START)
         assert len(starts) == 2
 
-        msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+        msg_snapshots = _of_type(events, EventType.MESSAGES_SNAPSHOT)
         last_snap = msg_snapshots[-1]
-        ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+        ai_msgs = _by_role(last_snap.messages, "assistant")
         assert len(ai_msgs) == 2
         for m in ai_msgs:
             assert m.id.startswith("lc_run--"), f"Expected LangChain ID, got {m.id}"
@@ -2751,20 +2219,13 @@ def describe_non_streamed_id_reconciliation():
             def emit(event: UserAsked) -> PhaseA:
                 return PhaseA(messages=(ai,))
 
-            graph = EventGraph([emit], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            events = await _collect(adapter, _make_input())
+            graph = _graph(emit)
+            events = await _stream(graph)
 
-            starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+            starts = _of_type(events, EventType.TEXT_MESSAGE_START)
             assert len(starts) == 0
 
-            snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
-            assert len(snapshots) >= 1
-            last_snap = snapshots[-1]
-            ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+            ai_msgs = _roled(events, "assistant")
             assert len(ai_msgs) == 1
             assert ai_msgs[0].id == "lc-ai-1"
 
@@ -2781,19 +2242,15 @@ def describe_non_streamed_id_reconciliation():
             def step2(event: PhaseA) -> PhaseB:
                 return PhaseB(messages=(ai2,))
 
-            graph = EventGraph([step1, step2], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            events = await _collect(adapter, _make_input())
+            graph = _graph(step1, step2)
+            events = await _stream(graph)
 
-            starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+            starts = _of_type(events, EventType.TEXT_MESSAGE_START)
             assert len(starts) == 0
 
-            snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+            snapshots = _of_type(events, EventType.MESSAGES_SNAPSHOT)
             last_snap = snapshots[-1]
-            ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+            ai_msgs = _by_role(last_snap.messages, "assistant")
             snapshot_ids = {m.id for m in ai_msgs}
             assert snapshot_ids == {"lc-ai-1", "lc-ai-2"}
 
@@ -2806,22 +2263,15 @@ def describe_non_streamed_id_reconciliation():
             def emit(event: UserAsked) -> PhaseA:
                 return PhaseA(messages=(empty_ai,))
 
-            graph = EventGraph([emit], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            events = await _collect(adapter, _make_input())
+            graph = _graph(emit)
+            events = await _stream(graph)
 
             # No TextMessageStart should have been emitted
-            starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+            starts = _of_type(events, EventType.TEXT_MESSAGE_START)
             assert len(starts) == 0
 
             # Snapshot should keep the original LC ID, not rewrite to an orphan msg-*
-            snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
-            assert len(snapshots) >= 1
-            last_snap = snapshots[-1]
-            ai_msgs = [m for m in last_snap.messages if m.role == "assistant"]
+            ai_msgs = _roled(events, "assistant")
             for m in ai_msgs:
                 assert not m.id.startswith("msg-"), (
                     f"Orphan override: snapshot rewrote to {m.id} with no "
@@ -2834,11 +2284,7 @@ def describe_unclosed_stream_on_error():
         """TEXT_MESSAGE_END must be emitted for open streams before RUN_ERROR."""
         from langgraph_events.stream import LLMToken
 
-        @on(UserAsked)
-        def reply(event: UserAsked) -> AgentReplied:
-            return AgentReplied(message=AIMessage(content="ok"))
-
-        graph = EventGraph([reply], reducers=[message_reducer()])
+        graph = _graph(reply)
 
         async def exploding_stream(
             seed,
@@ -2856,11 +2302,7 @@ def describe_unclosed_stream_on_error():
 
         monkeypatch.setattr(graph, "astream_events", exploding_stream)
 
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="go"),
-        )
-        events = await _collect(adapter, _make_input())
+        events = await _stream(graph)
 
         types = _types(events)
         assert EventType.RUN_STARTED in types
@@ -2885,29 +2327,17 @@ def describe_changed_reducers_none_fallback():
         """When changed_reducers is None, first frame emits both snapshots."""
         from langgraph_events.stream import StreamFrame
 
-        @on(UserAsked)
-        def reply(event: UserAsked) -> AgentReplied:
-            return AgentReplied(message=AIMessage(content="ok"))
-
-        graph = EventGraph([reply], reducers=[message_reducer()])
-
-        async def fake_astream_events(
-            seed,
-            *,
-            include_reducers,
-            include_llm_tokens,
-            include_custom_events,
-            config,
-        ):
-            del seed, include_reducers, include_llm_tokens
-            del include_custom_events, config
-            # Simulate v1 path: changed_reducers=None
-            yield StreamFrame(
+        graph = _graph(reply)
+        # Simulate v1 path: changed_reducers=None
+        _patch_astream(
+            monkeypatch,
+            graph,
+            StreamFrame(
                 event=UserAsked(question="go"),
                 reducers={"messages": [HumanMessage(content="go")]},
                 changed_reducers=None,
-            )
-            yield StreamFrame(
+            ),
+            StreamFrame(
                 event=AgentReplied(message=AIMessage(content="ok")),
                 reducers={
                     "messages": [
@@ -2916,18 +2346,13 @@ def describe_changed_reducers_none_fallback():
                     ]
                 },
                 changed_reducers=None,
-            )
-
-        monkeypatch.setattr(graph, "astream_events", fake_astream_events)
-
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="go"),
+            ),
         )
-        events = await _collect(adapter, _make_input())
 
-        state_snapshots = [e for e in events if e.type == EventType.STATE_SNAPSHOT]
-        msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+        events = await _stream(graph)
+
+        state_snapshots = _of_type(events, EventType.STATE_SNAPSHOT)
+        msg_snapshots = _of_type(events, EventType.MESSAGES_SNAPSHOT)
 
         # First frame emits state snapshot; second does not (since
         # changed_reducers=None falls through to "already emitted" check)
@@ -2942,23 +2367,9 @@ def describe_system_message_conversion():
     """SystemMessage in message_reducer is converted to AG-UI SystemMessage."""
 
     async def it_includes_system_message_in_snapshot():
-        @on(UserAsked)
-        def set_system(event: UserAsked) -> SystemPromptDelivered:
-            return SystemPromptDelivered(
-                message=SystemMessage(content="You are a helpful assistant")
-            )
+        events = await _emit(SystemMessage(content="You are a helpful assistant"))
 
-        graph = EventGraph([set_system], reducers=[message_reducer()])
-        adapter = AGUIAdapter(
-            graph=graph,
-            seed_factory=lambda inp: UserAsked(question="go"),
-        )
-        events = await _collect(adapter, _make_input())
-
-        msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
-        assert len(msg_snapshots) >= 1
-        last_snap = msg_snapshots[-1]
-        sys_msgs = [m for m in last_snap.messages if m.role == "system"]
+        sys_msgs = _roled(events, "system")
         assert len(sys_msgs) >= 1
         assert sys_msgs[0].content == "You are a helpful assistant"
 
@@ -2968,304 +2379,156 @@ def describe_agui_message_extras():
 
     def when_the_reserved_key_carries_a_mapping():
         async def it_forwards_each_entry_as_an_agui_message_field():
-            @on(UserAsked)
-            def notify(event: UserAsked) -> SystemPromptDelivered:
-                return SystemPromptDelivered(
-                    message=SystemMessage(
-                        content="the step failed",
-                        additional_kwargs={
-                            "langgraph_events.agui": {"failure": {"retryable": True}}
-                        },
-                    )
+            events = await _emit(
+                SystemMessage(
+                    content="the step failed",
+                    additional_kwargs={
+                        "langgraph_events.agui": {"failure": {"retryable": True}}
+                    },
                 )
-
-            graph = EventGraph([notify], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
             )
-            events = await _collect(adapter, _make_input())
 
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+            [sys_msg] = _roled(events, "system")
             assert sys_msg.model_dump()["failure"] == {"retryable": True}
 
         async def it_forwards_on_a_tool_message():
-            @on(UserAsked)
-            def run_tool(event: UserAsked) -> ToolsExecuted:
-                return ToolsExecuted(
-                    messages=(
-                        ToolMessage(
-                            content="42",
-                            tool_call_id="tc-1",
-                            additional_kwargs={
-                                "langgraph_events.agui": {"latency_ms": 12}
-                            },
-                        ),
-                    )
+            events = await _emit(
+                ToolMessage(
+                    content="42",
+                    tool_call_id="tc-1",
+                    additional_kwargs={"langgraph_events.agui": {"latency_ms": 12}},
                 )
-
-            graph = EventGraph([run_tool], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
             )
-            events = await _collect(adapter, _make_input())
 
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+            [tool_msg] = _roled(events, "tool")
             assert tool_msg.model_dump()["latency_ms"] == 12
 
         async def it_forwards_on_a_user_message():
-            @on(UserAsked)
-            def echo(event: UserAsked) -> UserSent:
-                return UserSent(
-                    message=HumanMessage(
-                        content="hello",
-                        additional_kwargs={
-                            "langgraph_events.agui": {"source": "voice"}
-                        },
-                    )
+            events = await _emit(
+                HumanMessage(
+                    content="hello",
+                    additional_kwargs={"langgraph_events.agui": {"source": "voice"}},
                 )
-
-            graph = EventGraph([echo], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
             )
-            events = await _collect(adapter, _make_input())
 
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [user_msg] = [m for m in snap.messages if m.role == "user"]
+            [user_msg] = _roled(events, "user")
             assert user_msg.model_dump()["source"] == "voice"
 
         async def it_forwards_on_an_assistant_message():
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(
-                    message=AIMessage(
-                        content="hi",
-                        additional_kwargs={
-                            "langgraph_events.agui": {"confidence": 0.9}
-                        },
-                    )
+            events = await _emit(
+                AIMessage(
+                    content="hi",
+                    additional_kwargs={"langgraph_events.agui": {"confidence": 0.9}},
                 )
-
-            graph = EventGraph([reply], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
             )
-            events = await _collect(adapter, _make_input())
 
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [ai_msg] = [m for m in snap.messages if m.role == "assistant"]
+            [ai_msg] = _roled(events, "assistant")
             assert ai_msg.model_dump()["confidence"] == 0.9
 
     def when_the_reserved_key_is_absent():
         async def it_adds_no_fields():
-            @on(UserAsked)
-            def notify(event: UserAsked) -> SystemPromptDelivered:
-                return SystemPromptDelivered(
-                    message=SystemMessage(
-                        content="plain",
-                        additional_kwargs={"internal_trace_id": "t-1"},
-                    )
+            events = await _emit(
+                SystemMessage(
+                    content="plain",
+                    additional_kwargs={"internal_trace_id": "t-1"},
                 )
-
-            graph = EventGraph([notify], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
             )
-            events = await _collect(adapter, _make_input())
 
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+            [sys_msg] = _roled(events, "system")
             assert sys_msg.model_extra == {}
 
     def when_an_entry_names_a_declared_agui_field():
         """The declared field wins — the entry would rewrite protocol data."""
 
-        async def it_drops_the_entry_and_keeps_the_rest():
-            @on(UserAsked)
-            def notify(event: UserAsked) -> SystemPromptDelivered:
-                return SystemPromptDelivered(
-                    message=SystemMessage(
-                        content="plain",
-                        additional_kwargs={
-                            "langgraph_events.agui": {
-                                "content": "hijacked",
-                                "failure": "kept",
-                            }
-                        },
-                    )
-                )
-
-            graph = EventGraph([notify], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
+        def _hijacking_message() -> SystemMessage:
+            return SystemMessage(
+                content="plain",
+                additional_kwargs={"langgraph_events.agui": {"content": "hijacked"}},
             )
-            events = await _collect(adapter, _make_input())
 
-            assert not [e for e in events if e.type == EventType.RUN_ERROR]
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+        async def it_drops_the_entry_and_keeps_the_rest():
+            events = await _emit(
+                SystemMessage(
+                    content="plain",
+                    additional_kwargs={
+                        "langgraph_events.agui": {
+                            "content": "hijacked",
+                            "failure": "kept",
+                        }
+                    },
+                )
+            )
+
+            assert not _of_type(events, EventType.RUN_ERROR)
+            [sys_msg] = _roled(events, "system")
             assert sys_msg.content == "plain"
             assert sys_msg.model_extra == {"failure": "kept"}
 
         async def it_warns_naming_the_key():
-            @on(UserAsked)
-            def notify(event: UserAsked) -> SystemPromptDelivered:
-                return SystemPromptDelivered(
-                    message=SystemMessage(
-                        content="plain",
-                        additional_kwargs={
-                            "langgraph_events.agui": {"content": "hijacked"}
-                        },
-                    )
-                )
-
-            graph = EventGraph([notify], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
             _warned_extras.clear()
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                await _collect(adapter, _make_input())
+            caught = await _stream_warnings(_graph(_emitting(_hijacking_message())))
 
-            assert [x for x in w if "declares content" in str(x.message)]
+            assert [x for x in caught if "declares content" in str(x.message)]
 
         async def it_warns_once_for_the_repeated_drop():
-            @on(UserAsked)
-            def notify(event: UserAsked) -> SystemPromptDelivered:
-                return SystemPromptDelivered(
-                    message=SystemMessage(
-                        content="plain",
-                        additional_kwargs={
-                            "langgraph_events.agui": {"content": "hijacked"}
-                        },
-                    )
-                )
-
-            graph = EventGraph([notify], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
             _warned_extras.clear()
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                await _collect(adapter, _make_input())
-                await _collect(adapter, _make_input())
+            caught = await _stream_warnings(
+                _graph(_emitting(_hijacking_message())), runs=2
+            )
 
-            assert len([x for x in w if "declares content" in str(x.message)]) == 1
+            assert len([x for x in caught if "declares content" in str(x.message)]) == 1
 
         async def it_rejects_a_camel_case_alias_of_a_declared_field():
-            @on(UserAsked)
-            def run_tool(event: UserAsked) -> ToolsExecuted:
-                return ToolsExecuted(
-                    messages=(
-                        ToolMessage(
-                            content="42",
-                            tool_call_id="tc-1",
-                            additional_kwargs={
-                                "langgraph_events.agui": {"toolCallId": "spoofed"}
-                            },
-                        ),
-                    )
+            events = await _emit(
+                ToolMessage(
+                    content="42",
+                    tool_call_id="tc-1",
+                    additional_kwargs={
+                        "langgraph_events.agui": {"toolCallId": "spoofed"}
+                    },
                 )
-
-            graph = EventGraph([run_tool], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
             )
-            events = await _collect(adapter, _make_input())
 
-            assert not [e for e in events if e.type == EventType.RUN_ERROR]
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+            assert not _of_type(events, EventType.RUN_ERROR)
+            [tool_msg] = _roled(events, "tool")
             assert tool_msg.tool_call_id == "tc-1"
             assert tool_msg.model_extra == {}
 
     def when_an_entry_key_is_not_a_string():
         async def it_drops_the_entry_and_keeps_the_rest():
-            @on(UserAsked)
-            def notify(event: UserAsked) -> SystemPromptDelivered:
-                return SystemPromptDelivered(
-                    message=SystemMessage(
-                        content="plain",
-                        additional_kwargs={
-                            "langgraph_events.agui": {7: "numeric", "failure": "kept"}
-                        },
-                    )
+            events = await _emit(
+                SystemMessage(
+                    content="plain",
+                    additional_kwargs={
+                        "langgraph_events.agui": {7: "numeric", "failure": "kept"}
+                    },
                 )
-
-            graph = EventGraph([notify], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
             )
-            events = await _collect(adapter, _make_input())
 
-            assert not [e for e in events if e.type == EventType.RUN_ERROR]
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+            assert not _of_type(events, EventType.RUN_ERROR)
+            [sys_msg] = _roled(events, "system")
             assert sys_msg.model_extra == {"failure": "kept"}
 
     def when_the_reserved_key_is_not_a_mapping():
-        async def it_drops_the_value():
-            @on(UserAsked)
-            def notify(event: UserAsked) -> SystemPromptDelivered:
-                return SystemPromptDelivered(
-                    message=SystemMessage(
-                        content="plain",
-                        additional_kwargs={
-                            "langgraph_events.agui": ["not", "a", "mapping"]
-                        },
-                    )
-                )
-
-            graph = EventGraph([notify], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
+        def _list_valued_message() -> SystemMessage:
+            return SystemMessage(
+                content="plain",
+                additional_kwargs={"langgraph_events.agui": ["not", "a", "mapping"]},
             )
-            events = await _collect(adapter, _make_input())
 
-            assert not [e for e in events if e.type == EventType.RUN_ERROR]
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+        async def it_drops_the_value():
+            events = await _emit(_list_valued_message())
+
+            assert not _of_type(events, EventType.RUN_ERROR)
+            [sys_msg] = _roled(events, "system")
             assert sys_msg.content == "plain"
             assert sys_msg.model_extra == {}
 
         async def it_warns_naming_the_type_it_got():
-            @on(UserAsked)
-            def notify(event: UserAsked) -> SystemPromptDelivered:
-                return SystemPromptDelivered(
-                    message=SystemMessage(
-                        content="plain",
-                        additional_kwargs={
-                            "langgraph_events.agui": ["not", "a", "mapping"]
-                        },
-                    )
-                )
-
-            graph = EventGraph([notify], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
             _warned_extras.clear()
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                await _collect(adapter, _make_input())
+            caught = await _stream_warnings(_graph(_emitting(_list_valued_message())))
 
-            assert [x for x in w if "list" in str(x.message)]
+            assert [x for x in caught if "list" in str(x.message)]
 
     def when_a_bad_reserved_key_is_already_in_the_checkpoint():
         """`build_messages_snapshot` runs on every `connect()`.
@@ -3276,38 +2539,20 @@ def describe_agui_message_extras():
         """
 
         async def it_still_serves_the_connect_snapshot():
-            @on(UserAsked)
-            def notify(event: UserAsked) -> SystemPromptDelivered:
-                return SystemPromptDelivered(
-                    message=SystemMessage(
-                        content="plain",
-                        additional_kwargs={
-                            "langgraph_events.agui": ["not", "a", "mapping"]
-                        },
-                    )
-                )
-
-            graph = EventGraph(
-                [notify],
-                checkpointer=MemorySaver(),
-                reducers=[message_reducer()],
+            poisoned = SystemMessage(
+                content="plain",
+                additional_kwargs={"langgraph_events.agui": ["not", "a", "mapping"]},
             )
+            graph = _graph(_emitting(poisoned), checkpointer=MemorySaver())
             await graph.ainvoke(
                 UserAsked(question="go"),
-                config={"configurable": {"thread_id": "t-poisoned"}},
+                config=_config("t-poisoned"),
             )
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="unused"),
+            events = await _connect(
+                graph, _make_input(thread_id="t-poisoned"), seed_factory=_ask("unused")
             )
 
-            events = [
-                event
-                async for event in adapter.connect(_make_input(thread_id="t-poisoned"))
-            ]
-
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+            [sys_msg] = _roled(events, "system")
             assert sys_msg.content == "plain"
             assert sys_msg.model_extra == {}
 
@@ -3317,7 +2562,6 @@ def describe_agui_message_extras_round_trip():
 
     def when_an_inbound_message_carries_extra_fields():
         async def it_returns_them_to_the_client_unchanged():
-            from ag_ui.core import ToolMessage as AguiToolMessage
 
             carried: list[Any] = []
 
@@ -3329,10 +2573,9 @@ def describe_agui_message_extras_round_trip():
             def replay(event: UserAsked) -> ToolsExecuted:
                 return ToolsExecuted(messages=tuple(carried))
 
-            graph = EventGraph([replay], reducers=[message_reducer()])
-            adapter = AGUIAdapter(graph=graph, seed_factory=seed)
-            events = await _collect(
-                adapter,
+            graph = _graph(replay)
+            events = await _stream(
+                graph,
                 _make_input(
                     messages=[
                         AguiToolMessage(
@@ -3344,10 +2587,10 @@ def describe_agui_message_extras_round_trip():
                         )
                     ]
                 ),
+                seed_factory=seed,
             )
 
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+            [tool_msg] = _roled(events, "tool")
             assert tool_msg.model_dump()["latency_ms"] == 12
 
 
@@ -3356,70 +2599,29 @@ def describe_message_name_forwarding():
 
     def when_the_langchain_message_has_a_name():
         async def it_forwards_the_name_on_an_assistant_message():
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="hi", name="planner"))
+            events = await _emit(AIMessage(content="hi", name="planner"))
 
-            graph = EventGraph([reply], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            events = await _collect(adapter, _make_input())
-
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [ai_msg] = [m for m in snap.messages if m.role == "assistant"]
+            [ai_msg] = _roled(events, "assistant")
             assert ai_msg.name == "planner"
 
         async def it_forwards_the_name_on_a_user_message():
-            @on(UserAsked)
-            def echo(event: UserAsked) -> UserSent:
-                return UserSent(message=HumanMessage(content="hi", name="alice"))
+            events = await _emit(HumanMessage(content="hi", name="alice"))
 
-            graph = EventGraph([echo], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            events = await _collect(adapter, _make_input())
-
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [user_msg] = [m for m in snap.messages if m.role == "user"]
+            [user_msg] = _roled(events, "user")
             assert user_msg.name == "alice"
 
         async def it_forwards_the_name_on_a_system_message():
-            @on(UserAsked)
-            def notify(event: UserAsked) -> SystemPromptDelivered:
-                return SystemPromptDelivered(
-                    message=SystemMessage(content="rules", name="policy")
-                )
+            events = await _emit(SystemMessage(content="rules", name="policy"))
 
-            graph = EventGraph([notify], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            events = await _collect(adapter, _make_input())
-
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [sys_msg] = [m for m in snap.messages if m.role == "system"]
+            [sys_msg] = _roled(events, "system")
             assert sys_msg.name == "policy"
 
     def when_the_langchain_message_has_no_name():
         async def it_leaves_the_name_unset():
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="hi"))
+            graph = _graph(reply_hi)
+            events = await _stream(graph)
 
-            graph = EventGraph([reply], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            events = await _collect(adapter, _make_input())
-
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [ai_msg] = [m for m in snap.messages if m.role == "assistant"]
+            [ai_msg] = _roled(events, "assistant")
             assert ai_msg.name is None
 
 
@@ -3428,124 +2630,64 @@ def describe_tool_message_status_conversion():
 
     def when_the_status_is_error():
         async def it_sets_the_agui_error_field():
-            @on(UserAsked)
-            def run_tool(event: UserAsked) -> ToolsExecuted:
-                return ToolsExecuted(
-                    messages=(
-                        ToolMessage(
-                            content="boom",
-                            tool_call_id="tc-1",
-                            status="error",
-                        ),
-                    )
+            events = await _emit(
+                ToolMessage(
+                    content="boom",
+                    tool_call_id="tc-1",
+                    status="error",
                 )
-
-            graph = EventGraph([run_tool], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
             )
-            events = await _collect(adapter, _make_input())
 
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+            [tool_msg] = _roled(events, "tool")
             assert tool_msg.error == "boom"
             assert tool_msg.content == "boom"
 
         def when_the_content_is_empty():
             async def it_still_sets_a_truthy_error():
-                @on(UserAsked)
-                def run_tool(event: UserAsked) -> ToolsExecuted:
-                    return ToolsExecuted(
-                        messages=(
-                            ToolMessage(
-                                content="",
-                                tool_call_id="tc-1",
-                                status="error",
-                            ),
-                        )
+                events = await _emit(
+                    ToolMessage(
+                        content="",
+                        tool_call_id="tc-1",
+                        status="error",
                     )
-
-                graph = EventGraph([run_tool], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
                 )
-                events = await _collect(adapter, _make_input())
 
-                snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-                [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+                [tool_msg] = _roled(events, "tool")
                 assert tool_msg.error == "error"
                 assert tool_msg.content == ""
 
         def when_the_content_is_a_block_list():
             async def it_still_sets_a_truthy_error():
-                @on(UserAsked)
-                def run_tool(event: UserAsked) -> ToolsExecuted:
-                    return ToolsExecuted(
-                        messages=(
-                            ToolMessage(
-                                content=[{"type": "text", "text": "boom"}],
-                                tool_call_id="tc-1",
-                                status="error",
-                            ),
-                        )
+                events = await _emit(
+                    ToolMessage(
+                        content=[{"type": "text", "text": "boom"}],
+                        tool_call_id="tc-1",
+                        status="error",
                     )
-
-                graph = EventGraph([run_tool], reducers=[message_reducer()])
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
                 )
-                events = await _collect(adapter, _make_input())
 
-                snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-                [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+                [tool_msg] = _roled(events, "tool")
                 assert tool_msg.error == "error"
                 assert tool_msg.content == ""
 
     def when_the_status_is_success():
         async def it_leaves_the_agui_error_field_unset():
-            @on(UserAsked)
-            def run_tool(event: UserAsked) -> ToolsExecuted:
-                return ToolsExecuted(
-                    messages=(ToolMessage(content="42", tool_call_id="tc-1"),)
-                )
+            events = await _emit(ToolMessage(content="42", tool_call_id="tc-1"))
 
-            graph = EventGraph([run_tool], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            events = await _collect(adapter, _make_input())
-
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+            [tool_msg] = _roled(events, "tool")
             assert tool_msg.error is None
 
     def when_the_content_is_a_block_list():
         async def it_still_builds_the_snapshot():
-            @on(UserAsked)
-            def run_tool(event: UserAsked) -> ToolsExecuted:
-                return ToolsExecuted(
-                    messages=(
-                        ToolMessage(
-                            content=[{"type": "text", "text": "42"}],
-                            tool_call_id="tc-1",
-                        ),
-                    )
+            events = await _emit(
+                ToolMessage(
+                    content=[{"type": "text", "text": "42"}],
+                    tool_call_id="tc-1",
                 )
-
-            graph = EventGraph([run_tool], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
             )
-            events = await _collect(adapter, _make_input())
 
-            assert not [e for e in events if e.type == EventType.RUN_ERROR]
-            snap = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT][-1]
-            [tool_msg] = [m for m in snap.messages if m.role == "tool"]
+            assert not _of_type(events, EventType.RUN_ERROR)
+            [tool_msg] = _roled(events, "tool")
             assert tool_msg.content == ""
 
         async def it_logs_a_warning_naming_the_tool_call(caplog):
@@ -3560,11 +2702,8 @@ def describe_tool_message_status_conversion():
                     )
                 )
 
-            graph = EventGraph([run_tool], reducers=[message_reducer()])
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
+            graph = _graph(run_tool)
+            adapter = _adapter(graph)
             await _collect(adapter, _make_input())
 
             assert any("tc-dropped" in r.message for r in caplog.records)
@@ -3592,18 +2731,11 @@ def describe_multiple_custom_reducers():
             def handle_a(event: StepA) -> StepB:
                 return StepB(value="from_a")
 
-            graph = EventGraph(
-                [handle_a],
-                reducers=[message_reducer(), reducer_a, reducer_b],
-            )
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: StepA(value="first"),
-            )
-            events = await _collect(adapter, _make_input())
+            graph = _graph(handle_a, reducers=[message_reducer(), reducer_a, reducer_b])
+            events = await _stream(graph, seed_factory=lambda inp: StepA(value="first"))
 
-            state_snapshots = [e for e in events if e.type == EventType.STATE_SNAPSHOT]
-            msg_snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+            state_snapshots = _of_type(events, EventType.STATE_SNAPSHOT)
+            msg_snapshots = _of_type(events, EventType.MESSAGES_SNAPSHOT)
 
             # StateSnapshot should appear: initial + when custom reducers change
             assert len(state_snapshots) >= 2
@@ -3648,51 +2780,26 @@ def describe_tool_call_streaming():
 
     def when_single_tool_call():
         async def it_emits_start_args_end_in_order(monkeypatch):
-            @on(UserAsked)
-            def ask(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
+            graph = _graph(reply)
 
-            graph = EventGraph([ask], reducers=[message_reducer()])
-
-            async def fake_astream(*args, **kwargs):
-                del args, kwargs
-                yield _tool_call_chunk_event(
+            _patch_compiled_astream(
+                monkeypatch,
+                graph,
+                _tool_call_chunk_event(
                     "run-a",
                     {"name": "search", "args": "", "id": "tc-1", "index": 0},
-                )
-                yield _tool_call_chunk_event(
+                ),
+                _tool_call_chunk_event(
                     "run-a",
                     {"name": "", "args": '{"q":"hi"}', "id": "", "index": 0},
-                )
-                yield {
-                    "event": "on_chat_model_end",
-                    "run_id": "run-a",
-                    "data": {"output": AIMessage(id="msg-x", content="ok")},
-                }
-
-            monkeypatch.setattr(graph.compiled, "astream_events", fake_astream)
-
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="q"),
+                ),
+                _chat_model_end("run-a", AIMessage(id="msg-x", content="ok")),
             )
-            events = await _collect(adapter, _make_input())
 
-            tc_types = [
-                e.type
-                for e in events
-                if e.type
-                in (
-                    EventType.TOOL_CALL_START,
-                    EventType.TOOL_CALL_ARGS,
-                    EventType.TOOL_CALL_END,
-                )
-            ]
-            assert tc_types == [
-                EventType.TOOL_CALL_START,
-                EventType.TOOL_CALL_ARGS,
-                EventType.TOOL_CALL_END,
-            ]
+            events = await _stream(graph, seed_factory=_ask("q"))
+
+            tc_types = _tool_call_types(events)
+            assert tc_types == _TOOL_CALL_TRIPLE
             start = next(e for e in events if e.type == EventType.TOOL_CALL_START)
             args_ev = next(e for e in events if e.type == EventType.TOOL_CALL_ARGS)
             end = next(e for e in events if e.type == EventType.TOOL_CALL_END)
@@ -3704,73 +2811,49 @@ def describe_tool_call_streaming():
 
     def when_parallel_tool_calls():
         async def it_gives_each_index_its_own_triple(monkeypatch):
-            @on(UserAsked)
-            def ask(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
+            graph = _graph(reply)
 
-            graph = EventGraph([ask], reducers=[message_reducer()])
-
-            async def fake_astream(*args, **kwargs):
-                del args, kwargs
-                yield _tool_call_chunk_event(
+            _patch_compiled_astream(
+                monkeypatch,
+                graph,
+                _tool_call_chunk_event(
                     "run-p",
                     {"name": "search", "args": "", "id": "tc-1", "index": 0},
                     {"name": "lookup", "args": "", "id": "tc-2", "index": 1},
-                )
-                yield _tool_call_chunk_event(
+                ),
+                _tool_call_chunk_event(
                     "run-p",
                     {"name": "", "args": '{"q":"a"}', "id": "", "index": 0},
                     {"name": "", "args": '{"k":"b"}', "id": "", "index": 1},
-                )
-                yield {
-                    "event": "on_chat_model_end",
-                    "run_id": "run-p",
-                    "data": {"output": AIMessage(id="msg-y", content="ok")},
-                }
-
-            monkeypatch.setattr(graph.compiled, "astream_events", fake_astream)
-
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="q"),
+                ),
+                _chat_model_end("run-p", AIMessage(id="msg-y", content="ok")),
             )
-            events = await _collect(adapter, _make_input())
 
-            starts = [e for e in events if e.type == EventType.TOOL_CALL_START]
-            args_evs = [e for e in events if e.type == EventType.TOOL_CALL_ARGS]
-            ends = [e for e in events if e.type == EventType.TOOL_CALL_END]
+            events = await _stream(graph, seed_factory=_ask("q"))
+
+            starts = _of_type(events, EventType.TOOL_CALL_START)
+            args_evs = _of_type(events, EventType.TOOL_CALL_ARGS)
+            ends = _of_type(events, EventType.TOOL_CALL_END)
             assert {s.tool_call_id for s in starts} == {"tc-1", "tc-2"}
             assert len(args_evs) == 2
             assert {e.tool_call_id for e in ends} == {"tc-1", "tc-2"}
 
     def when_chunk_carries_text_and_tool_call():
         async def it_emits_text_message_and_uses_its_id_as_parent(monkeypatch):
-            @on(UserAsked)
-            def ask(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
+            graph = _graph(reply)
 
-            graph = EventGraph([ask], reducers=[message_reducer()])
-
-            async def fake_astream(*args, **kwargs):
-                del args, kwargs
-                yield _tool_call_chunk_event(
+            _patch_compiled_astream(
+                monkeypatch,
+                graph,
+                _tool_call_chunk_event(
                     "run-m",
                     {"name": "search", "args": "", "id": "tc-9", "index": 0},
                     content="thinking…",
-                )
-                yield {
-                    "event": "on_chat_model_end",
-                    "run_id": "run-m",
-                    "data": {"output": AIMessage(id="msg-z", content="thinking…")},
-                }
-
-            monkeypatch.setattr(graph.compiled, "astream_events", fake_astream)
-
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="q"),
+                ),
+                _chat_model_end("run-m", AIMessage(id="msg-z", content="thinking…")),
             )
-            events = await _collect(adapter, _make_input())
+
+            events = await _stream(graph, seed_factory=_ask("q"))
 
             text_start = next(
                 e for e in events if e.type == EventType.TEXT_MESSAGE_START
@@ -3780,57 +2863,37 @@ def describe_tool_call_streaming():
 
     def when_no_text_message_in_stream():
         async def it_emits_none_parent_message_id(monkeypatch):
-            @on(UserAsked)
-            def ask(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
+            graph = _graph(reply)
 
-            graph = EventGraph([ask], reducers=[message_reducer()])
-
-            async def fake_astream(*args, **kwargs):
-                del args, kwargs
-                yield _tool_call_chunk_event(
+            _patch_compiled_astream(
+                monkeypatch,
+                graph,
+                _tool_call_chunk_event(
                     "run-n",
                     {"name": "search", "args": "", "id": "tc-n", "index": 0},
-                )
-                yield {
-                    "event": "on_chat_model_end",
-                    "run_id": "run-n",
-                    "data": {"output": AIMessage(id="msg-n", content="")},
-                }
-
-            monkeypatch.setattr(graph.compiled, "astream_events", fake_astream)
-
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="q"),
+                ),
+                _chat_model_end("run-n", AIMessage(id="msg-n", content="")),
             )
-            events = await _collect(adapter, _make_input())
+
+            events = await _stream(graph, seed_factory=_ask("q"))
 
             tc_start = next(e for e in events if e.type == EventType.TOOL_CALL_START)
             assert tc_start.parent_message_id is None
 
     def when_first_chunk_has_no_id():
         async def it_emits_run_error(monkeypatch):
-            @on(UserAsked)
-            def ask(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
+            graph = _graph(reply)
 
-            graph = EventGraph([ask], reducers=[message_reducer()])
-
-            async def fake_astream(*args, **kwargs):
-                del args, kwargs
-                yield _tool_call_chunk_event(
+            _patch_compiled_astream(
+                monkeypatch,
+                graph,
+                _tool_call_chunk_event(
                     "run-no-id",
                     {"name": "search", "args": "", "id": "", "index": 0},
-                )
-
-            monkeypatch.setattr(graph.compiled, "astream_events", fake_astream)
-
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="q"),
+                ),
             )
-            events = await _collect(adapter, _make_input())
+
+            events = await _stream(graph, seed_factory=_ask("q"))
 
             run_err = next((e for e in events if e.type == EventType.RUN_ERROR), None)
             assert run_err is not None
@@ -3840,26 +2903,18 @@ def describe_tool_call_streaming():
 
     def when_first_chunk_has_no_name():
         async def it_emits_run_error(monkeypatch):
-            @on(UserAsked)
-            def ask(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
+            graph = _graph(reply)
 
-            graph = EventGraph([ask], reducers=[message_reducer()])
-
-            async def fake_astream(*args, **kwargs):
-                del args, kwargs
-                yield _tool_call_chunk_event(
+            _patch_compiled_astream(
+                monkeypatch,
+                graph,
+                _tool_call_chunk_event(
                     "run-no-name",
                     {"name": "", "args": "", "id": "tc-x", "index": 0},
-                )
-
-            monkeypatch.setattr(graph.compiled, "astream_events", fake_astream)
-
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="q"),
+                ),
             )
-            events = await _collect(adapter, _make_input())
+
+            events = await _stream(graph, seed_factory=_ask("q"))
 
             run_err = next((e for e in events if e.type == EventType.RUN_ERROR), None)
             assert run_err is not None
@@ -3868,11 +2923,7 @@ def describe_tool_call_streaming():
 
     def when_stream_errors_mid_call():
         async def it_drains_tool_call_end_before_run_error(monkeypatch):
-            @on(UserAsked)
-            def ask(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph([ask], reducers=[message_reducer()])
+            graph = _graph(reply)
 
             async def fake_astream(*args, **kwargs):
                 del args, kwargs
@@ -3884,11 +2935,7 @@ def describe_tool_call_streaming():
 
             monkeypatch.setattr(graph.compiled, "astream_events", fake_astream)
 
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="q"),
-            )
-            events = await _collect(adapter, _make_input())
+            events = await _stream(graph, seed_factory=_ask("q"))
 
             tc_end = next(
                 (e for e in events if e.type == EventType.TOOL_CALL_END), None
@@ -3934,32 +2981,15 @@ def describe_FrontendToolCallRequested_mapping():
                     tool_call_id="tc-c1",
                 )
 
-            graph = EventGraph(
-                [request],
-                reducers=[message_reducer()],
-                checkpointer=MemorySaver(),
-            )
-            adapter = AGUIAdapter(
-                graph=graph,
+            graph = _graph(request, checkpointer=MemorySaver())
+            events = await _stream(
+                graph,
+                _make_input(thread_id="t-fe-1"),
                 seed_factory=lambda inp: AskConfirm(prompt="Ship?"),
             )
-            events = await _collect(adapter, _make_input(thread_id="t-fe-1"))
 
-            triple = [
-                e.type
-                for e in events
-                if e.type
-                in (
-                    EventType.TOOL_CALL_START,
-                    EventType.TOOL_CALL_ARGS,
-                    EventType.TOOL_CALL_END,
-                )
-            ]
-            assert triple == [
-                EventType.TOOL_CALL_START,
-                EventType.TOOL_CALL_ARGS,
-                EventType.TOOL_CALL_END,
-            ]
+            triple = _tool_call_types(events)
+            assert triple == _TOOL_CALL_TRIPLE
 
             start = next(e for e in events if e.type == EventType.TOOL_CALL_START)
             args_ev = next(e for e in events if e.type == EventType.TOOL_CALL_ARGS)
@@ -3977,22 +3007,17 @@ def describe_FrontendToolCallRequested_mapping():
             def request(event: AskConfirm) -> FrontendToolCallRequested:
                 return FrontendToolCallRequested(name="ping", tool_call_id="tc-ping")
 
-            graph = EventGraph(
-                [request],
-                reducers=[message_reducer()],
-                checkpointer=MemorySaver(),
-            )
-            adapter = AGUIAdapter(
-                graph=graph,
+            graph = _graph(request, checkpointer=MemorySaver())
+            events = await _stream(
+                graph,
+                _make_input(thread_id="t-fe-2"),
                 seed_factory=lambda inp: AskConfirm(prompt=""),
             )
-            events = await _collect(adapter, _make_input(thread_id="t-fe-2"))
             args_ev = next(e for e in events if e.type == EventType.TOOL_CALL_ARGS)
             assert args_ev.delta == "{}"
 
     def when_tool_result_received():
         async def it_continues_graph_after_resume():
-            from ag_ui.core import ToolMessage as AguiToolMessage
 
             @on(AskShip)
             def request(event: AskShip) -> FrontendToolCallRequested:
@@ -4009,39 +3034,21 @@ def describe_FrontendToolCallRequested_mapping():
                     approved = bool(json.loads(m.content or "{}").get("approved"))
                 return Shipped(release="v1", approved=approved)
 
-            graph = EventGraph(
-                [request, ship],
-                reducers=[message_reducer()],
-                checkpointer=MemorySaver(),
-            )
+            graph = _graph(request, ship, checkpointer=MemorySaver())
 
             def resume_factory(input_data, checkpoint_state=None):
                 results = detect_new_tool_results(input_data, checkpoint_state)
                 return ToolsExecuted(messages=tuple(results)) if results else None
 
-            adapter = AGUIAdapter(
-                graph=graph,
+            adapter = _adapter(
+                graph,
                 seed_factory=lambda inp: AskShip(release="v1"),
                 resume_factory=resume_factory,
             )
 
             # Step 1 — initial run pauses on FrontendToolCallRequested
             first = await _collect(adapter, _make_input(thread_id="t-roundtrip"))
-            triple = [
-                e.type
-                for e in first
-                if e.type
-                in (
-                    EventType.TOOL_CALL_START,
-                    EventType.TOOL_CALL_ARGS,
-                    EventType.TOOL_CALL_END,
-                )
-            ]
-            assert triple == [
-                EventType.TOOL_CALL_START,
-                EventType.TOOL_CALL_ARGS,
-                EventType.TOOL_CALL_END,
-            ]
+            assert _tool_call_types(first) == _TOOL_CALL_TRIPLE
             # ship handler has not run yet
             assert not any(
                 e.type == EventType.CUSTOM and e.name == "Shipped" for e in first
@@ -4061,9 +3068,7 @@ def describe_FrontendToolCallRequested_mapping():
             )
             second = await _collect(adapter, second_input)
 
-            shipped = [
-                e for e in second if e.type == EventType.CUSTOM and e.name == "Shipped"
-            ]
+            shipped = _custom(second, "Shipped")
             assert len(shipped) == 1
             assert shipped[0].value == {"release": "v1", "approved": True}
             assert second[-1].type == EventType.RUN_FINISHED
@@ -4080,16 +3085,12 @@ def describe_FrontendToolCallRequested_mapping():
                     tool_call_id="tc-bad-args",
                 )
 
-            graph = EventGraph(
-                [request],
-                reducers=[message_reducer()],
-                checkpointer=MemorySaver(),
-            )
-            adapter = AGUIAdapter(
-                graph=graph,
+            graph = _graph(request, checkpointer=MemorySaver())
+            events = await _stream(
+                graph,
+                _make_input(thread_id="t-fe-bad-args"),
                 seed_factory=lambda inp: AskConfirm(prompt="x"),
             )
-            events = await _collect(adapter, _make_input(thread_id="t-fe-bad-args"))
 
             run_err = next((e for e in events if e.type == EventType.RUN_ERROR), None)
             assert run_err is not None
@@ -4152,59 +3153,23 @@ def describe_detect_new_tool_results():
 
     def when_fresh_run():
         def it_returns_empty():
-            from ag_ui.core import ToolMessage as AguiToolMessage
-
-            inp = _make_input(
-                messages=[
-                    AguiToolMessage(
-                        id="m-1",
-                        role="tool",
-                        content="42",
-                        tool_call_id="tc-1",
-                    ),
-                ],
-            )
-            assert detect_new_tool_results(inp, None) == []
+            assert detect_new_tool_results(_tool_input(), None) == []
 
     def when_all_tool_ids_known():
         def it_returns_empty():
-            from ag_ui.core import ToolMessage as AguiToolMessage
-
-            inp = _make_input(
-                messages=[
-                    AguiToolMessage(
-                        id="m-1",
-                        role="tool",
-                        content="42",
-                        tool_call_id="tc-1",
-                    ),
-                ],
-            )
             checkpoint = {
                 "messages": [
                     ToolMessage(content="42", tool_call_id="tc-1"),
                 ],
             }
-            assert detect_new_tool_results(inp, checkpoint) == []
+            assert detect_new_tool_results(_tool_input(), checkpoint) == []
 
     def when_some_new():
         def it_returns_only_unknown_ids():
-            from ag_ui.core import ToolMessage as AguiToolMessage
-
             inp = _make_input(
                 messages=[
-                    AguiToolMessage(
-                        id="m-1",
-                        role="tool",
-                        content="old",
-                        tool_call_id="tc-old",
-                    ),
-                    AguiToolMessage(
-                        id="m-2",
-                        role="tool",
-                        content="new",
-                        tool_call_id="tc-new",
-                    ),
+                    _agui_tool_message(content="old", tool_call_id="tc-old"),
+                    _agui_tool_message(id="m-2", content="new", tool_call_id="tc-new"),
                 ],
             )
             checkpoint = {
@@ -4217,20 +3182,9 @@ def describe_detect_new_tool_results():
 
     def when_checkpoint_messages_none():
         def it_treats_as_no_history():
-            from ag_ui.core import ToolMessage as AguiToolMessage
-
-            inp = _make_input(
-                messages=[
-                    AguiToolMessage(
-                        id="m-1",
-                        role="tool",
-                        content="hello",
-                        tool_call_id="tc-1",
-                    ),
-                ],
+            out = detect_new_tool_results(
+                _tool_input(content="hello"), {"messages": None}
             )
-            checkpoint = {"messages": None}
-            out = detect_new_tool_results(inp, checkpoint)
             assert len(out) == 1
             assert out[0].tool_call_id == "tc-1"
 
@@ -4262,37 +3216,13 @@ def describe_detect_new_tool_results():
 
     def when_the_agui_message_reports_an_error():
         def it_marks_the_langchain_message_as_an_error():
-            from ag_ui.core import ToolMessage as AguiToolMessage
-
-            inp = _make_input(
-                messages=[
-                    AguiToolMessage(
-                        id="m-1",
-                        role="tool",
-                        content="boom",
-                        tool_call_id="tc-1",
-                        error="boom",
-                    ),
-                ],
-            )
+            inp = _tool_input(content="boom", error="boom")
             [out] = detect_new_tool_results(inp, {"messages": []})
             assert out.status == "error"
 
     def when_the_agui_message_reports_no_error():
         def it_marks_the_langchain_message_as_a_success():
-            from ag_ui.core import ToolMessage as AguiToolMessage
-
-            inp = _make_input(
-                messages=[
-                    AguiToolMessage(
-                        id="m-1",
-                        role="tool",
-                        content="42",
-                        tool_call_id="tc-1",
-                    ),
-                ],
-            )
-            [out] = detect_new_tool_results(inp, {"messages": []})
+            [out] = detect_new_tool_results(_tool_input(), {"messages": []})
             assert out.status == "success"
 
     def when_the_agui_error_field_is_an_empty_string():
@@ -4304,39 +3234,14 @@ def describe_detect_new_tool_results():
         """
 
         def it_marks_the_langchain_message_as_a_success():
-            from ag_ui.core import ToolMessage as AguiToolMessage
-
-            inp = _make_input(
-                messages=[
-                    AguiToolMessage(
-                        id="m-1",
-                        role="tool",
-                        content="42",
-                        tool_call_id="tc-1",
-                        error="",
-                    ),
-                ],
-            )
-            [out] = detect_new_tool_results(inp, {"messages": []})
+            [out] = detect_new_tool_results(_tool_input(error=""), {"messages": []})
             assert out.status == "success"
 
     def when_the_agui_message_carries_extra_fields():
         """The same slot `agui_messages_to_langchain` fills on the other path."""
 
         def it_collects_them_under_the_reserved_additional_kwargs_key():
-            from ag_ui.core import ToolMessage as AguiToolMessage
-
-            inp = _make_input(
-                messages=[
-                    AguiToolMessage(
-                        id="m-1",
-                        role="tool",
-                        content="42",
-                        tool_call_id="tc-1",
-                        latency_ms=12,
-                    ),
-                ],
-            )
+            inp = _tool_input(latency_ms=12)
             [out] = detect_new_tool_results(inp, {"messages": []})
             assert out.additional_kwargs == {
                 "langgraph_events.agui": {"latency_ms": 12}
@@ -4344,37 +3249,13 @@ def describe_detect_new_tool_results():
 
         def when_the_extra_fields_exceed_the_cap():
             def it_drops_them():
-                from ag_ui.core import ToolMessage as AguiToolMessage
-
-                inp = _make_input(
-                    messages=[
-                        AguiToolMessage(
-                            id="m-1",
-                            role="tool",
-                            content="42",
-                            tool_call_id="tc-1",
-                            blob="a" * 9000,
-                        ),
-                    ],
-                )
+                inp = _tool_input(blob="a" * 9000)
                 [out] = detect_new_tool_results(inp, {"messages": []})
                 assert out.additional_kwargs == {}
 
     def when_the_agui_message_carries_no_extra_fields():
         def it_leaves_additional_kwargs_empty():
-            from ag_ui.core import ToolMessage as AguiToolMessage
-
-            inp = _make_input(
-                messages=[
-                    AguiToolMessage(
-                        id="m-1",
-                        role="tool",
-                        content="42",
-                        tool_call_id="tc-1",
-                    ),
-                ],
-            )
-            [out] = detect_new_tool_results(inp, {"messages": []})
+            [out] = detect_new_tool_results(_tool_input(), {"messages": []})
             assert out.additional_kwargs == {}
 
 
@@ -4399,60 +3280,69 @@ def describe_frontend_state_mutated_event_class():
 def describe_frontend_state_mutated():
     """AG-UI adapter emits FrontendStateMutated before the seed event."""
 
+    def _focus_reducer(transform: Any = None) -> Any:
+        """A ``focus`` ScalarReducer fed from ``FrontendStateMutated.state``."""
+        from langgraph_events import SKIP, ScalarReducer
+        from langgraph_events.agui import FrontendStateMutated
+
+        def read(event: Any) -> Any:
+            if "focus" not in event.state:
+                return SKIP
+            value = event.state["focus"]
+            return transform(value) if transform else value
+
+        return ScalarReducer(name="focus", event_type=FrontendStateMutated, fn=read)
+
+    def _focus_recorder(seen: list[str | None]) -> Any:
+        """A ``UserAsked`` handler recording the ``focus`` channel it was given."""
+
+        @on(UserAsked)
+        def reply_focus(event: UserAsked, focus: str | None = None) -> AgentReplied:
+            seen.append(focus)
+            return AgentReplied(message=AIMessage(content="ok"))
+
+        return reply_focus
+
+    def _focus_approver(seen: list[str | None]) -> Any:
+        """An ``ApprovalGiven`` handler recording the ``focus`` channel."""
+
+        @on(ApprovalGiven)
+        def finish_focus(
+            event: ApprovalGiven,
+            focus: str | None = None,
+        ) -> AgentReplied:
+            seen.append(focus)
+            return AgentReplied(message=AIMessage(content="ok"))
+
+        return finish_focus
+
+    def _fsm_events(log: Any) -> list[Any]:
+        from langgraph_events.agui import FrontendStateMutated
+
+        return [e for e in log if isinstance(e, FrontendStateMutated)]
+
+    async def _log_after_client_state(thread_id: str, state: Any) -> list[Any]:
+        """Stream one run carrying client ``state``; return the persisted log."""
+        graph = _graph(reply, checkpointer=MemorySaver())
+        await _stream(graph, _make_input(thread_id=thread_id, state=state))
+        return list(graph.get_state(_config(thread_id)).events)
+
     def when_state_has_non_dedicated_keys():
         async def it_applies_scalar_reducer_before_seed_handler_runs():
-            from langgraph_events import SKIP, ScalarReducer
-            from langgraph_events.agui import FrontendStateMutated
-
-            focus = ScalarReducer(
-                name="focus",
-                event_type=FrontendStateMutated,
-                fn=lambda e: e.state.get("focus", SKIP),
-            )
             seen: list[str | None] = []
-
-            @on(UserAsked)
-            def reply(event: UserAsked, focus: str | None = None) -> AgentReplied:
-                seen.append(focus)
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph(
-                [reply],
-                reducers=[message_reducer(), focus],
+            graph = _graph(
+                _focus_recorder(seen),
+                reducers=[message_reducer(), _focus_reducer()],
                 checkpointer=MemorySaver(),
             )
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            await _collect(adapter, _make_input(state={"focus": "scene-42"}))
+            await _stream(graph, _make_input(state={"focus": "scene-42"}))
 
             assert seen == ["scene-42"]
 
         async def it_records_frontend_state_mutated_in_event_log():
-            from langgraph_events.agui import FrontendStateMutated
+            log = await _log_after_client_state("thread-fsm-1", {"focus": "scene-42"})
 
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph(
-                [reply],
-                reducers=[message_reducer()],
-                checkpointer=MemorySaver(),
-            )
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            config = {"configurable": {"thread_id": "thread-fsm-1"}}
-            await _collect(
-                adapter,
-                _make_input(thread_id="thread-fsm-1", state={"focus": "scene-42"}),
-            )
-
-            log = graph.get_state(config).events
-            fsm_events = [e for e in log if isinstance(e, FrontendStateMutated)]
+            fsm_events = _fsm_events(log)
             assert len(fsm_events) == 1
             assert fsm_events[0].state == {"focus": "scene-42"}
 
@@ -4462,116 +3352,36 @@ def describe_frontend_state_mutated():
 
     def when_state_is_empty():
         async def it_does_not_emit_frontend_state_mutated():
-            from langgraph_events.agui import FrontendStateMutated
+            log = await _log_after_client_state("thread-fsm-empty", {})
 
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph(
-                [reply],
-                reducers=[message_reducer()],
-                checkpointer=MemorySaver(),
-            )
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            config = {"configurable": {"thread_id": "thread-fsm-empty"}}
-            await _collect(
-                adapter,
-                _make_input(thread_id="thread-fsm-empty", state={}),
-            )
-
-            log = graph.get_state(config).events
-            assert not any(isinstance(e, FrontendStateMutated) for e in log)
+            assert not _fsm_events(log)
 
     def when_state_is_none():
         async def it_does_not_emit_frontend_state_mutated():
-            from langgraph_events.agui import FrontendStateMutated
+            log = await _log_after_client_state("thread-fsm-none", None)
 
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph(
-                [reply],
-                reducers=[message_reducer()],
-                checkpointer=MemorySaver(),
-            )
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            config = {"configurable": {"thread_id": "thread-fsm-none"}}
-            await _collect(
-                adapter,
-                _make_input(thread_id="thread-fsm-none", state=None),
-            )
-
-            log = graph.get_state(config).events
-            assert not any(isinstance(e, FrontendStateMutated) for e in log)
+            assert not _fsm_events(log)
 
     def when_state_contains_only_dedicated_keys():
         async def it_does_not_emit_frontend_state_mutated():
-            from langgraph_events.agui import FrontendStateMutated
-
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph(
-                [reply],
-                reducers=[message_reducer()],
-                checkpointer=MemorySaver(),
-            )
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            config = {"configurable": {"thread_id": "thread-fsm-msgs-only"}}
-            await _collect(
-                adapter,
-                _make_input(
-                    thread_id="thread-fsm-msgs-only",
-                    state={"messages": [{"role": "user", "content": "forged"}]},
-                ),
+            log = await _log_after_client_state(
+                "thread-fsm-msgs-only",
+                {"messages": [{"role": "user", "content": "forged"}]},
             )
 
-            log = graph.get_state(config).events
-            assert not any(isinstance(e, FrontendStateMutated) for e in log)
+            assert not _fsm_events(log)
 
     def when_state_has_dedicated_plus_other_keys():
         async def it_strips_dedicated_keys_from_the_emitted_event():
-            from langgraph_events.agui import FrontendStateMutated
-
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph(
-                [reply],
-                reducers=[message_reducer()],
-                checkpointer=MemorySaver(),
-            )
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            config = {"configurable": {"thread_id": "thread-fsm-mixed"}}
-            await _collect(
-                adapter,
-                _make_input(
-                    thread_id="thread-fsm-mixed",
-                    state={
-                        "messages": [{"role": "user", "content": "forged"}],
-                        "focus": "scene-7",
-                    },
-                ),
+            log = await _log_after_client_state(
+                "thread-fsm-mixed",
+                {
+                    "messages": [{"role": "user", "content": "forged"}],
+                    "focus": "scene-7",
+                },
             )
 
-            log = graph.get_state(config).events
-            fsm_events = [e for e in log if isinstance(e, FrontendStateMutated)]
+            fsm_events = _fsm_events(log)
             assert len(fsm_events) == 1
             assert fsm_events[0].state == {"focus": "scene-7"}
             assert "messages" not in fsm_events[0].state
@@ -4582,37 +3392,17 @@ def describe_frontend_state_mutated():
                 """Defense-in-depth: a stale client echoing `state.events` must
                 never inject the EventGraph audit log back into the graph.
                 """
-                from langgraph_events.agui import FrontendStateMutated
-
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="ok"))
-
-                graph = EventGraph(
-                    [reply],
-                    reducers=[message_reducer()],
-                    checkpointer=MemorySaver(),
-                )
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
-                )
-                config = {"configurable": {"thread_id": "thread-fsm-events-echo"}}
-                await _collect(
-                    adapter,
-                    _make_input(
-                        thread_id="thread-fsm-events-echo",
-                        state={
-                            "events": [
-                                {"type": "stale", "payload": "from-client"},
-                            ],
-                            "user_key": "v",
-                        },
-                    ),
+                log = await _log_after_client_state(
+                    "thread-fsm-events-echo",
+                    {
+                        "events": [
+                            {"type": "stale", "payload": "from-client"},
+                        ],
+                        "user_key": "v",
+                    },
                 )
 
-                log = graph.get_state(config).events
-                fsm_events = [e for e in log if isinstance(e, FrontendStateMutated)]
+                fsm_events = _fsm_events(log)
                 assert len(fsm_events) == 1
                 assert fsm_events[0].state == {"user_key": "v"}
                 assert "events" not in fsm_events[0].state
@@ -4620,60 +3410,19 @@ def describe_frontend_state_mutated():
         def when_state_only_has_internal_keys():
             async def it_drops_the_event_entirely():
                 """If the only key is the internal `events`, no FSM event fires."""
-                from langgraph_events.agui import FrontendStateMutated
-
-                @on(UserAsked)
-                def reply(event: UserAsked) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="ok"))
-
-                graph = EventGraph(
-                    [reply],
-                    reducers=[message_reducer()],
-                    checkpointer=MemorySaver(),
-                )
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="go"),
-                )
-                config = {"configurable": {"thread_id": "thread-fsm-events-only"}}
-                await _collect(
-                    adapter,
-                    _make_input(
-                        thread_id="thread-fsm-events-only",
-                        state={"events": [{"type": "stale"}]},
-                    ),
+                log = await _log_after_client_state(
+                    "thread-fsm-events-only", {"events": [{"type": "stale"}]}
                 )
 
-                log = graph.get_state(config).events
-                assert not any(isinstance(e, FrontendStateMutated) for e in log)
+                assert not _fsm_events(log)
 
     def when_no_checkpointer():
         async def it_still_applies_state_within_the_run():
-            from langgraph_events import SKIP, ScalarReducer
-            from langgraph_events.agui import FrontendStateMutated
-
-            focus = ScalarReducer(
-                name="focus",
-                event_type=FrontendStateMutated,
-                fn=lambda e: e.state.get("focus", SKIP),
-            )
             seen: list[str | None] = []
-
-            @on(UserAsked)
-            def reply(event: UserAsked, focus: str | None = None) -> AgentReplied:
-                seen.append(focus)
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph(
-                [reply],
-                reducers=[message_reducer(), focus],
-                # No checkpointer — used to be a hard skip under apre_seed.
+            graph = _graph(
+                _focus_recorder(seen), reducers=[message_reducer(), _focus_reducer()]
             )
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            await _collect(adapter, _make_input(state={"focus": "no-ckpt"}))
+            await _stream(graph, _make_input(state={"focus": "no-ckpt"}))
 
             assert seen == ["no-ckpt"]
 
@@ -4688,79 +3437,32 @@ def describe_frontend_state_mutated():
         """
 
         async def it_applies_the_transformation_on_non_resume():
-            from langgraph_events import SKIP, ScalarReducer
-            from langgraph_events.agui import FrontendStateMutated
-
-            focus = ScalarReducer(
-                name="focus",
-                event_type=FrontendStateMutated,
-                fn=lambda e: e.state["focus"].upper() if "focus" in e.state else SKIP,
-            )
             seen: list[str | None] = []
-
-            @on(UserAsked)
-            def reply(event: UserAsked, focus: str | None = None) -> AgentReplied:
-                seen.append(focus)
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph(
-                [reply],
-                reducers=[message_reducer(), focus],
+            graph = _graph(
+                _focus_recorder(seen),
+                reducers=[message_reducer(), _focus_reducer(str.upper)],
                 checkpointer=MemorySaver(),
             )
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            await _collect(adapter, _make_input(state={"focus": "scene-lc"}))
+            await _stream(graph, _make_input(state={"focus": "scene-lc"}))
 
             assert seen == ["SCENE-LC"]
 
         async def it_applies_the_transformation_on_resume():
-            from langgraph_events import SKIP, ScalarReducer
-            from langgraph_events.agui import FrontendStateMutated
-
-            focus = ScalarReducer(
-                name="focus",
-                event_type=FrontendStateMutated,
-                fn=lambda e: e.state["focus"].upper() if "focus" in e.state else SKIP,
-            )
             seen: list[str | None] = []
-
-            @on(UserAsked)
-            def ask(event: UserAsked) -> ApprovalRequested:
-                return ApprovalRequested(draft="ship it?")
-
-            @on(ApprovalGiven)
-            def finish(
-                event: ApprovalGiven,
-                focus: str | None = None,
-            ) -> AgentReplied:
-                seen.append(focus)
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph(
-                [ask, finish],
-                reducers=[message_reducer(), focus],
+            graph = _graph(
+                ask_ship,
+                _focus_approver(seen),
+                reducers=[message_reducer(), _focus_reducer(str.upper)],
                 checkpointer=MemorySaver(),
             )
 
             thread_id = "thread-fsm-fn-resume"
-            config = {"configurable": {"thread_id": thread_id}}
-
-            await graph.ainvoke(UserAsked(question="approve?"), config=config)
-
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="unused"),
-                resume_factory=lambda inp: ApprovalGiven(approved=True),
+            await graph.ainvoke(
+                UserAsked(question="approve?"), config=_config(thread_id)
             )
-            await _collect(
-                adapter,
-                _make_input(
-                    thread_id=thread_id,
-                    state={"focus": "scene-lc"},
-                ),
+
+            await _resume(
+                graph, _make_input(thread_id=thread_id, state={"focus": "scene-lc"})
             )
 
             # Transformed value — fn's `.upper()` ran on resume too.
@@ -4777,29 +3479,14 @@ def describe_frontend_state_mutated():
                     return None
                 return FocusLogged(value=focus)
 
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph(
-                [log_focus, reply],
-                reducers=[message_reducer()],
-                checkpointer=MemorySaver(),
-            )
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
-            config = {"configurable": {"thread_id": "thread-fsm-handler"}}
-            await _collect(
-                adapter,
-                _make_input(
-                    thread_id="thread-fsm-handler",
-                    state={"focus": "handler-case"},
-                ),
+            thread_id = "thread-fsm-handler"
+            graph = _graph(log_focus, reply, checkpointer=MemorySaver())
+            await _stream(
+                graph,
+                _make_input(thread_id=thread_id, state={"focus": "handler-case"}),
             )
 
-            log = graph.get_state(config).events
+            log = graph.get_state(_config(thread_id)).events
             focus_events = [e for e in log if isinstance(e, FocusLogged)]
             assert len(focus_events) == 1
             assert focus_events[0].value == "handler-case"
@@ -4807,56 +3494,28 @@ def describe_frontend_state_mutated():
     def when_resuming():
         def with_state_change_from_client():
             async def it_applies_state_before_resume_event_handler_runs():
-                from langgraph_events import SKIP, ScalarReducer
-                from langgraph_events.agui import FrontendStateMutated
-
-                focus = ScalarReducer(
-                    name="focus",
-                    event_type=FrontendStateMutated,
-                    fn=lambda e: e.state.get("focus", SKIP),
-                )
                 seen: list[str | None] = []
-
-                @on(UserAsked)
-                def ask(event: UserAsked) -> ApprovalRequested:
-                    return ApprovalRequested(draft="ship it?")
-
-                @on(ApprovalGiven)
-                def finish(
-                    event: ApprovalGiven,
-                    focus: str | None = None,
-                ) -> AgentReplied:
-                    seen.append(focus)
-                    return AgentReplied(message=AIMessage(content="ok"))
-
-                graph = EventGraph(
-                    [ask, finish],
-                    reducers=[message_reducer(), focus],
+                graph = _graph(
+                    ask_ship,
+                    _focus_approver(seen),
+                    reducers=[message_reducer(), _focus_reducer()],
                     checkpointer=MemorySaver(),
                 )
 
                 thread_id = "thread-fsm-resume"
-                config = {"configurable": {"thread_id": thread_id}}
-
                 # Drive the graph to an interrupt (bypassing the adapter —
                 # mirrors the priming pattern in
                 # `it_suppresses_resumed_events`).
-                await graph.ainvoke(UserAsked(question="approve?"), config=config)
+                await graph.ainvoke(
+                    UserAsked(question="approve?"), config=_config(thread_id)
+                )
 
                 # Now resume via the adapter, shipping client state along
                 # with the resume input.  The checkpoint's pending
                 # interrupt causes the adapter to take the resume branch.
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="unused"),
-                    resume_factory=lambda inp: ApprovalGiven(approved=True),
-                )
-                await _collect(
-                    adapter,
-                    _make_input(
-                        thread_id=thread_id,
-                        state={"focus": "resume-case"},
-                    ),
+                await _resume(
+                    graph,
+                    _make_input(thread_id=thread_id, state={"focus": "resume-case"}),
                 )
 
                 assert seen == ["resume-case"]
@@ -4888,37 +3547,31 @@ def describe_frontend_state_mutated():
                     return ApprovalRequested(draft="proceed?")
 
                 @on(ApprovalGiven)
-                def finish(
+                def finish_strategy(
                     event: ApprovalGiven,
                     walkthrough_strategy: str | None = None,
                 ) -> AgentReplied:
                     seen_strategy.append(walkthrough_strategy)
                     return AgentReplied(message=AIMessage(content="ok"))
 
-                graph = EventGraph(
-                    [ask, finish],
+                graph = _graph(
+                    ask,
+                    finish_strategy,
                     reducers=[message_reducer(), strategy],
                     checkpointer=MemorySaver(),
                 )
 
                 thread_id = "thread-backend-authoritative"
-                config = {"configurable": {"thread_id": thread_id}}
-                await graph.ainvoke(UserAsked(question="?"), config=config)
+                await graph.ainvoke(UserAsked(question="?"), config=_config(thread_id))
 
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="unused"),
-                    resume_factory=lambda inp: ApprovalGiven(approved=True),
-                )
                 # Stale frontend snapshot tries to inject a NULL strategy.
                 # Under the old apre_seed bypass this would clobber the
                 # channel; under FSM dispatch the reducer doesn't subscribe
                 # to FSM, so it's a no-op and the domain event wins.
-                await _collect(
-                    adapter,
+                await _resume(
+                    graph,
                     _make_input(
-                        thread_id=thread_id,
-                        state={"walkthrough_strategy": None},
+                        thread_id=thread_id, state={"walkthrough_strategy": None}
                     ),
                 )
 
@@ -4952,35 +3605,19 @@ def describe_frontend_state_mutated():
                     reducer=operator.add,
                 )
 
-                @on(UserAsked)
-                def ask(event: UserAsked) -> ApprovalRequested:
-                    return ApprovalRequested(draft="ok?")
-
-                @on(ApprovalGiven)
-                def finish(event: ApprovalGiven) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="done"))
-
-                graph = EventGraph(
-                    [ask, finish],
+                graph = _graph(
+                    ask_ok,
+                    finish,
                     reducers=[message_reducer(), focus_log],
                     checkpointer=MemorySaver(),
                 )
 
                 thread_id = "thread-fsm-no-double-count"
-                config = {"configurable": {"thread_id": thread_id}}
+                config = _config(thread_id)
                 await graph.ainvoke(UserAsked(question="?"), config=config)
 
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="unused"),
-                    resume_factory=lambda inp: ApprovalGiven(approved=True),
-                )
-                events = await _collect(
-                    adapter,
-                    _make_input(
-                        thread_id=thread_id,
-                        state={"focus": "X"},
-                    ),
+                events = await _resume(
+                    graph, _make_input(thread_id=thread_id, state={"focus": "X"})
                 )
 
                 # Persisted checkpoint: single contribution (correct).
@@ -4988,7 +3625,7 @@ def describe_frontend_state_mutated():
                 assert checkpoint_values.get("focus_log") == ["X"]
 
                 # Streamed STATE_SNAPSHOT: must also be single contribution.
-                snapshots = [e for e in events if e.type == EventType.STATE_SNAPSHOT]
+                snapshots = _of_type(events, EventType.STATE_SNAPSHOT)
                 assert snapshots, "expected at least one STATE_SNAPSHOT"
                 last = snapshots[-1].snapshot
                 assert last.get("focus_log") == ["X"], (
@@ -5024,18 +3661,15 @@ def describe_frontend_state_mutated():
                 def prime(event: FocusEcho) -> ApprovalRequested:
                     return ApprovalRequested(draft="ok?")
 
-                @on(ApprovalGiven)
-                def finish(event: ApprovalGiven) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="done"))
-
-                graph = EventGraph(
-                    [prime, finish],
+                graph = _graph(
+                    prime,
+                    finish,
                     reducers=[message_reducer(), focus_log],
                     checkpointer=MemorySaver(),
                 )
 
                 thread_id = "thread-fsm-layered"
-                config = {"configurable": {"thread_id": thread_id}}
+                config = _config(thread_id)
                 # Prime the channel: two prior FocusEcho events accumulate
                 # ["a", "b"] before the interrupt.
                 await graph.ainvoke(
@@ -5044,17 +3678,10 @@ def describe_frontend_state_mutated():
                 checkpoint_before = (await graph.compiled.aget_state(config)).values
                 assert checkpoint_before.get("focus_log") == ["a", "b"]
 
-                adapter = AGUIAdapter(
-                    graph=graph,
+                events = await _resume(
+                    graph,
+                    _make_input(thread_id=thread_id, state={"focus": "X"}),
                     seed_factory=lambda inp: FocusEcho(value="unused"),
-                    resume_factory=lambda inp: ApprovalGiven(approved=True),
-                )
-                events = await _collect(
-                    adapter,
-                    _make_input(
-                        thread_id=thread_id,
-                        state={"focus": "X"},
-                    ),
                 )
 
                 # Persisted checkpoint: exactly one new entry layered on top.
@@ -5062,7 +3689,7 @@ def describe_frontend_state_mutated():
                 assert checkpoint_after.get("focus_log") == ["a", "b", "X"]
 
                 # Streamed STATE_SNAPSHOT: same — no double-count regression.
-                snapshots = [e for e in events if e.type == EventType.STATE_SNAPSHOT]
+                snapshots = _of_type(events, EventType.STATE_SNAPSHOT)
                 assert snapshots, "expected at least one STATE_SNAPSHOT"
                 last = snapshots[-1].snapshot
                 assert last.get("focus_log") == ["a", "b", "X"], (
@@ -5075,41 +3702,18 @@ def describe_frontend_state_mutated():
             async def it_emits_a_frontend_state_mutated_event_on_resume():
                 """FSM appears in the audit log on the resume path,
                 exactly like the non-resume path."""
-                from langgraph_events.agui import FrontendStateMutated
-
-                @on(UserAsked)
-                def ask(event: UserAsked) -> ApprovalRequested:
-                    return ApprovalRequested(draft="ok?")
-
-                @on(ApprovalGiven)
-                def finish(event: ApprovalGiven) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="done"))
-
-                graph = EventGraph(
-                    [ask, finish],
-                    reducers=[message_reducer()],
-                    checkpointer=MemorySaver(),
-                )
+                graph = _graph(ask_ok, finish, checkpointer=MemorySaver())
 
                 thread_id = "thread-fsm-resume-audit"
-                config = {"configurable": {"thread_id": thread_id}}
+                config = _config(thread_id)
                 await graph.ainvoke(UserAsked(question="?"), config=config)
 
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="unused"),
-                    resume_factory=lambda inp: ApprovalGiven(approved=True),
-                )
-                await _collect(
-                    adapter,
-                    _make_input(
-                        thread_id=thread_id,
-                        state={"focus": "resume-audit"},
-                    ),
+                await _resume(
+                    graph,
+                    _make_input(thread_id=thread_id, state={"focus": "resume-audit"}),
                 )
 
-                log = graph.get_state(config).events
-                fsm_events = [e for e in log if isinstance(e, FrontendStateMutated)]
+                fsm_events = _fsm_events(graph.get_state(config).events)
                 assert len(fsm_events) == 1
                 assert fsm_events[0].state == {"focus": "resume-audit"}
 
@@ -5121,35 +3725,15 @@ def describe_frontend_state_mutated():
                 output reduces on top."""
                 from langgraph_events.agui import FrontendStateMutated
 
-                @on(UserAsked)
-                def ask(event: UserAsked) -> ApprovalRequested:
-                    return ApprovalRequested(draft="ok?")
-
-                @on(ApprovalGiven)
-                def finish(event: ApprovalGiven) -> AgentReplied:
-                    return AgentReplied(message=AIMessage(content="done"))
-
-                graph = EventGraph(
-                    [ask, finish],
-                    reducers=[message_reducer()],
-                    checkpointer=MemorySaver(),
-                )
+                graph = _graph(ask_ok, finish, checkpointer=MemorySaver())
 
                 thread_id = "thread-fsm-resume-order"
-                config = {"configurable": {"thread_id": thread_id}}
+                config = _config(thread_id)
                 await graph.ainvoke(UserAsked(question="?"), config=config)
 
-                adapter = AGUIAdapter(
-                    graph=graph,
-                    seed_factory=lambda inp: UserAsked(question="unused"),
-                    resume_factory=lambda inp: ApprovalGiven(approved=True),
-                )
-                await _collect(
-                    adapter,
-                    _make_input(
-                        thread_id=thread_id,
-                        state={"focus": "ordering"},
-                    ),
+                await _resume(
+                    graph,
+                    _make_input(thread_id=thread_id, state={"focus": "ordering"}),
                 )
 
                 log = list(graph.get_state(config).events)
@@ -5172,19 +3756,8 @@ def describe_frontend_state_mutated():
             # Ensure the warning can fire for this class in this test run.
             _warned_classes.discard(FrontendStateMutated)
 
-            @on(UserAsked)
-            def reply(event: UserAsked) -> AgentReplied:
-                return AgentReplied(message=AIMessage(content="ok"))
-
-            graph = EventGraph(
-                [reply],
-                reducers=[message_reducer()],
-                checkpointer=MemorySaver(),
-            )
-            adapter = AGUIAdapter(
-                graph=graph,
-                seed_factory=lambda inp: UserAsked(question="go"),
-            )
+            graph = _graph(reply, checkpointer=MemorySaver())
+            adapter = _adapter(graph)
 
             with warnings.catch_warnings(record=True) as captured:
                 warnings.simplefilter("always")

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -17,6 +17,7 @@ from conftest import (
 )
 from langchain_core.messages import (
     AIMessage,
+    AIMessageChunk,
     BaseMessage,
     HumanMessage,
     SystemMessage,
@@ -32,6 +33,7 @@ from langgraph_events import (
     EventGraph,
     EventLog,
     Halted,
+    HandlerRaised,
     IntegrationEvent,
     Interrupted,
     MaxRoundsExceeded,
@@ -57,6 +59,7 @@ from langgraph_events.stream import (
     CustomEventFrame,
     LLMStreamEnd,
     LLMToken,
+    LLMToolCallChunk,
     StateSnapshotFrame,
     StreamFrame,
 )
@@ -86,6 +89,117 @@ class _OrphanSuite(Namespace):
         label: str = ""
 
 
+class _ApprovalRequested(Interrupted):
+    """Interrupt narrowed on by the field-matcher suites."""
+
+    draft: str = ""
+
+
+class _OtherInterrupted(Interrupted):
+    """Interrupt that must *not* satisfy an ``_ApprovalRequested`` matcher."""
+
+    reason: str = ""
+
+
+class _ReviewApproved(IntegrationEvent):
+    """Resume value for the field-matcher suites."""
+
+
+class _Acknowledge(IntegrationEvent):
+    """Alternative resume value for the field-matcher suites."""
+
+
+class _OtherEvent(IntegrationEvent):
+    """Resume value that must *not* satisfy a ``_ReviewApproved`` matcher."""
+
+
+class _UserMsgReceived(IntegrationEvent):
+    """User turn in the shared ReAct-loop scenario."""
+
+    content: str = ""
+
+
+class _AssistantMsgSent(IntegrationEvent):
+    """Assistant turn in the shared ReAct-loop scenario."""
+
+    content: str = ""
+    needs_tool: bool = False
+
+
+class _ToolResultReturned(IntegrationEvent):
+    """Tool result in the shared ReAct-loop scenario."""
+
+    result: str = ""
+
+
+class _FinalAnswerProduced(IntegrationEvent):
+    """Terminal answer in the shared ReAct-loop scenario."""
+
+    answer: str = ""
+
+
+@on(_AssistantMsgSent)
+def _handle_response(
+    event: _AssistantMsgSent,
+) -> _ToolResultReturned | _FinalAnswerProduced:
+    """ReAct branch: run the tool when asked, otherwise finalize."""
+    if event.needs_tool:
+        return _ToolResultReturned(result="42")
+    return _FinalAnswerProduced(answer=event.content)
+
+
+@on(Started)
+def _to_processed(event: Started) -> Processed:
+    """``Started`` leg of the deadline / RunPaused scenarios."""
+    return Processed(data=event.data)
+
+
+@on(MessageReceived)
+def _to_ended(event: MessageReceived) -> Ended:
+    """``MessageReceived`` leg of the deadline / RunPaused scenarios."""
+    return Ended(result=event.text)
+
+
+def _deadline_graph(thread_id: str) -> tuple[EventGraph, dict[str, typing.Any]]:
+    """Checkpointed two-handler graph for the deadline suites, plus its config."""
+    graph = EventGraph([_to_processed, _to_ended], checkpointer=MemorySaver())
+    return graph, {"configurable": {"thread_id": thread_id}}
+
+
+class _DedupError(Exception):
+    """Declared raise used by the handler-dedup suites."""
+
+
+@on(Started, raises=_DedupError)
+def _raiser(event: Started) -> Ended:
+    """Handler passed twice so name dedup has to copy its ``raises=``."""
+    raise _DedupError("boom")
+
+
+@on(HandlerRaised, exception=_DedupError)
+def _catcher(event: HandlerRaised) -> Ended:
+    """Catcher passed twice so name dedup has to copy its field matchers."""
+    return Ended(result="caught")
+
+
+class _Triggered(IntegrationEvent):
+    """Seed for the scalar-reducer suites."""
+
+    value: str = ""
+    tag: str = ""
+
+
+class _Unmatched(IntegrationEvent):
+    """Event type the scalar-reducer suites reduce over but never emit."""
+
+
+class _ResultProduced(IntegrationEvent):
+    """Terminal event carrying an injected reducer value as text."""
+
+    got: str = ""
+    summary: str = ""
+
+
 class _WidgetSuite(Namespace):
     """Command with a nested DomainEvent outcome — no subscriber."""
 
@@ -102,6 +216,136 @@ class _WidgetSuite(Namespace):
 def _data_reducer() -> Reducer:
     """Simple reducer that accumulates Started.data values."""
     return Reducer(name="data_items", event_type=Started, fn=lambda e: [e.data])
+
+
+class _UserSent(IntegrationEvent, MessageEvent):
+    """Inbound chat turn for the LLM-streaming suites."""
+
+    message: HumanMessage = None  # type: ignore[assignment]
+
+
+class _AgentReplied(IntegrationEvent, MessageEvent):
+    """Outbound chat turn for the LLM-streaming suites."""
+
+    message: AIMessage = None  # type: ignore[assignment]
+
+
+@on(Started)
+def _echo(event: Started) -> Ended:
+    """Trivial ``Started -> Ended`` step for suites that just need a graph."""
+    return Ended(result=event.data)
+
+
+@on(Started)
+def _relay(event: Started) -> Processed:
+    """First leg of the shared ``Started -> Processed -> Ended`` chain."""
+    return Processed(data=event.data)
+
+
+@on(Processed)
+def _finish(event: Processed) -> Ended:
+    """Second leg of the shared ``Started -> Processed -> Ended`` chain."""
+    return Ended(result=event.data)
+
+
+@on(Started)
+def _pause_at_step_one(event: Started) -> _StepInterrupted:
+    """Interrupts the run so resume-oriented suites have a paused thread."""
+    return _StepInterrupted(step=1)
+
+
+@on(Completed)
+def _finish_completed(event: Completed) -> Ended:
+    """Resume-side step that turns a ``Completed`` resume value into ``Ended``."""
+    return Ended(result=event.result)
+
+
+def _echo_graph(**kwargs: typing.Any) -> EventGraph:
+    """An ``EventGraph`` whose sole handler echoes ``Started`` into ``Ended``."""
+    return EventGraph([_echo], **kwargs)
+
+
+def _chain_graph(**kwargs: typing.Any) -> EventGraph:
+    """An ``EventGraph`` running ``Started -> Processed -> Ended``."""
+    return EventGraph([_relay, _finish], **kwargs)
+
+
+def _interruptible_graph(
+    thread_id: str, **kwargs: typing.Any
+) -> tuple[EventGraph, dict[str, typing.Any]]:
+    """A checkpointed graph that pauses on ``Started``, plus its thread config."""
+    graph = EventGraph(
+        [_pause_at_step_one, _finish_completed],
+        checkpointer=MemorySaver(),
+        **kwargs,
+    )
+    return graph, {"configurable": {"thread_id": thread_id}}
+
+
+def _llm_graph(response: str, prompt: str = "hi") -> EventGraph:
+    """A message-reducing graph whose handler replies from a canned LLM."""
+    from langchain_core.language_models.fake_chat_models import FakeListChatModel
+
+    llm = FakeListChatModel(responses=[response], sleep=0)
+
+    @on(_UserSent)
+    async def reply(event: _UserSent, messages: list[typing.Any]) -> _AgentReplied:
+        reply_message = await llm.ainvoke([*messages, HumanMessage(content=prompt)])
+        return _AgentReplied(message=reply_message)
+
+    return EventGraph([reply], reducers=[message_reducer()])
+
+
+async def _adrain(stream: typing.AsyncIterator[typing.Any]) -> list[typing.Any]:
+    """Collect an async stream into a list."""
+    return [item async for item in stream]
+
+
+def _fake_astream_events(
+    *payloads: dict[str, typing.Any],
+) -> typing.Callable[..., typing.AsyncIterator[dict[str, typing.Any]]]:
+    """Stand-in for ``compiled.astream_events`` yielding fixed v2 payloads."""
+
+    async def fake(
+        *args: typing.Any, **kwargs: typing.Any
+    ) -> typing.AsyncIterator[dict[str, typing.Any]]:
+        del args, kwargs
+        for payload in payloads:
+            yield payload
+
+    return fake
+
+
+def _custom_payload(name: str, data: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    """A raw ``on_custom_event`` v2 payload."""
+    return {"event": "on_custom_event", "name": name, "data": data}
+
+
+def _chat_payload(
+    chunk: AIMessageChunk, run_id: str = "run-x"
+) -> dict[str, typing.Any]:
+    """A raw ``on_chat_model_stream`` v2 payload."""
+    return {"event": "on_chat_model_stream", "run_id": run_id, "data": {"chunk": chunk}}
+
+
+def _tool_call_chunk_message(
+    content: str = "",
+    *,
+    name: str = "search",
+    args: str = "",
+    tool_call_id: str = "tc-1",
+    index: int | None = 0,
+) -> AIMessageChunk:
+    """An ``AIMessageChunk`` with one tool-call chunk; ``index=None`` omits the key."""
+    chunk: dict[str, typing.Any] = {
+        "name": name,
+        "args": args,
+        "id": tool_call_id,
+        "type": "tool_call_chunk",
+    }
+    if index is not None:
+        chunk["index"] = index
+    return AIMessageChunk(content=content, tool_call_chunks=[chunk])
 
 
 # ---------------------------------------------------------------------------
@@ -424,50 +668,29 @@ def describe_EventGraph():
                     assert log.latest(Summarized) == Summarized(count=1)
 
                 def it_supports_react_loop_pattern():
-                    class UserMsgReceived(IntegrationEvent):
-                        content: str = ""
-
-                    class AssistantMsgSent(IntegrationEvent):
-                        content: str = ""
-                        needs_tool: bool = False
-
-                    class ToolResultReturned(IntegrationEvent):
-                        result: str = ""
-
-                    class FinalAnswerProduced(IntegrationEvent):
-                        answer: str = ""
-
                     call_count = 0
 
-                    @on(UserMsgReceived, ToolResultReturned)
-                    def call_llm(event: Event, log: EventLog) -> AssistantMsgSent:
+                    @on(_UserMsgReceived, _ToolResultReturned)
+                    def call_llm(event: Event, log: EventLog) -> _AssistantMsgSent:
                         nonlocal call_count
                         call_count += 1
-                        if isinstance(event, UserMsgReceived):
-                            return AssistantMsgSent(
+                        if isinstance(event, _UserMsgReceived):
+                            return _AssistantMsgSent(
                                 content="need tool", needs_tool=True
                             )
-                        return AssistantMsgSent(
+                        return _AssistantMsgSent(
                             content=f"got:{event.result}",
                             needs_tool=False,
                         )
 
-                    @on(AssistantMsgSent)
-                    def handle_response(
-                        event: AssistantMsgSent,
-                    ) -> ToolResultReturned | FinalAnswerProduced:
-                        if event.needs_tool:
-                            return ToolResultReturned(result="42")
-                        return FinalAnswerProduced(answer=event.content)
-
-                    graph = EventGraph([call_llm, handle_response])
-                    log = graph.invoke(UserMsgReceived(content="what is 6*7?"))
+                    graph = EventGraph([call_llm, _handle_response])
+                    log = graph.invoke(_UserMsgReceived(content="what is 6*7?"))
                     assert call_count == 2
-                    assert log.latest(FinalAnswerProduced) == (
-                        FinalAnswerProduced(answer="got:42")
+                    assert log.latest(_FinalAnswerProduced) == (
+                        _FinalAnswerProduced(answer="got:42")
                     )
-                    assert log.has(ToolResultReturned)
-                    assert log.has(AssistantMsgSent)
+                    assert log.has(_ToolResultReturned)
+                    assert log.has(_AssistantMsgSent)
 
             def when_both_types_pending():
 
@@ -563,38 +786,6 @@ def describe_EventGraph():
                     )
                     assert log.has(SystemPromptSet)
                     assert log.latest(Ended) == Ended(result="has_prompt=True")
-
-                def it_contributes_to_message_reducer():
-                    class UserMsgReceived(IntegrationEvent, MessageEvent):
-                        message: HumanMessage = None  # type: ignore[assignment]
-
-                    class Finished(IntegrationEvent):
-                        answer: str = ""
-
-                    r = message_reducer()
-
-                    received_messages: list[list[BaseMessage]] = []
-
-                    @on(UserMsgReceived)
-                    def respond(
-                        event: UserMsgReceived, messages: list[BaseMessage]
-                    ) -> Finished:
-                        received_messages.append(list(messages))
-                        return Finished(answer="ok")
-
-                    graph = EventGraph([respond], reducers=[r])
-                    log = graph.invoke(
-                        [
-                            SystemPromptSet.from_str("You are a test bot"),
-                            UserMsgReceived(message=HumanMessage(content="hello")),
-                        ]
-                    )
-                    assert log.latest(Finished) is not None
-                    msgs = received_messages[0]
-                    assert len(msgs) == 2
-                    assert isinstance(msgs[0], SystemMessage)
-                    assert msgs[0].content == "You are a test bot"
-                    assert msgs[1].content == "hello"
 
         def describe_ainvoke():
 
@@ -929,76 +1120,60 @@ def describe_EventGraph():
 
     def describe_field_matchers():
 
+        def _resume_after_interrupt(handlers, resume_with, thread_id: str) -> EventLog:
+            """Interrupt a checkpointed graph, then resume it with ``resume_with``."""
+            graph = EventGraph(handlers, checkpointer=MemorySaver())
+            config = {"configurable": {"thread_id": thread_id}}
+            graph.invoke(Started(data="test"), config=config)
+            return graph.resume(resume_with, config=config)
+
         def when_field_matches():
 
             def it_dispatches_the_handler():
-                from langgraph.checkpoint.memory import MemorySaver
-
-                class ApprovalRequested(Interrupted):
-                    draft: str = ""
-
-                class ReviewApproved(IntegrationEvent):
-                    pass
-
                 captured = []
 
                 @on(Started)
-                def need_input(event: Started) -> ApprovalRequested:
-                    return ApprovalRequested(draft="hello")
+                def need_input(event: Started) -> _ApprovalRequested:
+                    return _ApprovalRequested(draft="hello")
 
-                @on(Resumed, interrupted=ApprovalRequested)
+                @on(Resumed, interrupted=_ApprovalRequested)
                 def handle_approval(event: Resumed) -> Ended:
                     captured.append(event.interrupted)
                     return Ended(result="approved")
 
-                graph = EventGraph(
+                log = _resume_after_interrupt(
                     [need_input, handle_approval],
-                    checkpointer=MemorySaver(),
+                    _ReviewApproved(),
+                    "field-match-test",
                 )
-                config = {"configurable": {"thread_id": "field-match-test"}}
-                graph.invoke(Started(data="test"), config=config)
-                log = graph.resume(ReviewApproved(), config=config)
 
                 assert log.latest(Ended) == Ended(result="approved")
                 assert len(captured) == 1
-                assert isinstance(captured[0], ApprovalRequested)
+                assert isinstance(captured[0], _ApprovalRequested)
 
         def when_field_does_not_match():
 
             def it_skips_the_handler():
-                from langgraph.checkpoint.memory import MemorySaver
-
-                class ApprovalRequested(Interrupted):
-                    draft: str = ""
-
-                class OtherInterrupted(Interrupted):
-                    reason: str = ""
-
-                class ReviewApproved(IntegrationEvent):
-                    pass
-
                 captured = []
 
                 @on(Started)
-                def need_input(event: Started) -> OtherInterrupted:
-                    return OtherInterrupted(reason="different")
+                def need_input(event: Started) -> _OtherInterrupted:
+                    return _OtherInterrupted(reason="different")
 
-                @on(Resumed, interrupted=ApprovalRequested)
+                @on(Resumed, interrupted=_ApprovalRequested)
                 def handle_approval(event: Resumed) -> Ended:
                     captured.append("should not fire")
                     return Ended(result="approved")
 
-                @on(ReviewApproved)
-                def fallback(event: ReviewApproved) -> Ended:
+                @on(_ReviewApproved)
+                def fallback(event: _ReviewApproved) -> Ended:
                     return Ended(result="fallback")
 
-                graph = EventGraph(
+                log = _resume_after_interrupt(
                     [need_input, handle_approval, fallback],
-                    checkpointer=MemorySaver(),
+                    _ReviewApproved(),
+                    "field-no-match-test",
                 )
-                config = {"configurable": {"thread_id": "field-no-match-test"}}
-                graph.invoke(Started(data="test"), config=config)
-                log = graph.resume(ReviewApproved(), config=config)
 
                 assert len(captured) == 0
                 assert log.latest(Ended) == Ended(result="fallback")
@@ -1007,39 +1182,26 @@ def describe_EventGraph():
 
             def it_skips_the_handler():
                 """A None field value does not match a field matcher."""
-                from langgraph.checkpoint.memory import MemorySaver
-
-                class ApprovalRequested(Interrupted):
-                    draft: str = ""
-
-                class OtherInterrupted(Interrupted):
-                    reason: str = ""
-
-                class Acknowledge(IntegrationEvent):
-                    pass
-
                 captured = []
 
                 @on(Started)
-                def need_input(event: Started) -> OtherInterrupted:
-                    return OtherInterrupted(reason="test")
+                def need_input(event: Started) -> _OtherInterrupted:
+                    return _OtherInterrupted(reason="test")
 
-                @on(Resumed, interrupted=ApprovalRequested)
+                @on(Resumed, interrupted=_ApprovalRequested)
                 def approval_handler(event: Resumed) -> Ended:
                     captured.append("should not fire")
                     return Ended(result="approval")
 
-                @on(Acknowledge)
-                def fallback(event: Acknowledge) -> Ended:
+                @on(_Acknowledge)
+                def fallback(event: _Acknowledge) -> Ended:
                     return Ended(result="fallback")
 
-                graph = EventGraph(
+                log = _resume_after_interrupt(
                     [need_input, approval_handler, fallback],
-                    checkpointer=MemorySaver(),
+                    _Acknowledge(),
+                    "field-none-test",
                 )
-                config = {"configurable": {"thread_id": "field-none-test"}}
-                graph.invoke(Started(data="test"), config=config)
-                log = graph.resume(Acknowledge(), config=config)
 
                 assert len(captured) == 0
                 assert log.latest(Ended) == Ended(result="fallback")
@@ -1047,116 +1209,83 @@ def describe_EventGraph():
         def when_handler_requests_field_injection():
 
             def it_injects_the_narrowed_field():
-                from langgraph.checkpoint.memory import MemorySaver
-
-                class ApprovalRequested(Interrupted):
-                    draft: str = ""
-
-                class ReviewApproved(IntegrationEvent):
-                    pass
-
                 injected_values = []
 
                 @on(Started)
-                def need_input(event: Started) -> ApprovalRequested:
-                    return ApprovalRequested(draft="my draft")
+                def need_input(event: Started) -> _ApprovalRequested:
+                    return _ApprovalRequested(draft="my draft")
 
-                @on(Resumed, interrupted=ApprovalRequested)
+                @on(Resumed, interrupted=_ApprovalRequested)
                 def handle_approval(
-                    event: Resumed, interrupted: ApprovalRequested
+                    event: Resumed, interrupted: _ApprovalRequested
                 ) -> Ended:
                     injected_values.append(interrupted)
                     return Ended(result=interrupted.draft)
 
-                graph = EventGraph(
+                log = _resume_after_interrupt(
                     [need_input, handle_approval],
-                    checkpointer=MemorySaver(),
+                    _ReviewApproved(),
+                    "field-inject-test",
                 )
-                config = {"configurable": {"thread_id": "field-inject-test"}}
-                graph.invoke(Started(data="test"), config=config)
-                log = graph.resume(ReviewApproved(), config=config)
 
                 assert log.latest(Ended) == Ended(result="my draft")
                 assert len(injected_values) == 1
-                assert isinstance(injected_values[0], ApprovalRequested)
+                assert isinstance(injected_values[0], _ApprovalRequested)
                 assert injected_values[0].draft == "my draft"
 
         def when_multiple_field_matchers():
 
             def it_requires_all_fields_to_match():
-                from langgraph.checkpoint.memory import MemorySaver
-
-                class ApprovalRequested(Interrupted):
-                    draft: str = ""
-
-                class ReviewApproved(IntegrationEvent):
-                    pass
-
                 captured = []
 
                 @on(Started)
-                def need_input(event: Started) -> ApprovalRequested:
-                    return ApprovalRequested(draft="hello")
+                def need_input(event: Started) -> _ApprovalRequested:
+                    return _ApprovalRequested(draft="hello")
 
-                @on(Resumed, interrupted=ApprovalRequested, value=ReviewApproved)
+                @on(Resumed, interrupted=_ApprovalRequested, value=_ReviewApproved)
                 def strict_handler(
                     event: Resumed,
-                    interrupted: ApprovalRequested,
-                    value: ReviewApproved,
+                    interrupted: _ApprovalRequested,
+                    value: _ReviewApproved,
                 ) -> Ended:
                     captured.append((interrupted, value))
                     return Ended(result="strict")
 
-                graph = EventGraph(
+                log = _resume_after_interrupt(
                     [need_input, strict_handler],
-                    checkpointer=MemorySaver(),
+                    _ReviewApproved(),
+                    "multi-field-test",
                 )
-                config = {"configurable": {"thread_id": "multi-field-test"}}
-                graph.invoke(Started(data="test"), config=config)
-                log = graph.resume(ReviewApproved(), config=config)
 
                 assert log.latest(Ended) == Ended(result="strict")
                 assert len(captured) == 1
-                assert isinstance(captured[0][0], ApprovalRequested)
-                assert isinstance(captured[0][1], ReviewApproved)
+                assert isinstance(captured[0][0], _ApprovalRequested)
+                assert isinstance(captured[0][1], _ReviewApproved)
 
             def when_one_field_does_not_match():
 
                 def it_skips_the_handler():
-                    from langgraph.checkpoint.memory import MemorySaver
-
-                    class ApprovalRequested(Interrupted):
-                        draft: str = ""
-
-                    class ReviewApproved(IntegrationEvent):
-                        pass
-
-                    class OtherEvent(IntegrationEvent):
-                        pass
-
                     captured = []
 
                     @on(Started)
-                    def need_input(event: Started) -> ApprovalRequested:
-                        return ApprovalRequested(draft="hello")
+                    def need_input(event: Started) -> _ApprovalRequested:
+                        return _ApprovalRequested(draft="hello")
 
-                    # value=OtherEvent won't match ReviewApproved
-                    @on(Resumed, interrupted=ApprovalRequested, value=OtherEvent)
+                    # value=_OtherEvent won't match _ReviewApproved
+                    @on(Resumed, interrupted=_ApprovalRequested, value=_OtherEvent)
                     def strict_handler(event: Resumed) -> Ended:
                         captured.append("should not fire")
                         return Ended(result="strict")
 
-                    @on(ReviewApproved)
-                    def fallback(event: ReviewApproved) -> Ended:
+                    @on(_ReviewApproved)
+                    def fallback(event: _ReviewApproved) -> Ended:
                         return Ended(result="fallback")
 
-                    graph = EventGraph(
+                    log = _resume_after_interrupt(
                         [need_input, strict_handler, fallback],
-                        checkpointer=MemorySaver(),
+                        _ReviewApproved(),
+                        "multi-field-skip",
                     )
-                    config = {"configurable": {"thread_id": "multi-field-skip"}}
-                    graph.invoke(Started(data="test"), config=config)
-                    log = graph.resume(ReviewApproved(), config=config)
 
                     assert len(captured) == 0
                     assert log.latest(Ended) == Ended(result="fallback")
@@ -1495,25 +1624,12 @@ def describe_EventGraph():
         def describe_react_loop():
 
             def it_accumulates_system_user_assistant_tool_messages():
-                class UserMsgReceived(IntegrationEvent):
-                    content: str = ""
-
-                class AssistantMsgSent(IntegrationEvent):
-                    content: str = ""
-                    needs_tool: bool = False
-
-                class ToolResultReturned(IntegrationEvent):
-                    result: str = ""
-
-                class FinalAnswerProduced(IntegrationEvent):
-                    answer: str = ""
-
                 def to_messages(event: Event) -> list:
-                    if isinstance(event, UserMsgReceived):
+                    if isinstance(event, _UserMsgReceived):
                         return [("user", event.content)]
-                    if isinstance(event, AssistantMsgSent):
+                    if isinstance(event, _AssistantMsgSent):
                         return [("assistant", event.content)]
-                    if isinstance(event, ToolResultReturned):
+                    if isinstance(event, _ToolResultReturned):
                         return [("tool", event.result)]
                     return []
 
@@ -1525,28 +1641,20 @@ def describe_EventGraph():
                 )
                 message_snapshots: list[list] = []
 
-                @on(UserMsgReceived, ToolResultReturned)
-                def call_llm(event: Event, messages: list) -> AssistantMsgSent:
+                @on(_UserMsgReceived, _ToolResultReturned)
+                def call_llm(event: Event, messages: list) -> _AssistantMsgSent:
                     message_snapshots.append(list(messages))
-                    if isinstance(event, UserMsgReceived):
-                        return AssistantMsgSent(content="need tool", needs_tool=True)
-                    return AssistantMsgSent(
+                    if isinstance(event, _UserMsgReceived):
+                        return _AssistantMsgSent(content="need tool", needs_tool=True)
+                    return _AssistantMsgSent(
                         content=f"got:{event.result}",
                         needs_tool=False,
                     )
 
-                @on(AssistantMsgSent)
-                def handle_response(
-                    event: AssistantMsgSent,
-                ) -> ToolResultReturned | FinalAnswerProduced:
-                    if event.needs_tool:
-                        return ToolResultReturned(result="42")
-                    return FinalAnswerProduced(answer=event.content)
-
-                graph = EventGraph([call_llm, handle_response], reducers=[r])
-                log = graph.invoke(UserMsgReceived(content="what is 6*7?"))
-                assert log.latest(FinalAnswerProduced) == (
-                    FinalAnswerProduced(answer="got:42")
+                graph = EventGraph([call_llm, _handle_response], reducers=[r])
+                log = graph.invoke(_UserMsgReceived(content="what is 6*7?"))
+                assert log.latest(_FinalAnswerProduced) == (
+                    _FinalAnswerProduced(answer="got:42")
                 )
                 assert message_snapshots[0] == [
                     ("system", "You are helpful"),
@@ -1923,28 +2031,19 @@ def describe_EventGraph():
         def when_no_matching_events():
 
             def it_defaults_to_none():
-                class Triggered(IntegrationEvent):
-                    pass
-
-                class Unmatched(IntegrationEvent):
-                    pass
-
-                class ResultProduced(IntegrationEvent):
-                    got: str = ""
-
                 sr = ScalarReducer(
                     name="mode",
-                    event_type=Unmatched,
+                    event_type=_Unmatched,
                     fn=lambda e: "irrelevant",
                 )
 
-                @on(Triggered)
-                def handle(event: Triggered, mode: object) -> ResultProduced:
-                    return ResultProduced(got=str(mode))
+                @on(_Triggered)
+                def handle(event: _Triggered, mode: object) -> _ResultProduced:
+                    return _ResultProduced(got=str(mode))
 
                 graph = EventGraph([handle], reducers=[sr])
-                log = graph.invoke(Triggered())
-                assert log.latest(ResultProduced) == ResultProduced(got="None")
+                log = graph.invoke(_Triggered())
+                assert log.latest(_ResultProduced) == _ResultProduced(got="None")
 
             def it_returns_skip():
                 class StepCompleted(IntegrationEvent):
@@ -1964,88 +2063,67 @@ def describe_EventGraph():
                 )
 
             def it_treats_skip_from_fn_as_no_contribution():
-                class Triggered(IntegrationEvent):
-                    pass
-
                 from langgraph_events import SKIP
 
                 sr = ScalarReducer(
                     name="mode",
-                    event_type=Triggered,
+                    event_type=_Triggered,
                     fn=lambda e: SKIP,
                     default="fallback",
                 )
 
-                result = sr.collect([Triggered()])
+                result = sr.collect([_Triggered()])
                 assert result is SKIP
                 assert sr.has_contributions(result) is False
-                assert sr.seed([Triggered()]) == "fallback"
+                assert sr.seed([_Triggered()]) == "fallback"
 
             def it_uses_custom_default():
-                class Triggered(IntegrationEvent):
-                    pass
-
-                class Unmatched(IntegrationEvent):
-                    pass
-
-                class ResultProduced(IntegrationEvent):
-                    got: str = ""
-
                 sr = ScalarReducer(
                     name="mode",
-                    event_type=Unmatched,
+                    event_type=_Unmatched,
                     fn=lambda e: "irrelevant",
                     default="fallback",
                 )
 
-                @on(Triggered)
-                def handle(event: Triggered, mode: str) -> ResultProduced:
-                    return ResultProduced(got=mode)
+                @on(_Triggered)
+                def handle(event: _Triggered, mode: str) -> _ResultProduced:
+                    return _ResultProduced(got=mode)
 
                 graph = EventGraph([handle], reducers=[sr])
-                log = graph.invoke(Triggered())
-                assert log.latest(ResultProduced) == ResultProduced(got="fallback")
+                log = graph.invoke(_Triggered())
+                assert log.latest(_ResultProduced) == _ResultProduced(got="fallback")
 
         def when_mixed_list_reducers():
 
             def it_works_alongside_list_reducers():
-                class Triggered(IntegrationEvent):
-                    tag: str = ""
-
-                class ResultProduced(IntegrationEvent):
-                    summary: str = ""
-
                 list_r = Reducer(
                     name="tags",
-                    event_type=Triggered,
+                    event_type=_Triggered,
                     fn=lambda e: [e.tag] if e.tag else [],
                 )
                 scalar_r = ScalarReducer(
                     name="last_tag",
-                    event_type=Triggered,
+                    event_type=_Triggered,
                     fn=lambda e: e.tag,
                 )
 
-                @on(Triggered)
+                @on(_Triggered)
                 def handle(
-                    event: Triggered,
+                    event: _Triggered,
                     tags: list,
                     last_tag: object,
-                ) -> ResultProduced:
-                    return ResultProduced(summary=f"tags={tags},last={last_tag}")
+                ) -> _ResultProduced:
+                    return _ResultProduced(summary=f"tags={tags},last={last_tag}")
 
                 graph = EventGraph([handle], reducers=[list_r, scalar_r])
-                log = graph.invoke(Triggered(tag="x"))
-                assert log.latest(ResultProduced) == (
-                    ResultProduced(summary="tags=['x'],last=x")
+                log = graph.invoke(_Triggered(tag="x"))
+                assert log.latest(_ResultProduced) == (
+                    _ResultProduced(summary="tags=['x'],last=x")
                 )
 
         def when_parallel_handlers():
 
             def it_handles_parallel_handler_contributions():
-                class Triggered(IntegrationEvent):
-                    value: str = ""
-
                 class ResultAProduced(IntegrationEvent):
                     data: str = ""
 
@@ -2057,7 +2135,7 @@ def describe_EventGraph():
                     event_type=Event,
                     fn=lambda e: (
                         e.value
-                        if isinstance(e, Triggered)
+                        if isinstance(e, _Triggered)
                         else (
                             e.data
                             if isinstance(e, (ResultAProduced, ResultBProduced))
@@ -2066,16 +2144,16 @@ def describe_EventGraph():
                     ),
                 )
 
-                @on(Triggered)
-                def handler_a(event: Triggered, latest: object) -> ResultAProduced:
+                @on(_Triggered)
+                def handler_a(event: _Triggered, latest: object) -> ResultAProduced:
                     return ResultAProduced(data=f"a:{event.value}")
 
-                @on(Triggered)
-                def handler_b(event: Triggered, latest: object) -> ResultBProduced:
+                @on(_Triggered)
+                def handler_b(event: _Triggered, latest: object) -> ResultBProduced:
                     return ResultBProduced(data=f"b:{event.value}")
 
                 graph = EventGraph([handler_a, handler_b], reducers=[sr])
-                log = graph.invoke(Triggered(value="x"))
+                log = graph.invoke(_Triggered(value="x"))
                 # Both handlers run in parallel — should not crash
                 assert log.has(ResultAProduced)
                 assert log.has(ResultBProduced)
@@ -2089,9 +2167,6 @@ def describe_EventGraph():
                 class UnrelatedReceived(IntegrationEvent):
                     pass
 
-                class ResultProduced(IntegrationEvent):
-                    got: str = ""
-
                 sr = ScalarReducer(
                     name="kept",
                     event_type=ValueSet,
@@ -2103,23 +2178,20 @@ def describe_EventGraph():
                     return UnrelatedReceived()
 
                 @on(UnrelatedReceived)
-                def step2(event: UnrelatedReceived, kept: object) -> ResultProduced:
-                    return ResultProduced(got=str(kept))
+                def step2(event: UnrelatedReceived, kept: object) -> _ResultProduced:
+                    return _ResultProduced(got=str(kept))
 
                 graph = EventGraph([step1, step2], reducers=[sr])
                 log = graph.invoke(ValueSet(value="hello"))
                 # Round 2 produces UnrelatedReceived (doesn't match event_type) —
                 # scalar must still be "hello", not reverted.
-                assert log.latest(ResultProduced) == ResultProduced(got="hello")
+                assert log.latest(_ResultProduced) == _ResultProduced(got="hello")
 
         def when_fn_returns_none():
 
             def it_stores_none_as_valid_contribution():
                 class ClearSignaled(IntegrationEvent):
                     pass
-
-                class ResultProduced(IntegrationEvent):
-                    got: str = ""
 
                 sr = ScalarReducer(
                     name="value",
@@ -2129,13 +2201,13 @@ def describe_EventGraph():
                 )
 
                 @on(ClearSignaled)
-                def handle(event: ClearSignaled, value: object) -> ResultProduced:
-                    return ResultProduced(got=repr(value))
+                def handle(event: ClearSignaled, value: object) -> _ResultProduced:
+                    return _ResultProduced(got=repr(value))
 
                 graph = EventGraph([handle], reducers=[sr])
                 log = graph.invoke(ClearSignaled())
                 # fn returns None — this is a real contribution, not "no contribution"
-                assert log.latest(ResultProduced) == ResultProduced(got="None")
+                assert log.latest(_ResultProduced) == _ResultProduced(got="None")
 
         def when_protocol_event_type():
 
@@ -2152,9 +2224,6 @@ def describe_EventGraph():
                 class ScoreBRecorded(IntegrationEvent):
                     score: int = 0
 
-                class ResultProduced(IntegrationEvent):
-                    got: str = ""
-
                 sr = ScalarReducer(
                     name="last_score",
                     event_type=HasScore,
@@ -2166,45 +2235,41 @@ def describe_EventGraph():
                     return ScoreBRecorded(score=event.score + 10)
 
                 @on(ScoreBRecorded)
-                def step_b(event: ScoreBRecorded, last_score: object) -> ResultProduced:
-                    return ResultProduced(got=str(last_score))
+                def step_b(
+                    event: ScoreBRecorded, last_score: object
+                ) -> _ResultProduced:
+                    return _ResultProduced(got=str(last_score))
 
                 graph = EventGraph([step_a, step_b], reducers=[sr])
                 log = graph.invoke(ScoreARecorded(score=5))
                 # ScoreA(5) → 5, then ScoreB(15) → 15
-                assert log.latest(ResultProduced) == ResultProduced(got="15")
+                assert log.latest(_ResultProduced) == _ResultProduced(got="15")
 
         def when_checkpointer():
 
             def it_does_not_lose_scalar_on_re_invoke():
                 from langgraph.checkpoint.memory import MemorySaver
 
-                class Triggered(IntegrationEvent):
-                    value: str = ""
-
-                class ResultProduced(IntegrationEvent):
-                    got: str = ""
-
                 sr = ScalarReducer(
                     name="latest",
-                    event_type=Triggered,
+                    event_type=_Triggered,
                     fn=lambda e: e.value,
                 )
 
-                @on(Triggered)
-                def handle(event: Triggered, latest: object) -> ResultProduced:
-                    return ResultProduced(got=str(latest))
+                @on(_Triggered)
+                def handle(event: _Triggered, latest: object) -> _ResultProduced:
+                    return _ResultProduced(got=str(latest))
 
                 graph = EventGraph([handle], reducers=[sr], checkpointer=MemorySaver())
                 config = {"configurable": {"thread_id": "scalar-re-invoke"}}
 
                 # Run 1
-                log1 = graph.invoke(Triggered(value="first"), config=config)
-                assert log1.latest(ResultProduced) == ResultProduced(got="first")
+                log1 = graph.invoke(_Triggered(value="first"), config=config)
+                assert log1.latest(_ResultProduced) == _ResultProduced(got="first")
 
                 # Run 2 — re-invoke on same thread
-                log2 = graph.invoke(Triggered(value="second"), config=config)
-                assert log2.latest(ResultProduced) == ResultProduced(got="second")
+                log2 = graph.invoke(_Triggered(value="second"), config=config)
+                assert log2.latest(_ResultProduced) == _ResultProduced(got="second")
 
     def describe_message_reducer():
 
@@ -2356,21 +2421,7 @@ def describe_EventGraph():
         def when_no_checkpointer():
 
             def it_returns_same_instance():
-                @on(Started)
-                def step(event: Started) -> Ended:
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step])
-                first = graph.compiled
-                second = graph.compiled
-                assert first is second
-
-            def it_returns_cached_instance_on_second_call():
-                @on(Started)
-                def step(event: Started) -> Ended:
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step])
+                graph = _echo_graph()
                 first = graph.compiled
                 second = graph.compiled
                 assert first is second
@@ -2378,13 +2429,7 @@ def describe_EventGraph():
         def when_checkpointer():
 
             def it_persists_state():
-                from langgraph.checkpoint.memory import MemorySaver
-
-                @on(Started)
-                def step(event: Started) -> Ended:
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step], checkpointer=MemorySaver())
+                graph = _echo_graph(checkpointer=MemorySaver())
 
                 config = {"configurable": {"thread_id": "test-1"}}
                 log = graph.invoke(Started(data="hello"), config=config)
@@ -2394,8 +2439,6 @@ def describe_EventGraph():
                 assert len(state.events) == 2
 
             def it_only_processes_new_events_on_re_invoke():
-                from langgraph.checkpoint.memory import MemorySaver
-
                 seen: list[list[str]] = []
 
                 @on(Started)
@@ -2417,13 +2460,7 @@ def describe_EventGraph():
                 assert seen[-1] == ["b"]
 
             def it_handles_three_sequential_re_invokes():
-                from langgraph.checkpoint.memory import MemorySaver
-
-                @on(Started)
-                def step(event: Started) -> Ended:
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step], checkpointer=MemorySaver())
+                graph = _echo_graph(checkpointer=MemorySaver())
                 config = {"configurable": {"thread_id": "re-invoke-3"}}
 
                 graph.invoke(Started(data="first"), config=config)
@@ -2442,15 +2479,7 @@ def describe_EventGraph():
         def when_default():
 
             def it_yields_event_objects():
-                @on(Started)
-                def step1(event: Started) -> Processed:
-                    return Processed(data=event.data)
-
-                @on(Processed)
-                def step2(event: Processed) -> Ended:
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step1, step2])
+                graph = _chain_graph()
                 events = list(graph.stream_events(Started(data="hi")))
                 assert all(isinstance(e, Event) for e in events)
                 types = [type(e).__name__ for e in events]
@@ -2459,15 +2488,7 @@ def describe_EventGraph():
                 assert "Ended" in types
 
             def it_yields_events_in_order():
-                @on(Started)
-                def step1(event: Started) -> Processed:
-                    return Processed(data="mid")
-
-                @on(Processed)
-                def step2(event: Processed) -> Ended:
-                    return Ended(result="done")
-
-                graph = EventGraph([step1, step2])
+                graph = _chain_graph()
                 events = list(graph.stream_events(Started(data="go")))
                 assert isinstance(events[0], Started)
                 assert isinstance(events[-1], Ended)
@@ -2475,11 +2496,7 @@ def describe_EventGraph():
         def when_multi_seed():
 
             def it_includes_all_seed_types():
-                @on(Started)
-                def step(event: Started) -> Ended:
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step])
+                graph = _echo_graph()
                 events = list(graph.stream_events([Started(data="a")]))
                 types = [type(e).__name__ for e in events]
                 assert "Started" in types
@@ -2488,17 +2505,7 @@ def describe_EventGraph():
         def when_include_reducers_true():
 
             def it_yields_stream_frames():
-                reducer = _data_reducer()
-
-                @on(Started)
-                def step1(event: Started) -> Processed:
-                    return Processed(data=event.data)
-
-                @on(Processed)
-                def step2(event: Processed) -> Ended:
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step1, step2], reducers=[reducer])
+                graph = _chain_graph(reducers=[_data_reducer()])
                 frames = list(
                     graph.stream_events(
                         Started(data="hello"),
@@ -2519,13 +2526,7 @@ def describe_EventGraph():
         def when_include_reducers_selective():
 
             def it_only_includes_named_reducers():
-                reducer = _data_reducer()
-
-                @on(Started)
-                def step(event: Started) -> Ended:
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step], reducers=[reducer])
+                graph = _echo_graph(reducers=[_data_reducer()])
                 frames = list(
                     graph.stream_events(
                         Started(data="x"),
@@ -2538,13 +2539,7 @@ def describe_EventGraph():
         def when_include_reducers_partial_overlap():
 
             def it_includes_only_valid_reducer_names():
-                reducer = _data_reducer()
-
-                @on(Started)
-                def step(event: Started) -> Ended:
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step], reducers=[reducer])
+                graph = _echo_graph(reducers=[_data_reducer()])
                 frames = list(
                     graph.stream_events(
                         Started(data="x"),
@@ -2559,13 +2554,7 @@ def describe_EventGraph():
         def when_include_reducers_unknown_name():
 
             def it_warns_about_unknown_reducer_names():
-                reducer = _data_reducer()
-
-                @on(Started)
-                def step(event: Started) -> Ended:
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step], reducers=[reducer])
+                graph = _echo_graph(reducers=[_data_reducer()])
                 with pytest.warns(
                     UserWarning,
                     match="Unknown reducer name.*nonexistent",
@@ -2578,13 +2567,7 @@ def describe_EventGraph():
                     )
 
             def it_falls_back_to_bare_events():
-                reducer = _data_reducer()
-
-                @on(Started)
-                def step(event: Started) -> Ended:
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step], reducers=[reducer])
+                graph = _echo_graph(reducers=[_data_reducer()])
                 frames = list(
                     graph.stream_events(
                         Started(data="x"),
@@ -2596,11 +2579,7 @@ def describe_EventGraph():
         def when_include_reducers_false():
 
             def it_yields_bare_event_objects():
-                @on(Started)
-                def step(event: Started) -> Ended:
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step])
+                graph = _echo_graph()
                 events = list(graph.stream_events(Started(data="hi")))
                 assert all(isinstance(e, Event) for e in events)
                 assert not any(isinstance(e, StreamFrame) for e in events)
@@ -2609,24 +2588,13 @@ def describe_EventGraph():
 
             @pytest.mark.asyncio
             async def it_yields_stream_frames():
-                reducer = _data_reducer()
-
-                @on(Started)
-                def step1(event: Started) -> Processed:
-                    return Processed(data=event.data)
-
-                @on(Processed)
-                def step2(event: Processed) -> Ended:
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step1, step2], reducers=[reducer])
-                frames = [
-                    f
-                    async for f in graph.astream_events(
+                graph = _chain_graph(reducers=[_data_reducer()])
+                frames = await _adrain(
+                    graph.astream_events(
                         Started(data="async"),
                         include_reducers=True,
                     )
-                ]
+                )
                 assert all(isinstance(f, StreamFrame) for f in frames)
                 types = [type(f.event).__name__ for f in frames]
                 assert "Started" in types
@@ -2664,22 +2632,20 @@ def describe_EventGraph():
 
     def describe_stream_resume():
 
-        def it_yields_resume_handler_events():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            @on(Started)
-            def need_input(event: Started) -> _StepInterrupted:
-                return _StepInterrupted(step=1)
-
-            @on(Completed)
-            def finish(event: Completed) -> Ended:
-                return Ended(result=event.result)
-
-            graph = EventGraph(
-                [need_input, finish],
-                checkpointer=MemorySaver(),
+        async def _v2_resume_frames(graph, config):
+            """Resume through the v2 path; return the ``StreamFrame``s yielded."""
+            frames = await _adrain(
+                graph.astream_resume(
+                    Completed(result="done"),
+                    include_reducers=True,
+                    include_custom_events=True,
+                    config=config,
+                )
             )
-            config = {"configurable": {"thread_id": "sr-handler"}}
+            return [f for f in frames if isinstance(f, StreamFrame)]
+
+        def it_yields_resume_handler_events():
+            graph, config = _interruptible_graph("sr-handler")
             graph.invoke(Started(data="go"), config=config)
 
             events = list(graph.stream_resume(Completed(result="done"), config=config))
@@ -2687,21 +2653,7 @@ def describe_EventGraph():
             assert "Ended" in types
 
         def it_includes_stale_interrupted_in_raw_stream():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            @on(Started)
-            def need_input(event: Started) -> _StepInterrupted:
-                return _StepInterrupted(step=1)
-
-            @on(Completed)
-            def finish(event: Completed) -> Ended:
-                return Ended(result=event.result)
-
-            graph = EventGraph(
-                [need_input, finish],
-                checkpointer=MemorySaver(),
-            )
-            config = {"configurable": {"thread_id": "sr-no-stale"}}
+            graph, config = _interruptible_graph("sr-no-stale")
             graph.invoke(Started(data="go"), config=config)
 
             events = list(graph.stream_resume(Completed(result="done"), config=config))
@@ -2709,23 +2661,9 @@ def describe_EventGraph():
             assert any(isinstance(e, Interrupted) for e in events)
 
         def it_yields_reducer_stream_frames():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            @on(Started)
-            def need_input(event: Started) -> _StepInterrupted:
-                return _StepInterrupted(step=1)
-
-            @on(Completed)
-            def finish(event: Completed) -> Ended:
-                return Ended(result=event.result)
-
-            reducer = _data_reducer()
-            graph = EventGraph(
-                [need_input, finish],
-                checkpointer=MemorySaver(),
-                reducers=[reducer],
+            graph, config = _interruptible_graph(
+                "sr-reducers", reducers=[_data_reducer()]
             )
-            config = {"configurable": {"thread_id": "sr-reducers"}}
             graph.invoke(Started(data="go"), config=config)
 
             frames = list(
@@ -2740,45 +2678,22 @@ def describe_EventGraph():
 
         @pytest.mark.asyncio
         async def it_yields_resume_events_async():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            @on(Started)
-            def need_input(event: Started) -> _StepInterrupted:
-                return _StepInterrupted(step=1)
-
-            @on(Completed)
-            def finish(event: Completed) -> Ended:
-                return Ended(result=event.result)
-
-            graph = EventGraph(
-                [need_input, finish],
-                checkpointer=MemorySaver(),
-            )
-            config = {"configurable": {"thread_id": "sr-async"}}
+            graph, config = _interruptible_graph("sr-async")
             await graph.ainvoke(Started(data="go"), config=config)
 
-            events = [
-                e
-                async for e in graph.astream_resume(
-                    Completed(result="async-done"), config=config
-                )
-            ]
+            events = await _adrain(
+                graph.astream_resume(Completed(result="async-done"), config=config)
+            )
             types = [type(e).__name__ for e in events]
             assert "Ended" in types
 
         def it_yields_new_interrupted_during_resume():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            @on(Started)
-            def step_one(event: Started) -> _StepInterrupted:
-                return _StepInterrupted(step=1)
-
             @on(Completed)
             def step_two(event: Completed) -> _StepInterrupted:
                 return _StepInterrupted(step=2)
 
             graph = EventGraph(
-                [step_one, step_two],
+                [_pause_at_step_one, step_two],
                 checkpointer=MemorySaver(),
             )
             config = {"configurable": {"thread_id": "sr-new-interrupt"}}
@@ -2802,24 +2717,8 @@ def describe_EventGraph():
 
         @pytest.mark.asyncio
         async def it_preserves_reducer_state_from_checkpoint_in_v2():
-            from langgraph.checkpoint.memory import MemorySaver
-
             r = Reducer("texts", event_type=MessageReceived, fn=lambda e: [e.text])
-
-            @on(Started)
-            def need_input(event: Started) -> _StepInterrupted:
-                return _StepInterrupted(step=1)
-
-            @on(Completed)
-            def finish(event: Completed) -> Ended:
-                return Ended(result=event.result)
-
-            graph = EventGraph(
-                [need_input, finish],
-                checkpointer=MemorySaver(),
-                reducers=[r],
-            )
-            config = {"configurable": {"thread_id": "v2-resume-reducer"}}
+            graph, config = _interruptible_graph("v2-resume-reducer", reducers=[r])
 
             # First run — seed with MessageReceived to populate reducer, then
             # interrupt via Started → _StepInterrupted.
@@ -2828,25 +2727,13 @@ def describe_EventGraph():
             )
 
             # Resume via _astream_v2 path (include_custom_events forces v2)
-            frames = [
-                item
-                async for item in graph.astream_resume(
-                    Completed(result="done"),
-                    include_reducers=True,
-                    include_custom_events=True,
-                    config=config,
-                )
-            ]
-
-            stream_frames = [f for f in frames if isinstance(f, StreamFrame)]
+            stream_frames = await _v2_resume_frames(graph, config)
             assert len(stream_frames) > 0
             # Reducer must reflect checkpoint state ("hello" from first run)
             assert "hello" in stream_frames[0].reducers["texts"]
 
         @pytest.mark.asyncio
         async def it_accumulates_reducer_across_v2_astream_events_runs():
-            from langgraph.checkpoint.memory import MemorySaver
-
             r = Reducer("texts", event_type=MessageReceived, fn=lambda e: [e.text])
 
             @on(MessageReceived)
@@ -2860,27 +2747,19 @@ def describe_EventGraph():
             )
             config = {"configurable": {"thread_id": "v2-second-run"}}
 
-            # First run via astream_events (v2 path)
-            _ = [
-                item
-                async for item in graph.astream_events(
-                    MessageReceived(text="first"),
+            def _v2_run(text: str):
+                return graph.astream_events(
+                    MessageReceived(text=text),
                     include_reducers=True,
                     include_custom_events=True,
                     config=config,
                 )
-            ]
+
+            # First run via astream_events (v2 path)
+            _ = await _adrain(_v2_run("first"))
 
             # Second run on same thread — seed contributes on top of checkpoint
-            frames = [
-                item
-                async for item in graph.astream_events(
-                    MessageReceived(text="second"),
-                    include_reducers=True,
-                    include_custom_events=True,
-                    config=config,
-                )
-            ]
+            frames = await _adrain(_v2_run("second"))
 
             stream_frames = [f for f in frames if isinstance(f, StreamFrame)]
             assert len(stream_frames) > 0
@@ -2890,28 +2769,12 @@ def describe_EventGraph():
 
         @pytest.mark.asyncio
         async def it_preserves_scalar_reducer_from_checkpoint_in_v2():
-            from langgraph.checkpoint.memory import MemorySaver
-
             sr = ScalarReducer(
                 name="proposal",
                 event_type=MessageReceived,
                 fn=lambda e: e.text,
             )
-
-            @on(Started)
-            def need_input(event: Started) -> _StepInterrupted:
-                return _StepInterrupted(step=1)
-
-            @on(Completed)
-            def finish(event: Completed) -> Ended:
-                return Ended(result=event.result)
-
-            graph = EventGraph(
-                [need_input, finish],
-                checkpointer=MemorySaver(),
-                reducers=[sr],
-            )
-            config = {"configurable": {"thread_id": "v2-scalar-resume"}}
+            graph, config = _interruptible_graph("v2-scalar-resume", reducers=[sr])
 
             # First run — MessageReceived populates scalar, Started interrupts
             graph.invoke(
@@ -2919,17 +2782,7 @@ def describe_EventGraph():
             )
 
             # Resume via v2 path
-            frames = [
-                item
-                async for item in graph.astream_resume(
-                    Completed(result="done"),
-                    include_reducers=True,
-                    include_custom_events=True,
-                    config=config,
-                )
-            ]
-
-            stream_frames = [f for f in frames if isinstance(f, StreamFrame)]
+            stream_frames = await _v2_resume_frames(graph, config)
             assert len(stream_frames) > 0
             assert stream_frames[0].reducers["proposal"] == "chosen"
 
@@ -3224,21 +3077,7 @@ def describe_EventGraph():
                     RunPaused being a SystemEvent rather than a Halted
                     subclass — MaxRoundsExceeded would re-terminate here.
                     """
-                    from langgraph.checkpoint.memory import MemorySaver
-
-                    @on(Started)
-                    def to_processed(event: Started) -> Processed:
-                        return Processed(data=event.data)
-
-                    @on(MessageReceived)
-                    def to_ended(event: MessageReceived) -> Ended:
-                        return Ended(result=event.text)
-
-                    graph = EventGraph(
-                        [to_processed, to_ended],
-                        checkpointer=MemorySaver(),
-                    )
-                    config = {"configurable": {"thread_id": "deadline-resume"}}
+                    graph, config = _deadline_graph("deadline-resume")
 
                     # Run 1: deadline already expired → RunPaused emitted.
                     log1 = graph.invoke(
@@ -3377,21 +3216,7 @@ def describe_EventGraph():
                     the second run would inherit a stuck flag and
                     drain silently with no ``RunPaused`` event.
                     """
-                    from langgraph.checkpoint.memory import MemorySaver
-
-                    @on(Started)
-                    def to_processed(event: Started) -> Processed:
-                        return Processed(data=event.data)
-
-                    @on(MessageReceived)
-                    def to_ended(event: MessageReceived) -> Ended:
-                        return Ended(result=event.text)
-
-                    graph = EventGraph(
-                        [to_processed, to_ended],
-                        checkpointer=MemorySaver(),
-                    )
-                    config = {"configurable": {"thread_id": "double-pause"}}
+                    graph, config = _deadline_graph("double-pause")
 
                     log1 = graph.invoke(
                         Started(data="first"), deadline=0.0, config=config
@@ -3643,47 +3468,20 @@ def describe_EventGraph():
                 assert "-->|handler|" in output
                 assert "-->|handler_2|" in output
 
+            def _deduped_metas(handlers, prefix: str):
+                """Handler metas whose name starts with ``prefix`` after dedup."""
+                graph = EventGraph(handlers)
+                return [m for m in graph._handler_metas if m.name.startswith(prefix)]
+
             def it_preserves_raises_on_deduped_copies():
-                from langgraph_events import HandlerRaised
-
-                class _DedupError(Exception):
-                    pass
-
-                @on(Started, raises=_DedupError)
-                def raiser(event: Started) -> Ended:
-                    raise _DedupError("boom")
-
-                @on(HandlerRaised, exception=_DedupError)
-                def catcher(event: HandlerRaised) -> Ended:
-                    return Ended(result="caught")
-
-                graph = EventGraph([raiser, raiser, catcher])
-                raisers = [
-                    m for m in graph._handler_metas if m.name.startswith("raiser")
-                ]
+                raisers = _deduped_metas([_raiser, _raiser, _catcher], "_raiser")
                 assert len(raisers) == 2
                 # Without the fix, the second copy's raises= is silently dropped
                 for m in raisers:
                     assert m.raises == (_DedupError,)
 
             def it_preserves_field_matchers_on_deduped_copies():
-                from langgraph_events import HandlerRaised
-
-                class _DedupError(Exception):
-                    pass
-
-                @on(Started, raises=_DedupError)
-                def raiser(event: Started) -> Ended:
-                    raise _DedupError("boom")
-
-                @on(HandlerRaised, exception=_DedupError)
-                def catcher(event: HandlerRaised) -> Ended:
-                    return Ended(result="caught")
-
-                graph = EventGraph([raiser, catcher, catcher])
-                catchers = [
-                    m for m in graph._handler_metas if m.name.startswith("catcher")
-                ]
+                catchers = _deduped_metas([_raiser, _catcher, _catcher], "_catcher")
                 assert len(catchers) == 2
                 # Without the fix, the second copy becomes a universal catcher
                 for m in catchers:
@@ -3723,137 +3521,96 @@ def describe_EventGraph():
 
         def describe_custom_event_helpers():
 
-            @pytest.mark.asyncio
-            async def it_emits_custom_frames_from_sync_handler():
+            @on(Started)
+            def _emit_custom_sync(event: Started) -> Ended:
+                emit_custom("tool.progress", {"pct": 25})
+                return Ended(result=event.data)
 
-                @on(Started)
-                def step(event: Started) -> Ended:
-                    emit_custom("tool.progress", {"pct": 25})
-                    return Ended(result=event.data)
+            @on(Started)
+            async def _emit_custom_async(event: Started) -> Ended:
+                await aemit_custom("tool.progress", {"pct": 80})
+                return Ended(result=event.data)
 
-                graph = EventGraph([step])
-                items = [
-                    item
-                    async for item in graph.astream_events(
+            @on(Started)
+            def _emit_snapshot_sync(event: Started) -> Ended:
+                emit_state_snapshot({"step": "draft"})
+                return Ended(result=event.data)
+
+            @on(Started)
+            async def _emit_snapshot_async(event: Started) -> Ended:
+                await aemit_state_snapshot({"step": "review"})
+                return Ended(result=event.data)
+
+            async def _frames_from(step):
+                """Stream a one-handler graph with custom events switched on."""
+                return await _adrain(
+                    EventGraph([step]).astream_events(
                         Started(data="hello"),
                         include_custom_events=True,
                     )
-                ]
+                )
+
+            @pytest.mark.asyncio
+            @pytest.mark.parametrize(
+                "step, pct",
+                [(_emit_custom_sync, 25), (_emit_custom_async, 80)],
+                ids=["sync_handler", "async_handler"],
+            )
+            async def it_emits_custom_frames(step, pct):
+                items = await _frames_from(step)
 
                 custom_frames = [i for i in items if isinstance(i, CustomEventFrame)]
                 assert len(custom_frames) == 1
                 assert custom_frames[0].name == "tool.progress"
-                assert custom_frames[0].data == {"pct": 25}
+                assert custom_frames[0].data == {"pct": pct}
 
             @pytest.mark.asyncio
-            async def it_emits_custom_frames_from_async_handler():
-
-                @on(Started)
-                async def step(event: Started) -> Ended:
-                    await aemit_custom("tool.progress", {"pct": 80})
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step])
-                items = [
-                    item
-                    async for item in graph.astream_events(
-                        Started(data="hello"),
-                        include_custom_events=True,
-                    )
-                ]
-
-                custom_frames = [i for i in items if isinstance(i, CustomEventFrame)]
-                assert len(custom_frames) == 1
-                assert custom_frames[0].name == "tool.progress"
-                assert custom_frames[0].data == {"pct": 80}
-
-            @pytest.mark.asyncio
-            async def it_emits_state_snapshot_frames_from_sync_handler():
-                @on(Started)
-                def step(event: Started) -> Ended:
-                    emit_state_snapshot({"step": "draft"})
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step])
-                items = [
-                    item
-                    async for item in graph.astream_events(
-                        Started(data="hello"),
-                        include_custom_events=True,
-                    )
-                ]
+            @pytest.mark.parametrize(
+                "step, stage",
+                [(_emit_snapshot_sync, "draft"), (_emit_snapshot_async, "review")],
+                ids=["sync_handler", "async_handler"],
+            )
+            async def it_emits_state_snapshot_frames(step, stage):
+                items = await _frames_from(step)
 
                 snapshots = [i for i in items if isinstance(i, StateSnapshotFrame)]
                 assert len(snapshots) == 1
-                assert snapshots[0].data == {"step": "draft"}
+                assert snapshots[0].data == {"step": stage}
+
+            @pytest.mark.parametrize(
+                "emit",
+                [
+                    lambda: emit_custom("tool.progress", {"pct": 1}),
+                    lambda: emit_state_snapshot({"step": "x"}),
+                ],
+                ids=["emit_custom", "emit_state_snapshot"],
+            )
+            def it_raises_for_a_sync_emit_outside_a_handler(emit):
+                with pytest.raises(RuntimeError, match="while an EventGraph handler"):
+                    emit()
 
             @pytest.mark.asyncio
-            async def it_emits_state_snapshot_frames_from_async_handler():
-                @on(Started)
-                async def step(event: Started) -> Ended:
-                    await aemit_state_snapshot({"step": "review"})
-                    return Ended(result=event.data)
-
-                graph = EventGraph([step])
-                items = [
-                    item
-                    async for item in graph.astream_events(
-                        Started(data="hello"),
-                        include_custom_events=True,
-                    )
-                ]
-
-                snapshots = [i for i in items if isinstance(i, StateSnapshotFrame)]
-                assert len(snapshots) == 1
-                assert snapshots[0].data == {"step": "review"}
-
-            def it_raises_for_emit_custom_outside_handler():
+            @pytest.mark.parametrize(
+                "aemit",
+                [
+                    lambda: aemit_custom("tool.progress", {"pct": 1}),
+                    lambda: aemit_state_snapshot({"step": "x"}),
+                ],
+                ids=["aemit_custom", "aemit_state_snapshot"],
+            )
+            async def it_raises_for_an_async_emit_outside_a_handler(aemit):
                 with pytest.raises(RuntimeError, match="while an EventGraph handler"):
-                    emit_custom("tool.progress", {"pct": 1})
-
-            def it_raises_for_emit_state_snapshot_outside_handler():
-                with pytest.raises(RuntimeError, match="while an EventGraph handler"):
-                    emit_state_snapshot({"step": "x"})
-
-            @pytest.mark.asyncio
-            async def it_raises_for_aemit_custom_outside_handler():
-                with pytest.raises(RuntimeError, match="while an EventGraph handler"):
-                    await aemit_custom("tool.progress", {"pct": 1})
-
-            @pytest.mark.asyncio
-            async def it_raises_for_aemit_state_snapshot_outside_handler():
-                with pytest.raises(RuntimeError, match="while an EventGraph handler"):
-                    await aemit_state_snapshot({"step": "x"})
+                    await aemit()
 
         @pytest.mark.asyncio
         async def it_yields_llm_token_and_stream_end_frames():
-            from typing import Any
-
-            from langchain_core.language_models.fake_chat_models import (
-                FakeListChatModel,
-            )
-
-            llm = FakeListChatModel(responses=["hello world"], sleep=0)
-
-            class UserSent(IntegrationEvent, MessageEvent):
-                message: HumanMessage = None  # type: ignore[assignment]
-
-            class AgentReplied(IntegrationEvent, MessageEvent):
-                message: AIMessage = None  # type: ignore[assignment]
-
-            @on(UserSent)
-            async def reply(event: UserSent, messages: list[Any]) -> AgentReplied:
-                response = await llm.ainvoke([*messages, HumanMessage(content="hi")])
-                return AgentReplied(message=response)
-
-            graph = EventGraph([reply], reducers=[message_reducer()])
-            items = [
-                item
-                async for item in graph.astream_events(
-                    UserSent(message=HumanMessage(content="hi")),
+            graph = _llm_graph("hello world")
+            items = await _adrain(
+                graph.astream_events(
+                    _UserSent(message=HumanMessage(content="hi")),
                     include_llm_tokens=True,
                 )
-            ]
+            )
 
             tokens = [i for i in items if isinstance(i, LLMToken)]
             ends = [i for i in items if isinstance(i, LLMStreamEnd)]
@@ -3868,33 +3625,13 @@ def describe_EventGraph():
 
         @pytest.mark.asyncio
         async def it_yields_domain_events_alongside_llm_tokens():
-            from typing import Any
-
-            from langchain_core.language_models.fake_chat_models import (
-                FakeListChatModel,
-            )
-
-            llm = FakeListChatModel(responses=["reply"], sleep=0)
-
-            class UserSent(IntegrationEvent, MessageEvent):
-                message: HumanMessage = None  # type: ignore[assignment]
-
-            class AgentReplied(IntegrationEvent, MessageEvent):
-                message: AIMessage = None  # type: ignore[assignment]
-
-            @on(UserSent)
-            async def reply(event: UserSent, messages: list[Any]) -> AgentReplied:
-                response = await llm.ainvoke([*messages, HumanMessage(content="hi")])
-                return AgentReplied(message=response)
-
-            graph = EventGraph([reply], reducers=[message_reducer()])
-            items = [
-                item
-                async for item in graph.astream_events(
-                    UserSent(message=HumanMessage(content="hi")),
+            graph = _llm_graph("reply")
+            items = await _adrain(
+                graph.astream_events(
+                    _UserSent(message=HumanMessage(content="hi")),
                     include_llm_tokens=True,
                 )
-            ]
+            )
 
             domain_events = [i for i in items if isinstance(i, Event)]
             tokens = [i for i in items if isinstance(i, LLMToken)]
@@ -3903,34 +3640,14 @@ def describe_EventGraph():
 
         @pytest.mark.asyncio
         async def it_yields_reducer_frames_and_tokens():
-            from typing import Any
-
-            from langchain_core.language_models.fake_chat_models import (
-                FakeListChatModel,
-            )
-
-            llm = FakeListChatModel(responses=["hi back"], sleep=0)
-
-            class UserSent(IntegrationEvent, MessageEvent):
-                message: HumanMessage = None  # type: ignore[assignment]
-
-            class AgentReplied(IntegrationEvent, MessageEvent):
-                message: AIMessage = None  # type: ignore[assignment]
-
-            @on(UserSent)
-            async def reply(event: UserSent, messages: list[Any]) -> AgentReplied:
-                response = await llm.ainvoke([*messages, HumanMessage(content="go")])
-                return AgentReplied(message=response)
-
-            graph = EventGraph([reply], reducers=[message_reducer()])
-            items = [
-                item
-                async for item in graph.astream_events(
-                    UserSent(message=HumanMessage(content="go")),
+            graph = _llm_graph("hi back", prompt="go")
+            items = await _adrain(
+                graph.astream_events(
+                    _UserSent(message=HumanMessage(content="go")),
                     include_reducers=True,
                     include_llm_tokens=True,
                 )
-            ]
+            )
 
             frames = [i for i in items if isinstance(i, StreamFrame)]
             tokens = [i for i in items if isinstance(i, LLMToken)]
@@ -3945,25 +3662,14 @@ def describe_EventGraph():
 
         @pytest.mark.asyncio
         async def it_reports_empty_changed_reducers_for_non_matching_events():
-            reducer = _data_reducer()
-
-            @on(Started)
-            def step1(event: Started) -> Processed:
-                return Processed(data=f"mid:{event.data}")
-
-            @on(Processed)
-            def step2(event: Processed) -> Ended:
-                return Ended(result=event.data)
-
-            graph = EventGraph([step1, step2], reducers=[reducer])
-            items = [
-                item
-                async for item in graph.astream_events(
+            graph = _chain_graph(reducers=[_data_reducer()])
+            items = await _adrain(
+                graph.astream_events(
                     Started(data="x"),
                     include_reducers=True,
                     include_llm_tokens=True,
                 )
-            ]
+            )
 
             frames = [i for i in items if isinstance(i, StreamFrame)]
             assert len(frames) >= 3
@@ -3974,48 +3680,30 @@ def describe_EventGraph():
         @pytest.mark.asyncio
         async def it_omits_tokens_by_default():
             """Without include_llm_tokens, no LLMToken/LLMStreamEnd are yielded."""
-
-            @on(Started)
-            def step(event: Started) -> Ended:
-                return Ended(result=event.data)
-
-            graph = EventGraph([step])
-            items = [item async for item in graph.astream_events(Started(data="hi"))]
+            graph = _echo_graph()
+            items = await _adrain(graph.astream_events(Started(data="hi")))
             assert all(isinstance(i, Event) for i in items)
             assert not any(isinstance(i, (LLMToken, LLMStreamEnd)) for i in items)
 
         @pytest.mark.asyncio
         async def it_yields_custom_event_frames_from_v2_custom_events(monkeypatch):
+            graph = _echo_graph()
+            monkeypatch.setattr(
+                graph.compiled,
+                "astream_events",
+                _fake_astream_events(
+                    _custom_payload("progress", {"pct": 50}),
+                    _custom_payload(STATE_SNAPSHOT_EVENT_NAME, {"step": "draft"}),
+                ),
+            )
 
-            @on(Started)
-            def step(event: Started) -> Ended:
-                return Ended(result=event.data)
-
-            graph = EventGraph([step])
-
-            async def fake_astream_events(*args, **kwargs):
-                del args, kwargs
-                yield {
-                    "event": "on_custom_event",
-                    "name": "progress",
-                    "data": {"pct": 50},
-                }
-                yield {
-                    "event": "on_custom_event",
-                    "name": STATE_SNAPSHOT_EVENT_NAME,
-                    "data": {"step": "draft"},
-                }
-
-            monkeypatch.setattr(graph.compiled, "astream_events", fake_astream_events)
-
-            items = [
-                item
-                async for item in graph.astream_events(
+            items = await _adrain(
+                graph.astream_events(
                     Started(data="hi"),
                     include_llm_tokens=True,
                     include_custom_events=True,
                 )
-            ]
+            )
 
             custom_frames = [i for i in items if isinstance(i, CustomEventFrame)]
             assert len(custom_frames) == 1
@@ -4028,28 +3716,20 @@ def describe_EventGraph():
 
         @pytest.mark.asyncio
         async def it_does_not_yield_custom_event_frames_by_default(monkeypatch):
-
-            @on(Started)
-            def step(event: Started) -> Ended:
-                return Ended(result=event.data)
-
-            graph = EventGraph([step])
+            graph = _echo_graph()
 
             called = False
+            fake = _fake_astream_events(_custom_payload("progress", {"pct": 50}))
 
-            async def fake_astream_events(*args, **kwargs):
+            async def tracking_fake(*args, **kwargs):
                 nonlocal called
                 called = True
-                del args, kwargs
-                yield {
-                    "event": "on_custom_event",
-                    "name": "progress",
-                    "data": {"pct": 50},
-                }
+                async for payload in fake(*args, **kwargs):
+                    yield payload
 
-            monkeypatch.setattr(graph.compiled, "astream_events", fake_astream_events)
+            monkeypatch.setattr(graph.compiled, "astream_events", tracking_fake)
 
-            items = [item async for item in graph.astream_events(Started(data="hi"))]
+            items = await _adrain(graph.astream_events(Started(data="hi")))
             assert not any(isinstance(i, CustomEventFrame) for i in items)
             # Default flags route to _astream_core, not v2 — confirm the fake
             # was not called so the test's intent is clear.
@@ -4057,94 +3737,56 @@ def describe_EventGraph():
 
         @pytest.mark.asyncio
         async def it_filters_custom_events_in_v2_path(monkeypatch):
-
-            @on(Started)
-            def step(event: Started) -> Ended:
-                return Ended(result=event.data)
-
-            graph = EventGraph([step])
-
-            async def fake_astream_events(*args, **kwargs):
-                del args, kwargs
-                yield {
-                    "event": "on_custom_event",
-                    "name": "progress",
-                    "data": {"pct": 50},
-                }
-
-            monkeypatch.setattr(graph.compiled, "astream_events", fake_astream_events)
+            graph = _echo_graph()
+            monkeypatch.setattr(
+                graph.compiled,
+                "astream_events",
+                _fake_astream_events(_custom_payload("progress", {"pct": 50})),
+            )
 
             # include_llm_tokens routes to _astream_v2 but custom events off
-            items = [
-                item
-                async for item in graph.astream_events(
+            items = await _adrain(
+                graph.astream_events(
                     Started(data="hi"),
                     include_llm_tokens=True,
                     include_custom_events=False,
                 )
-            ]
+            )
             assert not any(isinstance(i, CustomEventFrame) for i in items)
 
         @pytest.mark.asyncio
-        async def it_yields_custom_event_frames_on_opt_in(
-            monkeypatch,
-        ):
+        async def it_yields_custom_event_frames_on_opt_in(monkeypatch):
+            graph = _echo_graph()
+            monkeypatch.setattr(
+                graph.compiled,
+                "astream_events",
+                _fake_astream_events(_custom_payload("progress", {"pct": 50})),
+            )
 
-            @on(Started)
-            def step(event: Started) -> Ended:
-                return Ended(result=event.data)
-
-            graph = EventGraph([step])
-
-            async def fake_astream_events(*args, **kwargs):
-                del args, kwargs
-                yield {
-                    "event": "on_custom_event",
-                    "name": "progress",
-                    "data": {"pct": 50},
-                }
-
-            monkeypatch.setattr(graph.compiled, "astream_events", fake_astream_events)
-
-            items = [
-                item
-                async for item in graph.astream_events(
+            items = await _adrain(
+                graph.astream_events(
                     Started(data="hi"),
                     include_custom_events=True,
                 )
-            ]
+            )
             custom_frames = [i for i in items if isinstance(i, CustomEventFrame)]
             assert len(custom_frames) == 1
 
         @pytest.mark.asyncio
-        async def it_yields_custom_event_frames_in_astream_resume(
-            monkeypatch,
-        ):
-            from langgraph.checkpoint.memory import MemorySaver
+        async def it_yields_custom_event_frames_in_astream_resume(monkeypatch):
+            graph = _echo_graph(checkpointer=MemorySaver())
+            monkeypatch.setattr(
+                graph.compiled,
+                "astream_events",
+                _fake_astream_events(_custom_payload("resume.progress", {"pct": 90})),
+            )
 
-            @on(Started)
-            def step(event: Started) -> Ended:
-                return Ended(result=event.data)
-
-            graph = EventGraph([step], checkpointer=MemorySaver())
-
-            async def fake_astream_events(*args, **kwargs):
-                del args, kwargs
-                yield {
-                    "event": "on_custom_event",
-                    "name": "resume.progress",
-                    "data": {"pct": 90},
-                }
-
-            monkeypatch.setattr(graph.compiled, "astream_events", fake_astream_events)
-
-            items = [
-                item
-                async for item in graph.astream_resume(
+            items = await _adrain(
+                graph.astream_resume(
                     Started(data="resume"),
                     include_custom_events=True,
                 )
-            ]
+            )
 
             custom_frames = [i for i in items if isinstance(i, CustomEventFrame)]
             assert len(custom_frames) == 1
@@ -4156,66 +3798,26 @@ def describe_EventGraph():
 
                 @pytest.mark.asyncio
                 async def it_yields_frames_per_tool_call_chunk(monkeypatch):
-                    from langchain_core.messages import AIMessageChunk
-
-                    from langgraph_events._graph import LLMToolCallChunk
-
-                    @on(Started)
-                    def step(event: Started) -> Ended:
-                        return Ended(result=event.data)
-
-                    graph = EventGraph([step])
-
-                    async def fake_astream_events(*args, **kwargs):
-                        del args, kwargs
-                        yield {
-                            "event": "on_chat_model_stream",
-                            "run_id": "run-x",
-                            "data": {
-                                "chunk": AIMessageChunk(
-                                    content="",
-                                    tool_call_chunks=[
-                                        {
-                                            "name": "search",
-                                            "args": "",
-                                            "id": "tc-1",
-                                            "index": 0,
-                                            "type": "tool_call_chunk",
-                                        },
-                                    ],
-                                ),
-                            },
-                        }
-                        yield {
-                            "event": "on_chat_model_stream",
-                            "run_id": "run-x",
-                            "data": {
-                                "chunk": AIMessageChunk(
-                                    content="",
-                                    tool_call_chunks=[
-                                        {
-                                            "name": "",
-                                            "args": '{"q":"hi"}',
-                                            "id": "",
-                                            "index": 0,
-                                            "type": "tool_call_chunk",
-                                        },
-                                    ],
-                                ),
-                            },
-                        }
-
+                    graph = _echo_graph()
                     monkeypatch.setattr(
-                        graph.compiled, "astream_events", fake_astream_events
+                        graph.compiled,
+                        "astream_events",
+                        _fake_astream_events(
+                            _chat_payload(_tool_call_chunk_message()),
+                            _chat_payload(
+                                _tool_call_chunk_message(
+                                    name="", args='{"q":"hi"}', tool_call_id=""
+                                )
+                            ),
+                        ),
                     )
 
-                    items = [
-                        item
-                        async for item in graph.astream_events(
+                    items = await _adrain(
+                        graph.astream_events(
                             Started(data="hi"),
                             include_llm_tokens=True,
                         )
-                    ]
+                    )
 
                     chunks = [i for i in items if isinstance(i, LLMToolCallChunk)]
                     assert len(chunks) == 2
@@ -4228,48 +3830,21 @@ def describe_EventGraph():
 
                 @pytest.mark.asyncio
                 async def it_yields_both_text_and_tool_call_from_one_chunk(monkeypatch):
-                    from langchain_core.messages import AIMessageChunk
-
-                    from langgraph_events._graph import LLMToken, LLMToolCallChunk
-
-                    @on(Started)
-                    def step(event: Started) -> Ended:
-                        return Ended(result=event.data)
-
-                    graph = EventGraph([step])
-
-                    async def fake_astream_events(*args, **kwargs):
-                        del args, kwargs
-                        yield {
-                            "event": "on_chat_model_stream",
-                            "run_id": "run-x",
-                            "data": {
-                                "chunk": AIMessageChunk(
-                                    content="thinking…",
-                                    tool_call_chunks=[
-                                        {
-                                            "name": "search",
-                                            "args": "",
-                                            "id": "tc-1",
-                                            "index": 0,
-                                            "type": "tool_call_chunk",
-                                        },
-                                    ],
-                                ),
-                            },
-                        }
-
+                    graph = _echo_graph()
                     monkeypatch.setattr(
-                        graph.compiled, "astream_events", fake_astream_events
+                        graph.compiled,
+                        "astream_events",
+                        _fake_astream_events(
+                            _chat_payload(_tool_call_chunk_message("thinking…"))
+                        ),
                     )
 
-                    items = [
-                        item
-                        async for item in graph.astream_events(
+                    items = await _adrain(
+                        graph.astream_events(
                             Started(data="hi"),
                             include_llm_tokens=True,
                         )
-                    ]
+                    )
 
                     tokens = [i for i in items if isinstance(i, LLMToken)]
                     chunks = [i for i in items if isinstance(i, LLMToolCallChunk)]
@@ -4282,84 +3857,32 @@ def describe_EventGraph():
 
                 @pytest.mark.asyncio
                 async def it_suppresses_chunks(monkeypatch):
-                    from langchain_core.messages import AIMessageChunk
-
-                    from langgraph_events._graph import LLMToolCallChunk
-
-                    @on(Started)
-                    def step(event: Started) -> Ended:
-                        return Ended(result=event.data)
-
-                    graph = EventGraph([step])
-
-                    async def fake_astream_events(*args, **kwargs):
-                        del args, kwargs
-                        yield {
-                            "event": "on_chat_model_stream",
-                            "run_id": "run-x",
-                            "data": {
-                                "chunk": AIMessageChunk(
-                                    content="",
-                                    tool_call_chunks=[
-                                        {
-                                            "name": "search",
-                                            "args": "",
-                                            "id": "tc-1",
-                                            "index": 0,
-                                            "type": "tool_call_chunk",
-                                        },
-                                    ],
-                                ),
-                            },
-                        }
-
+                    graph = _echo_graph()
                     monkeypatch.setattr(
-                        graph.compiled, "astream_events", fake_astream_events
+                        graph.compiled,
+                        "astream_events",
+                        _fake_astream_events(_chat_payload(_tool_call_chunk_message())),
                     )
 
-                    items = [
-                        item
-                        async for item in graph.astream_events(
+                    items = await _adrain(
+                        graph.astream_events(
                             Started(data="hi"),
                             include_custom_events=True,
                         )
-                    ]
+                    )
                     assert not any(isinstance(i, LLMToolCallChunk) for i in items)
 
             def when_chunk_missing_index():
 
                 @pytest.mark.asyncio
                 async def it_raises(monkeypatch):
-                    from langchain_core.messages import AIMessageChunk
-
-                    @on(Started)
-                    def step(event: Started) -> Ended:
-                        return Ended(result=event.data)
-
-                    graph = EventGraph([step])
-
-                    async def fake_astream_events(*args, **kwargs):
-                        del args, kwargs
-                        yield {
-                            "event": "on_chat_model_stream",
-                            "run_id": "run-x",
-                            "data": {
-                                "chunk": AIMessageChunk(
-                                    content="",
-                                    tool_call_chunks=[
-                                        {
-                                            "name": "search",
-                                            "args": "",
-                                            "id": "tc-1",
-                                            "type": "tool_call_chunk",
-                                        },
-                                    ],
-                                ),
-                            },
-                        }
-
+                    graph = _echo_graph()
                     monkeypatch.setattr(
-                        graph.compiled, "astream_events", fake_astream_events
+                        graph.compiled,
+                        "astream_events",
+                        _fake_astream_events(
+                            _chat_payload(_tool_call_chunk_message(index=None))
+                        ),
                     )
 
                     with pytest.raises(ValueError, match=r"missing 'index'"):
@@ -4659,62 +4182,50 @@ class _Go(IntegrationEvent):
     pass
 
 
+@on(Started)
+def _waiter(event: Started) -> _Pause:
+    """Pauses the run so resume-policy suites have an interrupted thread."""
+    return _Pause()
+
+
+@on(_Go)
+def _go_noop(event: _Go) -> None:
+    """Resume-side handler that produces nothing."""
+    return None
+
+
+@on(_Go)
+def _go_ends(event: _Go) -> Ended:
+    """Resume-side handler that completes the run."""
+    return Ended(result="went")
+
+
+def _resumable_pair(saver, tid: str, **kwargs: typing.Any):
+    """A graph whose paused handler was removed, plus the paused thread config."""
+    cfg = {"configurable": {"thread_id": tid}}
+    EventGraph([_waiter, _go_noop], checkpointer=saver).invoke(
+        Started(data="x"), config=cfg
+    )
+    return EventGraph([_go_noop], checkpointer=saver, **kwargs), cfg
+
+
 def describe_on_unresumable():
     # resume() on a thread that is not awaiting input (paused handler removed,
     # already-finished, or double-resume) is governed by
     # EventGraph(on_unresumable=...). Default `raise` turns the old silent
     # no-op into a clear error; `warn`/`halt` opt into non-fatal handling.
 
-    def _paused_thread(saver, tid):
-        from langgraph.checkpoint.memory import MemorySaver  # noqa: F401
-
-        @on(Started)
-        def waiter(event: Started) -> _Pause:
-            return _Pause()
-
-        @on(_Go)
-        def go(event: _Go) -> None:
-            return None
-
-        cfg = {"configurable": {"thread_id": tid}}
-        EventGraph([waiter, go], checkpointer=saver).invoke(
-            Started(data="x"), config=cfg
-        )
-        return cfg
-
     def when_the_paused_handler_was_removed():
         def with_default_policy():
             def it_raises_unresumable_error():
-                from langgraph.checkpoint.memory import MemorySaver
-
-                from langgraph_events import UnresumableError
-
-                saver = MemorySaver()
-                cfg = _paused_thread(saver, "unres-raise")
-
-                @on(_Go)
-                def go(event: _Go) -> None:
-                    return None
-
-                v2 = EventGraph([go], checkpointer=saver)  # waiter removed
+                v2, cfg = _resumable_pair(MemorySaver(), "unres-raise")
                 with pytest.raises(UnresumableError):
                     v2.resume(_Go(), config=cfg)
 
     def when_the_thread_is_genuinely_interrupted():
         def it_resumes_normally():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            @on(Started)
-            def waiter(event: Started) -> _Pause:
-                return _Pause()
-
-            @on(_Go)
-            def go(event: _Go) -> Ended:
-                return Ended(result="went")
-
-            saver = MemorySaver()
             cfg = {"configurable": {"thread_id": "unres-live"}}
-            graph = EventGraph([waiter, go], checkpointer=saver)
+            graph = EventGraph([_waiter, _go_ends], checkpointer=MemorySaver())
             graph.invoke(Started(data="x"), config=cfg)
             assert graph.get_state(cfg).is_interrupted
 
@@ -4723,27 +4234,14 @@ def describe_on_unresumable():
 
     def when_the_policy_value_is_invalid():
         def it_raises_at_construction():
-            @on(Started)
-            def h(event: Started) -> None:
-                return None
-
             with pytest.raises(ValueError, match="on_unresumable"):
-                EventGraph([h], on_unresumable="nope")  # type: ignore[arg-type]
+                EventGraph([_echo], on_unresumable="nope")  # type: ignore[arg-type]
 
     def when_warn_policy():
         def it_warns_and_leaves_the_log_unchanged():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            from langgraph_events import Halted
-
-            saver = MemorySaver()
-            cfg = _paused_thread(saver, "unres-warn")
-
-            @on(_Go)
-            def go(event: _Go) -> None:
-                return None
-
-            v2 = EventGraph([go], checkpointer=saver, on_unresumable="warn")
+            v2, cfg = _resumable_pair(
+                MemorySaver(), "unres-warn", on_unresumable="warn"
+            )
             with pytest.warns(UserWarning, match="not awaiting input"):
                 log = v2.resume(_Go(), config=cfg)
 
@@ -4751,78 +4249,41 @@ def describe_on_unresumable():
 
     def when_halt_policy():
         def it_finalizes_the_thread_terminally():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            from langgraph_events import Halted, Unresumable
-
-            saver = MemorySaver()
-            cfg = _paused_thread(saver, "unres-halt")
-
-            @on(_Go)
-            def go(event: _Go) -> None:
-                return None
-
-            v2 = EventGraph([go], checkpointer=saver, on_unresumable="halt")
+            v2, cfg = _resumable_pair(
+                MemorySaver(), "unres-halt", on_unresumable="halt"
+            )
             log = v2.resume(_Go(), config=cfg)
 
             assert isinstance(log.latest(Unresumable), Unresumable)
             assert isinstance(log.latest(Unresumable), Halted)
             assert not v2.get_state(cfg).is_interrupted
 
-    def when_resumed_via_aresume():
-        def it_honors_the_policy():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            from langgraph_events import UnresumableError
-
-            saver = MemorySaver()
-            cfg = _paused_thread(saver, "unres-aresume")
-
-            @on(_Go)
-            def go(event: _Go) -> None:
-                return None
-
-            v2 = EventGraph([go], checkpointer=saver)
+    def when_resumed_via_another_entrypoint():
+        # Every resume entrypoint consults the same on_unresumable policy.
+        @pytest.mark.parametrize(
+            "tid, drive",
+            [
+                (
+                    "unres-aresume",
+                    lambda graph, cfg: asyncio.run(graph.aresume(_Go(), config=cfg)),
+                ),
+                (
+                    "unres-stream",
+                    lambda graph, cfg: list(graph.stream_resume(_Go(), config=cfg)),
+                ),
+                (
+                    "unres-astream",
+                    lambda graph, cfg: asyncio.run(
+                        _adrain(graph.astream_resume(_Go(), config=cfg))
+                    ),
+                ),
+            ],
+            ids=["aresume", "stream_resume", "astream_resume"],
+        )
+        def it_honors_the_policy(tid, drive):
+            v2, cfg = _resumable_pair(MemorySaver(), tid)
             with pytest.raises(UnresumableError):
-                asyncio.run(v2.aresume(_Go(), config=cfg))
-
-    def when_resumed_via_stream_resume():
-        def it_honors_the_policy():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            from langgraph_events import UnresumableError
-
-            saver = MemorySaver()
-            cfg = _paused_thread(saver, "unres-stream")
-
-            @on(_Go)
-            def go(event: _Go) -> None:
-                return None
-
-            v2 = EventGraph([go], checkpointer=saver)
-            with pytest.raises(UnresumableError):
-                list(v2.stream_resume(_Go(), config=cfg))
-
-    def when_resumed_via_astream_resume():
-        def it_honors_the_policy():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            from langgraph_events import UnresumableError
-
-            saver = MemorySaver()
-            cfg = _paused_thread(saver, "unres-astream")
-
-            @on(_Go)
-            def go(event: _Go) -> None:
-                return None
-
-            v2 = EventGraph([go], checkpointer=saver)
-
-            async def drain():
-                return [x async for x in v2.astream_resume(_Go(), config=cfg)]
-
-            with pytest.raises(UnresumableError):
-                asyncio.run(drain())
+                drive(v2, cfg)
 
 
 class _AsyncOnlySaver(MemorySaver):
@@ -4867,39 +4328,27 @@ def describe_async_only_checkpointer():
     # on_unresumable policy reads previously went through sync get_state, which
     # such a checkpointer rejects from the running event loop.
 
-    async def _apaused(saver, tid):
-        """Pause a thread inside ``waiter`` via ainvoke; return its config."""
-
-        @on(Started)
-        def waiter(event: Started) -> _Pause:
-            return _Pause()
-
-        @on(_Go)
-        def go(event: _Go) -> None:
-            return None
-
+    async def _apaused_pair(tid: str, **kwargs: typing.Any):
+        """Pause a thread via ainvoke, then rebuild it without ``_waiter``."""
+        saver = _AsyncOnlySaver()
         cfg = {"configurable": {"thread_id": tid}}
-        await EventGraph([waiter, go], checkpointer=saver).ainvoke(
+        await EventGraph([_waiter, _go_noop], checkpointer=saver).ainvoke(
             Started(data="x"), config=cfg
         )
-        return cfg
+        return EventGraph([_go_noop], checkpointer=saver, **kwargs), cfg
 
     def when_the_thread_is_genuinely_pending():
         def without_sync_checkpointer_access():
+
+            async def _paused_graph(tid: str):
+                cfg = {"configurable": {"thread_id": tid}}
+                graph = EventGraph([_waiter, _go_ends], checkpointer=_AsyncOnlySaver())
+                await graph.ainvoke(Started(data="x"), config=cfg)
+                return graph, cfg
+
             @pytest.mark.asyncio
             async def it_aresumes():
-                @on(Started)
-                def waiter(event: Started) -> _Pause:
-                    return _Pause()
-
-                @on(_Go)
-                def go(event: _Go) -> Ended:
-                    return Ended(result="went")
-
-                saver = _AsyncOnlySaver()
-                cfg = {"configurable": {"thread_id": "async-only-aresume"}}
-                graph = EventGraph([waiter, go], checkpointer=saver)
-                await graph.ainvoke(Started(data="x"), config=cfg)
+                graph, cfg = await _paused_graph("async-only-aresume")
 
                 log = await graph.aresume(_Go(), config=cfg)
                 assert log.latest(Resumed) is not None
@@ -4907,46 +4356,21 @@ def describe_async_only_checkpointer():
 
             @pytest.mark.asyncio
             async def it_astream_resumes():
-                @on(Started)
-                def waiter(event: Started) -> _Pause:
-                    return _Pause()
+                graph, cfg = await _paused_graph("async-only-astream")
 
-                @on(_Go)
-                def go(event: _Go) -> Ended:
-                    return Ended(result="went")
-
-                saver = _AsyncOnlySaver()
-                cfg = {"configurable": {"thread_id": "async-only-astream"}}
-                graph = EventGraph([waiter, go], checkpointer=saver)
-                await graph.ainvoke(Started(data="x"), config=cfg)
-
-                events = [e async for e in graph.astream_resume(_Go(), config=cfg)]
+                events = await _adrain(graph.astream_resume(_Go(), config=cfg))
                 assert any(isinstance(e, Ended) for e in events)
 
     def when_the_thread_is_not_pending():
         @pytest.mark.asyncio
         async def it_aresume_raises_under_default_policy():
-            saver = _AsyncOnlySaver()
-            cfg = await _apaused(saver, "async-only-raise")
-
-            @on(_Go)
-            def go(event: _Go) -> None:
-                return None
-
-            v2 = EventGraph([go], checkpointer=saver)  # waiter removed
+            v2, cfg = await _apaused_pair("async-only-raise")
             with pytest.raises(UnresumableError):
                 await v2.aresume(_Go(), config=cfg)
 
         @pytest.mark.asyncio
         async def it_aresume_warns_and_leaves_the_log_unchanged():
-            saver = _AsyncOnlySaver()
-            cfg = await _apaused(saver, "async-only-warn")
-
-            @on(_Go)
-            def go(event: _Go) -> None:
-                return None
-
-            v2 = EventGraph([go], checkpointer=saver, on_unresumable="warn")
+            v2, cfg = await _apaused_pair("async-only-warn", on_unresumable="warn")
             with pytest.warns(UserWarning, match="not awaiting input"):
                 log = await v2.aresume(_Go(), config=cfg)
 
@@ -4954,29 +4378,17 @@ def describe_async_only_checkpointer():
 
         @pytest.mark.asyncio
         async def it_aresume_halt_finalizes_the_thread_terminally():
-            saver = _AsyncOnlySaver()
-            cfg = await _apaused(saver, "async-only-halt")
-
-            @on(_Go)
-            def go(event: _Go) -> None:
-                return None
-
-            v2 = EventGraph([go], checkpointer=saver, on_unresumable="halt")
+            v2, cfg = await _apaused_pair("async-only-halt", on_unresumable="halt")
             log = await v2.aresume(_Go(), config=cfg)
 
             assert log.latest(Unresumable) is not None
 
         @pytest.mark.asyncio
         async def it_astream_resume_halt_yields_the_terminal_event():
-            saver = _AsyncOnlySaver()
-            cfg = await _apaused(saver, "async-only-astream-halt")
-
-            @on(_Go)
-            def go(event: _Go) -> None:
-                return None
-
-            v2 = EventGraph([go], checkpointer=saver, on_unresumable="halt")
-            events = [e async for e in v2.astream_resume(_Go(), config=cfg)]
+            v2, cfg = await _apaused_pair(
+                "async-only-astream-halt", on_unresumable="halt"
+            )
+            events = await _adrain(v2.astream_resume(_Go(), config=cfg))
 
             assert any(isinstance(e, Unresumable) for e in events)
 
@@ -4986,106 +4398,72 @@ def describe_assert_resume_recovers():
     # proof for an @on(previously=) rename into one assertion — the handler
     # analog of assert_all_baselined_revive.
 
+    def _recovers(before: EventGraph, after: EventGraph):
+        from langgraph_events.serde import assert_resume_recovers
+
+        return assert_resume_recovers(
+            before, after, seed=Started(data="x"), resume_with=_Go()
+        )
+
     def when_a_renamed_handler_declares_previously():
         def it_returns_the_post_resume_log():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            from langgraph_events.serde import assert_resume_recovers
-
             saver = MemorySaver()
 
             @on(Started)
             def await_input(event: Started) -> _Pause:
                 return _Pause()
 
-            @on(_Go)
-            def go(event: _Go) -> Ended:
-                return Ended(result="went")
-
-            before = EventGraph([await_input, go], checkpointer=saver)
+            before = EventGraph([await_input, _go_ends], checkpointer=saver)
 
             @on(Started, previously="await_input")
             def gather(event: Started) -> _Pause:
                 return _Pause()
 
-            after = EventGraph([gather, go], checkpointer=saver)
+            after = EventGraph([gather, _go_ends], checkpointer=saver)
 
-            log = assert_resume_recovers(
-                before, after, seed=Started(data="x"), resume_with=_Go()
-            )
+            log = _recovers(before, after)
             assert log.latest(Ended) == Ended(result="went")
 
     def when_the_rename_is_undeclared():
         def it_propagates_unresumable_error():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            from langgraph_events import UnresumableError
-            from langgraph_events.serde import assert_resume_recovers
-
             saver = MemorySaver()
 
             @on(Started)
             def await_input(event: Started) -> _Pause:
                 return _Pause()
 
-            @on(_Go)
-            def go(event: _Go) -> None:
-                return None
-
-            before = EventGraph([await_input, go], checkpointer=saver)
+            before = EventGraph([await_input, _go_noop], checkpointer=saver)
 
             @on(Started)  # renamed, NO previously=
             def gather(event: Started) -> _Pause:
                 return _Pause()
 
-            after = EventGraph([gather, go], checkpointer=saver)
+            after = EventGraph([gather, _go_noop], checkpointer=saver)
 
             with pytest.raises(UnresumableError):
-                assert_resume_recovers(
-                    before, after, seed=Started(data="x"), resume_with=_Go()
-                )
+                _recovers(before, after)
 
     def when_the_seed_does_not_interrupt():
         def it_raises_a_precondition_error():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            from langgraph_events.serde import assert_resume_recovers
-
             saver = MemorySaver()
 
             @on(Started)
             def noop(event: Started) -> None:
                 return None
 
-            @on(_Go)
-            def go(event: _Go) -> None:
-                return None
-
-            before = EventGraph([noop, go], checkpointer=saver)
-            after = EventGraph([noop, go], checkpointer=saver)
+            before = EventGraph([noop, _go_noop], checkpointer=saver)
+            after = EventGraph([noop, _go_noop], checkpointer=saver)
 
             with pytest.raises(AssertionError, match="did not pause"):
-                assert_resume_recovers(
-                    before, after, seed=Started(data="x"), resume_with=_Go()
-                )
+                _recovers(before, after)
 
     def when_the_graphs_do_not_share_a_checkpointer():
         def it_raises_value_error():
-            from langgraph.checkpoint.memory import MemorySaver
-
-            from langgraph_events.serde import assert_resume_recovers
-
-            @on(Started)
-            def await_input(event: Started) -> _Pause:
-                return _Pause()
-
-            before = EventGraph([await_input], checkpointer=MemorySaver())
-            after = EventGraph([await_input], checkpointer=MemorySaver())
+            before = EventGraph([_waiter], checkpointer=MemorySaver())
+            after = EventGraph([_waiter], checkpointer=MemorySaver())
 
             with pytest.raises(ValueError, match="checkpointer"):
-                assert_resume_recovers(
-                    before, after, seed=Started(data="x"), resume_with=_Go()
-                )
+                _recovers(before, after)
 
 
 def describe_namespaces_cache():

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -451,6 +451,75 @@ class ReviewApproved(IntegrationEvent):
 # ``EXT_CONSTRUCTOR_KW_ARGS`` revival path that #68 broke. Module-level so
 # the qualname registered at encode time resolves on the import-and-getattr
 # walk performed by upstream's ext-hook.
+def _rename_migration(
+    name: str,
+    *,
+    old_module: str,
+    old_qualname: str,
+    new_module: str,
+    new_qualname: str,
+) -> Any:
+    """A single-operation ``Migration`` that renames one event identity."""
+    from langgraph_events.serde.migrations import Migration, RenameEvent
+
+    return Migration(
+        name=name,
+        operations=(
+            RenameEvent(
+                old_module=old_module,
+                old_qualname=old_qualname,
+                new_module=new_module,
+                new_qualname=new_qualname,
+            ),
+        ),
+    )
+
+
+def _persona_rename(name: str, **overrides: Any) -> Any:
+    """The recurring ``legacy.persona:Legacy.Approved`` -> ``Persona.Approve.Approved``
+    rename; ``overrides`` swap individual endpoints."""
+    endpoints: dict[str, Any] = {
+        "old_module": "legacy.persona",
+        "old_qualname": "Legacy.Approved",
+        "new_module": Persona.__module__,
+        "new_qualname": "Persona.Approve.Approved",
+    }
+    endpoints.update(overrides)
+    return _rename_migration(name, **endpoints)
+
+
+def _add_field_migration(
+    name: str, *, module: str, qualname: str, field: str, **default: Any
+) -> Any:
+    """A single-operation ``Migration`` that injects one missing field."""
+    from langgraph_events.serde.migrations import AddField, Migration
+
+    return Migration(
+        name=name,
+        operations=(
+            AddField(module=module, qualname=qualname, field=field, **default),
+        ),
+    )
+
+
+def _persisted_field_migration(name: str, field: str, **default: Any) -> Any:
+    """``_add_field_migration`` keyed on ``NestedPersist.Persist.Persisted``."""
+    return _add_field_migration(
+        name,
+        module=NestedPersist.__module__,
+        qualname="NestedPersist.Persist.Persisted",
+        field=field,
+        **default,
+    )
+
+
+def _persisted_payload(**kwargs: Any) -> Any:
+    """A legacy wire payload for ``NestedPersist.Persist.Persisted``."""
+    return synthesize_legacy_payload(
+        NestedPersist.__module__, "NestedPersist.Persist.Persisted", kwargs
+    )
+
+
 @dataclasses.dataclass
 class PlainPayload:
     name: str
@@ -813,33 +882,15 @@ def describe_NamespaceAwareSerde():
                 # under different qualnames. Once renamed, a checkpoint that
                 # captured pre-rename state holds a HETEROGENEOUS list of
                 # legacy payloads. Each branch must migrate independently.
-                from langgraph_events.serde.migrations import (
-                    Migration,
-                    RenameEvent,
-                )
 
                 migrations = [
-                    Migration(
-                        name="rename-persona-approved",
-                        operations=(
-                            RenameEvent(
-                                old_module="legacy.persona",
-                                old_qualname="Legacy.Approved",
-                                new_module=Persona.__module__,
-                                new_qualname="Persona.Approve.Approved",
-                            ),
-                        ),
-                    ),
-                    Migration(
-                        name="rename-story-approved",
-                        operations=(
-                            RenameEvent(
-                                old_module="legacy.story",
-                                old_qualname="Legacy.StoryApproved",
-                                new_module=Story.__module__,
-                                new_qualname="Story.Approve.Approved",
-                            ),
-                        ),
+                    _persona_rename("rename-persona-approved"),
+                    _rename_migration(
+                        "rename-story-approved",
+                        old_module="legacy.story",
+                        old_qualname="Legacy.StoryApproved",
+                        new_module=Story.__module__,
+                        new_qualname="Story.Approve.Approved",
                     ),
                 ]
                 serde = NamespaceAwareSerde(migrations=migrations)
@@ -882,23 +933,9 @@ def describe_NamespaceAwareSerde():
                 # branch already recurses with the same hook, so a renamed
                 # event one layer down should rewrite through the same
                 # rename table with zero extra code.
-                from langgraph_events.serde.migrations import (
-                    Migration,
-                    RenameEvent,
-                )
 
                 migrations = [
-                    Migration(
-                        name="rename-legacy-persona",
-                        operations=(
-                            RenameEvent(
-                                old_module="legacy.persona",
-                                old_qualname="Legacy.Approved",
-                                new_module=Persona.__module__,
-                                new_qualname="Persona.Approve.Approved",
-                            ),
-                        ),
-                    ),
+                    _persona_rename("rename-legacy-persona"),
                 ]
                 serde = NamespaceAwareSerde(migrations=migrations)
                 payload = _legacy_interrupted_payload(
@@ -1054,33 +1091,21 @@ def describe_NamespaceAwareSerde():
                 # release N renamed Legacy.A → Legacy.B; release N+1 renamed
                 # Legacy.B → Persona.Approve.Approved. Payloads from BOTH
                 # historic identities should land on the current class.
-                from langgraph_events.serde.migrations import (
-                    Migration,
-                    RenameEvent,
-                )
 
                 migrations = [
-                    Migration(
-                        name="release-N",
-                        operations=(
-                            RenameEvent(
-                                old_module="legacy.persona",
-                                old_qualname="Legacy.A",
-                                new_module="legacy.persona",
-                                new_qualname="Legacy.B",
-                            ),
-                        ),
+                    _rename_migration(
+                        "release-N",
+                        old_module="legacy.persona",
+                        old_qualname="Legacy.A",
+                        new_module="legacy.persona",
+                        new_qualname="Legacy.B",
                     ),
-                    Migration(
-                        name="release-N+1",
-                        operations=(
-                            RenameEvent(
-                                old_module="legacy.persona",
-                                old_qualname="Legacy.B",
-                                new_module=Persona.__module__,
-                                new_qualname="Persona.Approve.Approved",
-                            ),
-                        ),
+                    _rename_migration(
+                        "release-N+1",
+                        old_module="legacy.persona",
+                        old_qualname="Legacy.B",
+                        new_module=Persona.__module__,
+                        new_qualname="Persona.Approve.Approved",
                     ),
                 ]
 
@@ -1107,32 +1132,15 @@ def describe_NamespaceAwareSerde():
                 def it_injects_the_default_value():
                     # Without AddField the dataclass constructor raises
                     # TypeError because ``command_id`` is required.
-                    from langgraph_events.serde.migrations import (
-                        AddField,
-                        Migration,
+                    serde = NamespaceAwareSerde(
+                        migrations=[
+                            _persisted_field_migration(
+                                "add-command-id", "command_id", default="legacy"
+                            )
+                        ]
                     )
 
-                    migrations = [
-                        Migration(
-                            name="add-command-id",
-                            operations=(
-                                AddField(
-                                    module=NestedPersist.__module__,
-                                    qualname="NestedPersist.Persist.Persisted",
-                                    field="command_id",
-                                    default="legacy",
-                                ),
-                            ),
-                        ),
-                    ]
-                    serde = NamespaceAwareSerde(migrations=migrations)
-                    payload = synthesize_legacy_payload(
-                        NestedPersist.__module__,
-                        "NestedPersist.Persist.Persisted",
-                        {"note": "old"},
-                    )
-
-                    revived = serde.loads_typed(payload)
+                    revived = serde.loads_typed(_persisted_payload(note="old"))
 
                     assert isinstance(revived, NestedPersist.Persist.Persisted)
                     assert revived.command_id == "legacy"
@@ -1143,41 +1151,24 @@ def describe_NamespaceAwareSerde():
                     # Two distinct payloads must NOT share the same list
                     # object — that would be a classic mutable-default bug
                     # made worse by living one layer down inside the serde.
-                    from langgraph_events.serde.migrations import (
-                        AddField,
-                        Migration,
-                    )
-
-                    migrations = [
-                        Migration(
-                            name="add-tags",
-                            operations=(
-                                AddField(
-                                    module=NestedPersist.__module__,
-                                    qualname="NestedPersist.Persist.Persisted",
-                                    field="tags",
-                                    default_factory=list,
-                                ),
-                            ),
-                        ),
-                    ]
+                    #
                     # Override the default tuple field with a list-typed one
                     # by going through kwargs directly — we want to observe
                     # whether revival hands back the SAME list instance.
-                    serde = NamespaceAwareSerde(migrations=migrations)
-                    raw1 = synthesize_legacy_payload(
-                        NestedPersist.__module__,
-                        "NestedPersist.Persist.Persisted",
-                        {"command_id": "c1", "note": "a"},
-                    )
-                    raw2 = synthesize_legacy_payload(
-                        NestedPersist.__module__,
-                        "NestedPersist.Persist.Persisted",
-                        {"command_id": "c2", "note": "b"},
+                    serde = NamespaceAwareSerde(
+                        migrations=[
+                            _persisted_field_migration(
+                                "add-tags", "tags", default_factory=list
+                            )
+                        ]
                     )
 
-                    r1 = serde.loads_typed(raw1)
-                    r2 = serde.loads_typed(raw2)
+                    r1 = serde.loads_typed(
+                        _persisted_payload(command_id="c1", note="a")
+                    )
+                    r2 = serde.loads_typed(
+                        _persisted_payload(command_id="c2", note="b")
+                    )
 
                     # Frozen dataclass coerces our list into the declared
                     # ``tuple[str, ...]`` only when we pass a tuple — we
@@ -1190,32 +1181,17 @@ def describe_NamespaceAwareSerde():
                     # If a payload predates the AddField migration but
                     # happens to carry the field (e.g. a backfill ran),
                     # setdefault must not overwrite the existing value.
-                    from langgraph_events.serde.migrations import (
-                        AddField,
-                        Migration,
+                    serde = NamespaceAwareSerde(
+                        migrations=[
+                            _persisted_field_migration(
+                                "add-command-id", "command_id", default="legacy"
+                            )
+                        ]
                     )
 
-                    migrations = [
-                        Migration(
-                            name="add-command-id",
-                            operations=(
-                                AddField(
-                                    module=NestedPersist.__module__,
-                                    qualname="NestedPersist.Persist.Persisted",
-                                    field="command_id",
-                                    default="legacy",
-                                ),
-                            ),
-                        ),
-                    ]
-                    serde = NamespaceAwareSerde(migrations=migrations)
-                    payload = synthesize_legacy_payload(
-                        NestedPersist.__module__,
-                        "NestedPersist.Persist.Persisted",
-                        {"command_id": "from-old", "note": "n"},
+                    revived = serde.loads_typed(
+                        _persisted_payload(command_id="from-old", note="n")
                     )
-
-                    revived = serde.loads_typed(payload)
 
                     assert revived.command_id == "from-old"
 
@@ -1224,10 +1200,6 @@ def describe_NamespaceAwareSerde():
                 # Simulate a checkpoint produced by an older build where the
                 # event class lived at "legacy.module:Legacy.Approved", later
                 # renamed to the live `Persona.Approve.Approved`.
-                from langgraph_events.serde.migrations import (
-                    Migration,
-                    RenameEvent,
-                )
 
                 payload = synthesize_legacy_payload(
                     module="legacy.persona",
@@ -1235,17 +1207,7 @@ def describe_NamespaceAwareSerde():
                     kwargs={"note": "hi"},
                 )
                 migrations = [
-                    Migration(
-                        name="rename-legacy-persona-approved",
-                        operations=(
-                            RenameEvent(
-                                old_module="legacy.persona",
-                                old_qualname="Legacy.Approved",
-                                new_module=Persona.__module__,
-                                new_qualname="Persona.Approve.Approved",
-                            ),
-                        ),
-                    ),
+                    _persona_rename("rename-legacy-persona-approved"),
                 ]
 
                 serde = NamespaceAwareSerde(migrations=migrations)
@@ -1645,33 +1607,15 @@ def describe_NamespaceAwareSerde():
 
         def when_duplicate_old_source():
             def it_raises_naming_the_ambiguous_source():
-                from langgraph_events.serde.migrations import (
-                    Migration,
-                    RenameEvent,
-                )
 
                 migrations = [
-                    Migration(
-                        name="rename-to-persona",
-                        operations=(
-                            RenameEvent(
-                                old_module="legacy.persona",
-                                old_qualname="Legacy.Approved",
-                                new_module=Persona.__module__,
-                                new_qualname="Persona.Approve.Approved",
-                            ),
-                        ),
-                    ),
-                    Migration(
-                        name="rename-to-story",
-                        operations=(
-                            RenameEvent(
-                                old_module="legacy.persona",
-                                old_qualname="Legacy.Approved",
-                                new_module=Story.__module__,
-                                new_qualname="Story.Approve.Approved",
-                            ),
-                        ),
+                    _persona_rename("rename-to-persona"),
+                    _rename_migration(
+                        "rename-to-story",
+                        old_module="legacy.persona",
+                        old_qualname="Legacy.Approved",
+                        new_module=Story.__module__,
+                        new_qualname="Story.Approve.Approved",
                     ),
                 ]
 
@@ -1686,25 +1630,17 @@ def describe_NamespaceAwareSerde():
 
         def when_old_qualname_still_resolves():
             def it_raises_to_prevent_shadowing_the_live_class():
-                from langgraph_events.serde.migrations import (
-                    Migration,
-                    RenameEvent,
-                )
 
                 # `Persona.Approve.Approved` IS live — declaring a migration
                 # whose old name points at it would silently rewrite live
                 # payloads on read.
                 migrations = [
-                    Migration(
-                        name="shadows-live",
-                        operations=(
-                            RenameEvent(
-                                old_module=Persona.__module__,
-                                old_qualname="Persona.Approve.Approved",
-                                new_module=Story.__module__,
-                                new_qualname="Story.Approve.Approved",
-                            ),
-                        ),
+                    _rename_migration(
+                        "shadows-live",
+                        old_module=Persona.__module__,
+                        old_qualname="Persona.Approve.Approved",
+                        new_module=Story.__module__,
+                        new_qualname="Story.Approve.Approved",
                     ),
                 ]
 
@@ -1781,33 +1717,21 @@ def describe_NamespaceAwareSerde():
 
         def when_cycle_exists_in_chain():
             def it_raises_naming_the_cycle_start():
-                from langgraph_events.serde.migrations import (
-                    Migration,
-                    RenameEvent,
-                )
 
                 migrations = [
-                    Migration(
-                        name="forward",
-                        operations=(
-                            RenameEvent(
-                                old_module="legacy.a",
-                                old_qualname="A",
-                                new_module="legacy.b",
-                                new_qualname="B",
-                            ),
-                        ),
+                    _rename_migration(
+                        "forward",
+                        old_module="legacy.a",
+                        old_qualname="A",
+                        new_module="legacy.b",
+                        new_qualname="B",
                     ),
-                    Migration(
-                        name="reverse",
-                        operations=(
-                            RenameEvent(
-                                old_module="legacy.b",
-                                old_qualname="B",
-                                new_module="legacy.a",
-                                new_qualname="A",
-                            ),
-                        ),
+                    _rename_migration(
+                        "reverse",
+                        old_module="legacy.b",
+                        old_qualname="B",
+                        new_module="legacy.a",
+                        new_qualname="A",
                     ),
                 ]
 
@@ -1821,22 +1745,14 @@ def describe_NamespaceAwareSerde():
                 # which is technically true but misleads — the actual
                 # cause is that the user wrote a rename whose target
                 # equals its source (often a typo or stale paste).
-                from langgraph_events.serde.migrations import (
-                    Migration,
-                    RenameEvent,
-                )
 
                 migrations = [
-                    Migration(
-                        name="self",
-                        operations=(
-                            RenameEvent(
-                                old_module=Persona.__module__,
-                                old_qualname="Persona.Approve.Approved",
-                                new_module=Persona.__module__,
-                                new_qualname="Persona.Approve.Approved",
-                            ),
-                        ),
+                    _rename_migration(
+                        "self",
+                        old_module=Persona.__module__,
+                        old_qualname="Persona.Approve.Approved",
+                        new_module=Persona.__module__,
+                        new_qualname="Persona.Approve.Approved",
                     ),
                 ]
 
@@ -1912,25 +1828,11 @@ def describe_NamespaceAwareSerde():
         # not "live or migrated?").
 
         def it_returns_every_revivable_identity():
-            from langgraph_events.serde.migrations import (
-                Migration,
-                RenameEvent,
-            )
 
             serde = NamespaceAwareSerde(
                 namespaces=[DecoReorg],
                 migrations=[
-                    Migration(
-                        name="legacy-rename",
-                        operations=(
-                            RenameEvent(
-                                old_module="legacy.persona",
-                                old_qualname="Legacy.Approved",
-                                new_module=Persona.__module__,
-                                new_qualname="Persona.Approve.Approved",
-                            ),
-                        ),
-                    ),
+                    _persona_rename("legacy-rename"),
                 ],
             )
 
@@ -2033,24 +1935,12 @@ def describe_NamespaceAwareSerde():
         def when_baseline_identity_has_a_hand_authored_migration():
             def it_passes_silently(tmp_path: Any):
                 from langgraph_events.serde.migrations import (
-                    Migration,
-                    RenameEvent,
                     assert_all_baselined_cover,
                 )
 
                 serde = NamespaceAwareSerde(
                     migrations=[
-                        Migration(
-                            name="legacy-rename",
-                            operations=(
-                                RenameEvent(
-                                    old_module="legacy.persona",
-                                    old_qualname="Legacy.Approved",
-                                    new_module=Persona.__module__,
-                                    new_qualname="Persona.Approve.Approved",
-                                ),
-                            ),
-                        ),
+                        _persona_rename("legacy-rename"),
                     ],
                 )
                 baseline = _baseline_file(
@@ -2588,10 +2478,12 @@ def describe_origin_scoped_backfill():
                     note: str = ""
 
     def when_a_raw_AddField_targets_a_historic_identity():
-        def it_applies_before_the_rename():
+
+        def _new_era_serde() -> NamespaceAwareSerde:
+            """Serde whose only fill is keyed on the historic ``ChainScoped.New``."""
             from langgraph_events.serde.migrations import Migration
 
-            serde = NamespaceAwareSerde(
+            return NamespaceAwareSerde(
                 namespaces=[ChainScoped],
                 migrations=[
                     Migration.add_field(
@@ -2604,7 +2496,8 @@ def describe_origin_scoped_backfill():
                 ],
             )
 
-            revived = serde.loads_typed(
+        def it_applies_before_the_rename():
+            revived = _new_era_serde().loads_typed(
                 synthesize_legacy_payload(ChainScoped.__module__, "ChainScoped.New", {})
             )
 
@@ -2615,22 +2508,7 @@ def describe_origin_scoped_backfill():
             # Exact-origin contract: on the chain Old → New → current, a
             # fill keyed on New must not apply to payloads written under
             # Old. "Every era" is class-global @backfill's job.
-            from langgraph_events.serde.migrations import Migration
-
-            serde = NamespaceAwareSerde(
-                namespaces=[ChainScoped],
-                migrations=[
-                    Migration.add_field(
-                        name="new-era-fill",
-                        module=ChainScoped.__module__,
-                        qualname="ChainScoped.New",
-                        field="source",
-                        default="new-era",
-                    )
-                ],
-            )
-
-            revived = serde.loads_typed(
+            revived = _new_era_serde().loads_typed(
                 synthesize_legacy_payload(ChainScoped.__module__, "ChainScoped.Old", {})
             )
 
@@ -2847,69 +2725,65 @@ def describe_assert_all_baselined_handlers_cover():
     # the previous release wrote must still be live or covered by an
     # @on(previously=...) alias, else an interrupted checkpoint paused at the
     # old node would silently drop on resume.
+    # Aliased under ``_`` so pytest-describe does not collect the imported
+    # callables as tests of this block.
+    from langgraph_events.serde.migrations import (
+        assert_all_baselined_handlers_cover as _assert_handlers_cover,
+    )
+    from langgraph_events.serde.migrations.detect import (
+        CoverageError,
+        HandlerCoverageError,
+    )
+    from langgraph_events.serde.migrations.detect import (
+        write_baseline as _write_baseline,
+    )
+
+    def _baseline_for(graph: EventGraph, tmp_path: Any) -> Any:
+        """Write ``graph``'s handler baseline under *tmp_path* and return it."""
+        baseline = tmp_path / "b.json"
+        _write_baseline(graph, baseline)
+        return baseline
 
     def when_every_baselined_handler_is_live():
         def it_passes_silently(tmp_path: Any):
-            from langgraph_events.serde.migrations import (
-                assert_all_baselined_handlers_cover,
-            )
-            from langgraph_events.serde.migrations.detect import write_baseline
-
             @on(Started)
             def place(event: Started) -> None:
                 return None
 
             graph = EventGraph([place])
-            baseline = tmp_path / "b.json"
-            write_baseline(graph, baseline)
+            baseline = _baseline_for(graph, tmp_path)
 
-            assert_all_baselined_handlers_cover(graph, baseline)
+            _assert_handlers_cover(graph, baseline)
 
     def when_a_handler_is_renamed():
         def with_previously_declared():
             def it_passes(tmp_path: Any):
-                from langgraph_events.serde.migrations import (
-                    assert_all_baselined_handlers_cover,
-                )
-                from langgraph_events.serde.migrations.detect import write_baseline
-
                 @on(Started)
                 def place(event: Started) -> None:
                     return None
 
-                baseline = tmp_path / "b.json"
-                write_baseline(EventGraph([place]), baseline)
+                baseline = _baseline_for(EventGraph([place]), tmp_path)
 
                 @on(Started, previously="place")
                 def submit(event: Started) -> None:
                     return None
 
-                assert_all_baselined_handlers_cover(EventGraph([submit]), baseline)
+                _assert_handlers_cover(EventGraph([submit]), baseline)
 
         def without_previously_declared():
             def it_raises_naming_the_lost_handler(tmp_path: Any):
-                from langgraph_events.serde.migrations import (
-                    assert_all_baselined_handlers_cover,
-                )
-                from langgraph_events.serde.migrations.detect import (
-                    CoverageError,
-                    HandlerCoverageError,
-                    write_baseline,
-                )
-
                 @on(Started)
                 def place(event: Started) -> None:
                     return None
 
-                baseline = tmp_path / "b.json"
-                write_baseline(EventGraph([place]), baseline)
+                baseline = _baseline_for(EventGraph([place]), tmp_path)
 
                 @on(Started)
                 def submit(event: Started) -> None:
                     return None
 
                 with pytest.raises(HandlerCoverageError, match="place") as excinfo:
-                    assert_all_baselined_handlers_cover(EventGraph([submit]), baseline)
+                    _assert_handlers_cover(EventGraph([submit]), baseline)
                 # sibling of MigrationCoverageError under the shared base
                 assert isinstance(excinfo.value, CoverageError)
                 assert excinfo.value.uncovered == ("place",)
@@ -2919,11 +2793,6 @@ def describe_assert_all_baselined_handlers_cover():
         # HandlerMeta.previous_names the gate unions into its reachable set.
         def with_previously_declared():
             def it_passes(tmp_path: Any):
-                from langgraph_events.serde.migrations import (
-                    assert_all_baselined_handlers_cover,
-                )
-                from langgraph_events.serde.migrations.detect import write_baseline
-
                 class _Replat(Namespace):
                     class Persist(Command):
                         previously: ClassVar = ("persist",)
@@ -2935,23 +2804,12 @@ def describe_assert_all_baselined_handlers_cover():
                 def persist_reactor(event: Started) -> None:
                     return None
 
-                baseline = tmp_path / "b.json"
-                write_baseline(EventGraph([persist_reactor]), baseline)
+                baseline = _baseline_for(EventGraph([persist_reactor]), tmp_path)
 
-                assert_all_baselined_handlers_cover(
-                    EventGraph([_Replat.Persist]), baseline
-                )
+                _assert_handlers_cover(EventGraph([_Replat.Persist]), baseline)
 
         def without_previously_declared():
             def it_raises_naming_the_lost_handler(tmp_path: Any):
-                from langgraph_events.serde.migrations import (
-                    assert_all_baselined_handlers_cover,
-                )
-                from langgraph_events.serde.migrations.detect import (
-                    HandlerCoverageError,
-                    write_baseline,
-                )
-
                 class _Replat2(Namespace):
                     class Persist(Command):
                         def handle(self) -> None:
@@ -2961,13 +2819,10 @@ def describe_assert_all_baselined_handlers_cover():
                 def persist_reactor(event: Started) -> None:
                     return None
 
-                baseline = tmp_path / "b.json"
-                write_baseline(EventGraph([persist_reactor]), baseline)
+                baseline = _baseline_for(EventGraph([persist_reactor]), tmp_path)
 
                 with pytest.raises(HandlerCoverageError, match="persist"):
-                    assert_all_baselined_handlers_cover(
-                        EventGraph([_Replat2.Persist]), baseline
-                    )
+                    _assert_handlers_cover(EventGraph([_Replat2.Persist]), baseline)
 
     def when_baseline_recorded_old_positional_inline_command_names():
         # Pre-#97 baselines recorded inline command handlers by their
@@ -2977,14 +2832,6 @@ def describe_assert_all_baselined_handlers_cover():
 
         def it_raises_until_the_baseline_is_regenerated(tmp_path: Any):
             import json
-
-            from langgraph_events.serde.migrations import (
-                assert_all_baselined_handlers_cover,
-            )
-            from langgraph_events.serde.migrations.detect import (
-                HandlerCoverageError,
-                write_baseline,
-            )
 
             graph = EventGraph([Persona.Approve, Story.Approve])
             baseline = tmp_path / "b.json"
@@ -2999,20 +2846,16 @@ def describe_assert_all_baselined_handlers_cover():
             )
 
             with pytest.raises(HandlerCoverageError) as excinfo:
-                assert_all_baselined_handlers_cover(graph, baseline)
+                _assert_handlers_cover(graph, baseline)
             assert excinfo.value.uncovered == ("handle", "handle_2")
 
             # The documented one-time migration: regenerate the baseline.
-            write_baseline(graph, baseline)
-            assert_all_baselined_handlers_cover(graph, baseline)
+            _write_baseline(graph, baseline)
+            _assert_handlers_cover(graph, baseline)
 
     def when_baseline_predates_handler_tracking():
         def it_loads_a_v1_baseline_and_passes(tmp_path: Any):
             import json
-
-            from langgraph_events.serde.migrations import (
-                assert_all_baselined_handlers_cover,
-            )
 
             @on(Started)
             def place(event: Started) -> None:
@@ -3021,4 +2864,4 @@ def describe_assert_all_baselined_handlers_cover():
             baseline = tmp_path / "v1.json"
             baseline.write_text(json.dumps({"version": 1, "events": []}))
 
-            assert_all_baselined_handlers_cover(EventGraph([place]), baseline)
+            _assert_handlers_cover(EventGraph([place]), baseline)


### PR DESCRIPTION
## The gate has been passing falsely

The `jscpd` pre-commit hook runs an **unpinned** `npx jscpd`, and jscpd defaulted `--max-size` to **100kb** for years. Files above that are skipped **silently** — jscpd reports no error and does not list what it dropped.

Those files were exactly:

| file | size |
|---|---|
| `tests/test_agui.py` | 209 KB |
| `tests/test_event_graph.py` | 196 KB |
| `tests/test_serde.py` | 131 KB |

…which is to say, **the three files carrying ~89% of the duplication**. The gate reported ~4% while the real figure was **11.56%**.

Nothing in this repo changed to expose it. jscpd 5.x raised the default to 1mb, so an `npx` re-resolve started analysing those three files and the hook began failing on `main` with no commit responsible. CI never caught it because CI doesn't run jscpd.

## Half one — reduce the duplication

**4283 → 1471 duplicated lines. 11.56% → 4.14%.**

All of it was *self*-duplication inside single files — repeated scaffolding, not shared logic — which is the tractable kind:

| file | duplicated lines | change |
|---|---|---|
| `test_agui.py` | 2173 → 164 | −92.5% (file 5406 → 3979 lines) |
| `test_event_graph.py` | 961 → 243 | −74.7% |
| `test_serde.py` | 261 → 97 | −62.8% |

- **`test_agui.py`** — `_graph`/`_adapter`/`_stream`/`_connect`/`_resume` builders (130+ call sites each), 60 identical inline `@on` handler bodies hoisted to module level, and 151 query comprehensions collapsed into `_of_type`, `_snapshots`, `_by_role` and friends.
- **`test_event_graph.py`** — shared handlers and graph builders (`_echo_graph`, `_chain_graph`, `_interruptible_graph`, `_resumable_pair`, `_deadline_graph`), module-level event classes that 15 sites kept redeclaring, and parametrize over the emit/aemit and `on_unresumable` entrypoint families.
- **`test_serde.py`** — migration builders replacing 14 hand-rolled single-op literals. Migration names, payload kwargs and baseline versions are passed at **every** call site, never defaulted, so no case was collapsed. The `add_field` sugar-vs-explicit and v1/v2 baseline tests were deliberately left alone.

## No coverage was lost — verified, not asserted

Collected tests **1266 → 1264**. I diffed the full sorted collected-ID list; every one of the 13 removed IDs is accounted for:

- **11** are 1:1 **parametrized replacements** (e.g. `it_emits_custom_frames_from_sync_handler` → `it_emits_custom_frames[sync_handler]`). Same cases, same count, still one run per id.
- **2** are genuinely identical duplicates, merged into the sibling that sits at the API boundary:
  - `describe_compiled::when_no_checkpointer::it_returns_cached_instance_on_second_call` → `it_returns_same_instance` (byte-identical body)
  - `describe_SystemPromptSet::it_contributes_to_message_reducer` → the message_reducer suite's own `it_contributes_to_message_history` (identical setup, all five assertions)

Both surviving siblings confirmed present. **`test_agui.py`'s collected-ID list is byte-identical before and after** — nothing renamed, parametrized away, or merged there at all.

No assertion was changed, weakened, or deleted. Assertions that moved were relocated verbatim into helpers.

## Half two — make the gate incapable of lying again

This is the part that matters more than the percentage:

```yaml
entry: npx jscpd@5.0.16 src/ tests/ --min-tokens 30 --min-lines 2 --threshold 5 --max-size 5mb
```

- **Pinned** so the hook cannot change behaviour without a commit.
- **`--max-size` explicit**, comfortably above the largest file under `src/` and `tests/`.

The inline comment records why both matter, and specifically that *a skipped file produces no output* — the failure mode is silence, not an error, which is why this went unnoticed for so long.

## Verification

`pytest` 1264 passed / 1 skipped · `ruff check` + `format --check` clean · `mypy src/` clean · `validate_tests.py` 33/33 · `generate_mermaid.py --check` clean · **`jscpd` 4.14%, passing**. Full pre-commit chain green.

Only `tests/` and `.pre-commit-config.yaml` are touched — no `src/` changes.

## Worth knowing

At 4.14% this sits under the 5% threshold but not enormously. The remaining 1471 lines are spread thinly across many files rather than concentrated, so the next reduction would be materially harder than this one. If you'd rather have more headroom, `test_agui.py`'s residual 164 lines and `test_event_graph.py`'s 243 are where it still is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)