### PR TITLE
fix: name the class and field when a revive hits a field-shape mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   diagrams resolve their indices in `MermaidFlowchart.render`, which counts seeds and chained
   hops correctly by construction, and were always right.
 
+- **A field-shape mismatch on revive now names the class and the field.** `NamespaceAwareSerde`
+  revives a checkpointed event by calling the live class with the stored payload verbatim. An
+  `Event` is a frozen dataclass, so a stored key the class has since dropped, or a required field
+  the class has since gained with no `Migration.add_field`, raises `TypeError` out of `__init__`.
+  That type was missing from the ext-hook's `except` clause, so nothing reached the error channel
+  and ormsgpack's generic `ValueError: ext_hook failed` — no module, no class, no field, and a
+  `__cause__` of `None` — was all the caller saw. The clause now catches `TypeError` alongside
+  `ImportError` and `AttributeError`, and records `Cannot revive <module>.<qualname>: TypeError:
+  <message>. The class may have been renamed or removed, or its fields may have changed, since the
+  checkpoint was written.`
+
+  This is a diagnostic change only. The revive still raises, and a payload that revives today is
+  unaffected. A named added-field mismatch is fixed with `Migration.add_field`. An extra stored key
+  reaches no absorber at all, because `__init__` rejects every keyword the class does not declare.
+
 ## [0.24.0] - 2026-08-23
 
 ### Added

--- a/src/langgraph_events/serde/_jsonplus.py
+++ b/src/langgraph_events/serde/_jsonplus.py
@@ -206,11 +206,14 @@ def _make_ext_hook(
         )
         try:
             return _resolve_identity(module_name, qualname)(**kwargs)
-        except (ImportError, AttributeError) as exc:
+        except (ImportError, AttributeError, TypeError) as exc:
+            # ``TypeError`` is the field-shape mismatch: the identity
+            # resolves, but the stored kwargs carry a key the live class
+            # has dropped, or omit a field it has gained with no AddField.
             errors.append(
                 f"Cannot revive {module_name}.{qualname}: {type(exc).__name__}: {exc}. "
-                f"The class may have been renamed or removed since the "
-                f"checkpoint was written."
+                f"The class may have been renamed or removed, or its fields "
+                f"may have changed, since the checkpoint was written."
             )
             raise
 

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -107,6 +107,15 @@ class Story(Namespace):
             return Story.Approve.Approved(note=self.note)
 
 
+# Fixture for the field-shape diagnostics. ``reason`` is required and is the
+# only field, so one class covers both mismatch directions: a payload written
+# before the field existed omits it, and a payload written while a since-
+# dropped field existed carries a key the live ``__init__`` rejects.
+class FieldShape(Namespace):
+    class Persisted(DomainEvent):
+        reason: str
+
+
 # Fixtures for the decorator-driven migration tests. Module-level so their
 # qualnames resolve through ``importlib.import_module`` + dotted ``getattr``
 # at serde-construction validation time. Function-local classes acquire
@@ -600,6 +609,68 @@ def describe_NamespaceAwareSerde():
 
                 with pytest.raises(ValueError, match=r"GhostClass|Persona\.Approve"):
                     serde.loads_typed((kind, tampered))
+
+    def describe_revival_of_a_changed_class():
+        # Sibling of the missing-class case above. The identity still
+        # resolves, but the stored kwargs no longer match the live
+        # ``__init__``, so the frozen dataclass raises ``TypeError``.
+
+        def when_a_field_was_removed_from_the_class():
+            def it_names_the_identity_and_the_rejected_field():
+                serde = NamespaceAwareSerde()
+
+                # An extra stored key reaches no absorber — ``__init__``
+                # rejects every keyword the class does not declare.
+                payload = synthesize_legacy_payload(
+                    FieldShape.__module__,
+                    "FieldShape.Persisted",
+                    {"reason": "kept", "note": "dropped"},
+                )
+
+                with pytest.raises(ValueError) as excinfo:
+                    serde.loads_typed(payload)
+
+                message = str(excinfo.value)
+                assert "FieldShape.Persisted" in message
+                assert "TypeError" in message
+                assert "note" in message
+                assert "fields may have changed" in message
+
+        def when_a_required_field_was_added_to_the_class():
+            def without_a_migration():
+                def it_names_the_identity_and_the_missing_field():
+                    serde = NamespaceAwareSerde()
+
+                    # The reverse direction: a missing key CAN reach an
+                    # absorber, but only a class default or an ``AddField``
+                    # supplies one. A required field has neither.
+                    payload = synthesize_legacy_payload(
+                        FieldShape.__module__, "FieldShape.Persisted", {}
+                    )
+
+                    with pytest.raises(ValueError) as excinfo:
+                        serde.loads_typed(payload)
+
+                    message = str(excinfo.value)
+                    assert "FieldShape.Persisted" in message
+                    assert "TypeError" in message
+                    assert "reason" in message
+                    assert "fields may have changed" in message
+
+        def when_the_stored_fields_still_match():
+            def it_revives_the_event():
+                serde = NamespaceAwareSerde()
+
+                revived = serde.loads_typed(
+                    synthesize_legacy_payload(
+                        FieldShape.__module__,
+                        "FieldShape.Persisted",
+                        {"reason": "kept"},
+                    )
+                )
+
+                assert isinstance(revived, FieldShape.Persisted)
+                assert revived.reason == "kept"
 
     def describe_encode_fallback():
         # ``NamespaceAwareSerde._default`` is a strict superset of upstream's

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -108,9 +108,7 @@ class Story(Namespace):
 
 
 # Fixture for the field-shape diagnostics. ``reason`` is required and is the
-# only field, so one class covers both mismatch directions: a payload written
-# before the field existed omits it, and a payload written while a since-
-# dropped field existed carries a key the live ``__init__`` rejects.
+# only field, so one class covers both mismatch directions below.
 class FieldShape(Namespace):
     class Persisted(DomainEvent):
         reason: str
@@ -641,9 +639,9 @@ def describe_NamespaceAwareSerde():
                 def it_names_the_identity_and_the_missing_field():
                     serde = NamespaceAwareSerde()
 
-                    # The reverse direction: a missing key CAN reach an
-                    # absorber, but only a class default or an ``AddField``
-                    # supplies one. A required field has neither.
+                    # A missing key CAN reach an absorber, but only a class
+                    # default or an ``AddField`` supplies one. A required
+                    # field has neither.
                     payload = synthesize_legacy_payload(
                         FieldShape.__module__, "FieldShape.Persisted", {}
                     )
@@ -661,13 +659,13 @@ def describe_NamespaceAwareSerde():
             def it_revives_the_event():
                 serde = NamespaceAwareSerde()
 
-                revived = serde.loads_typed(
-                    synthesize_legacy_payload(
-                        FieldShape.__module__,
-                        "FieldShape.Persisted",
-                        {"reason": "kept"},
-                    )
+                payload = synthesize_legacy_payload(
+                    FieldShape.__module__,
+                    "FieldShape.Persisted",
+                    {"reason": "kept"},
                 )
+
+                revived = serde.loads_typed(payload)
 
                 assert isinstance(revived, FieldShape.Persisted)
                 assert revived.reason == "kept"


### PR DESCRIPTION
Closes #144.

## The problem

Revive calls `_resolve_identity(module, qualname)(**kwargs)` with the stored payload. The
surrounding `except` caught `(ImportError, AttributeError)` only.

A field-shape mismatch raises `TypeError`, which escaped uncaught. ormsgpack then swallowed it,
and the caller saw:

```
ValueError: ext_hook failed        __cause__: None
```

That names no module, no class and no field. A developer who hits it has no way to tell which
class changed, so the usual response is to abandon the thread.

## Two triggers, and the second is the common one

| Change to the class | Real error | Before |
|---|---|---|
| a field removed | `got an unexpected keyword argument 'note'` | `ext_hook failed` |
| a required field added, no `AddField` | `missing 1 required positional argument: 'reason'` | `ext_hook failed` |
| a field added **with a default** | none | revives, and needs no migration |

Row 2 is the likely mistake. Row 3 explains the asymmetry: a missing key can reach a class
default, an extra key has no absorber at any level.

## The fix

`TypeError` joins the caught types, and the recorded message names the identity.

```
Cannot revive test_serde.FieldShape.Persisted: TypeError: FieldShape.Persisted.__init__() got an
unexpected keyword argument 'note'. The class may have been renamed or removed, or its fields may
have changed, since the checkpoint was written.
```

The `EXT_INTERRUPT` arm of the same function already catches `TypeError` and formats this message
style. This makes the two arms consistent.

## Scope

This is a diagnostic change.

- It does NOT make a mismatched revive succeed.
- It does NOT add a way to drop a field. `Operation` is still `RenameEvent | AddField`.
- It does NOT change behaviour for a payload that revives today.
- A raising `__post_init__` raises `ValueError`, so it stays opaque. `tests/test_serde.py` records
  that limitation, and the note is intact. Its test passes unchanged, which shows the new catch
  does not swallow that case.

## Test

`1267 passed, 1 skipped`. Three new cases: a removed field, an added required field, and an
unchanged class that still revives. Each was confirmed to fail first, for the stated reason.
