### PR TITLE
feat: scope namespace names to the graph, not the process (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The uniqueness guard moves to where ambiguity actually causes harm. Two *different* namespaces of
   the same name reaching one graph is still a `TypeError`, now naming both classes with their
   modules — reducer discovery and `graph.namespaces()` group by name, so within a graph the name
-  must resolve to one class. Nested events carry a `__namespace_cls__` stamp alongside
-  `__namespace__`, and `NamespaceModel.Namespace` gains a `cls` field (absent from `to_dict()` /
-  `json()`, so `schema_version` is unchanged).
+  must resolve to one class. Subscribed *and* produced event types are checked, so a handler
+  emitting another lifetime's class is caught too. Nested events carry a `__namespace_cls__` stamp
+  alongside `__namespace__`, namespace-scoped reducers match on that class rather than the name,
+  and `NamespaceModel.Namespace` gains a `cls` field (absent from `to_dict()` / `json()`, so
+  `schema_version` is unchanged).
 
   Lifetimes are **sequential, not concurrent**: checkpointed events are keyed by
   `(__module__, __qualname__)` and resolved by import, so two lifetimes of the same module share

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Namespace names are scoped to the graph, not the process** — `Namespace` no longer keeps a
+  process-global registry, so redefining a name a previous namespace used is valid. This lets one
+  process run several independent engine lifetimes in sequence: run a scenario, end it, and start a
+  fresh one that resumes the same checkpointed log, with no subprocess and no file hand-off
+  ([#148](https://github.com/cadance-io/langgraph-events/issues/148)).
+
+  ```python
+  importlib.reload(app.trading)          # lifetime 2 redefines Trading
+  second = app.trading.Trading
+  saver.serde = NamespaceAwareSerde(namespaces=[second])
+  graph = EventGraph([second.Place], checkpointer=saver)
+  graph.get_state(config).events.latest(second.Place.Placed)   # lifetime 1's log, lifetime 2's class
+  ```
+
+  The uniqueness guard moves to where ambiguity actually causes harm. Two *different* namespaces of
+  the same name reaching one graph is still a `TypeError`, now naming both classes with their
+  modules — reducer discovery and `graph.namespaces()` group by name, so within a graph the name
+  must resolve to one class. Nested events carry a `__namespace_cls__` stamp alongside
+  `__namespace__`, and `NamespaceModel.Namespace` gains a `cls` field (absent from `to_dict()` /
+  `json()`, so `schema_version` is unchanged).
+
+  Lifetimes are **sequential, not concurrent**: checkpointed events are keyed by
+  `(__module__, __qualname__)` and resolved by import, so two lifetimes of the same module share
+  that identity. Namespaces must be importable at module scope
+  ([#150](https://github.com/cadance-io/langgraph-events/issues/150)).
+
+  The only behaviour lost is the import-time `TypeError` on a duplicate namespace name. Code that
+  worked before had at most one class per name, so nothing that passed starts failing — unless it
+  deliberately asserted on that error.
+
 ## [0.25.1] - 2026-08-27
 
 ### Changed

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,7 @@
 
 | Export | Type | Description |
 |---|---|---|
-| `Namespace` | Base class | Namespace for nested commands and outcomes; exposes `__namespace_name__`, `__reducers__` |
+| `Namespace` | Base class | Namespace for nested commands and outcomes; exposes `__namespace_name__`, `__reducers__`. Names are unique per *graph*, not per process — see [namespace scope](concepts.md#namespace-scope) |
 | `Command` | Base class | Imperative intent; must be nested inside a `Namespace`, and may not itself be subclassed once declared (`class Rush(Order.Place)` is a `TypeError`). Auto-exposes `.Outcomes` — union of nested `DomainEvent`s. A `handle` method on the class registers as the command's inline handler when passed to `EventGraph` |
 | `DomainEvent` | Base class | Fact inside the domain; must be nested inside a `Namespace` or `Command` |
 | `IntegrationEvent` | Base class | Cross-boundary fact; top-level |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -223,6 +223,8 @@ EventGraph([one.Place, two.Place])
 # app.a.Trading and app.b.Trading. Namespace names must be unique within a graph.
 ```
 
+A namespace reached only through a handler's *return* type counts too, so a handler that subscribes to one lifetime and emits another's class is rejected the same way.
+
 Across graphs the name is free. That is what lets one process run several independent engine lifetimes in sequence — a test that runs a scenario, ends it, and starts a fresh one against the same checkpointed log:
 
 ```python

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -213,6 +213,37 @@ A `Namespace` is where related features attach:
 !!! note "On `Namespace`"
     `Namespace` is a namespace — for grouping. A richer construct (with identity and size discipline) may layer on top in a future release.
 
+### Namespace names are scoped to a graph { #namespace-scope }
+
+A namespace name identifies one namespace **within a graph**, not within the process. Two namespaces of the same name reaching a single graph is an error — reducer discovery and `graph.namespaces()` both group by name, so the name has to resolve to one class:
+
+```python
+EventGraph([one.Place, two.Place])
+# TypeError: Two different namespaces named 'Trading' reached this graph:
+# app.a.Trading and app.b.Trading. Namespace names must be unique within a graph.
+```
+
+Across graphs the name is free. That is what lets one process run several independent engine lifetimes in sequence — a test that runs a scenario, ends it, and starts a fresh one against the same checkpointed log:
+
+```python
+import importlib
+import app.trading
+
+first = app.trading.Trading
+saver.serde = NamespaceAwareSerde(namespaces=[first])
+EventGraph([first.Place], checkpointer=saver).invoke(first.Place(sym="AAPL"), config=config)
+
+importlib.reload(app.trading)          # lifetime 2
+second = app.trading.Trading
+saver.serde = NamespaceAwareSerde(namespaces=[second])
+graph = EventGraph([second.Place], checkpointer=saver)
+
+graph.get_state(config).events.latest(second.Place.Placed)   # revived as lifetime 2's class
+```
+
+!!! warning "Sequential, not concurrent"
+    Checkpointed events are keyed by `(__module__, __qualname__)`, and that identity resolves through a module import. Two lifetimes of the same module therefore share it: once the second lifetime exists, the first one's graph no longer revives its own events. Run lifetimes one after another, not side by side. Namespaces must also be importable at module scope — one defined inside a function cannot be revived at all ([#150](https://github.com/cadance-io/langgraph-events/issues/150)).
+
 ## System events
 
 `SystemEvent` subclasses control runtime flow; subscribe like any event. See [Control Flow](control-flow.md) for `Interrupted` / `Resumed`, `HandlerRaised`, `HandlerRetried`, `InvariantViolated`. Full table in [API](api.md#system-events).

--- a/src/langgraph_events/_event.py
+++ b/src/langgraph_events/_event.py
@@ -63,8 +63,10 @@ class Event:
 
 
 _FINALIZED_ATTR = "__lge_namespace_finalized__"
-"""Marker set on a Namespace once ``__init_subclass__`` has run far enough for
-``on_namespace_finalize`` callbacks to see a fully stamped class. Read via
+"""Marker set on a Namespace at the point ``__init_subclass__`` reaches the
+stamping passes — the same point the old process-global registry recorded the
+class, so ``on_namespace_finalize`` fires immediately from exactly where it
+always did. Not a claim that stamping has finished: it has not. Read via
 ``__dict__`` so subclasses never inherit it."""
 
 

--- a/src/langgraph_events/_event.py
+++ b/src/langgraph_events/_event.py
@@ -62,10 +62,10 @@ class Event:
         new_events.append(self)
 
 
-_NAMESPACE_REGISTRY: dict[str, type[Namespace]] = {}
-"""Maps ``__namespace_name__`` -> Namespace class. Populated in
-``Namespace.__init_subclass__``. Used by ``EventGraph`` to auto-discover
-declarative reducers via a handler's subscribed event types."""
+_FINALIZED_ATTR = "__lge_namespace_finalized__"
+"""Marker set on a Namespace once ``__init_subclass__`` has run far enough for
+``on_namespace_finalize`` callbacks to see a fully stamped class. Read via
+``__dict__`` so subclasses never inherit it."""
 
 
 _NAMESPACE_FINALIZE_CALLBACKS: weakref.WeakKeyDictionary[
@@ -92,17 +92,34 @@ def on_namespace_finalize(cls: type, callback: Callable[[type, type], None]) -> 
     references via ``vars(namespace_cls)`` without touching private state.
     Multiple callbacks for the same class fire in registration order.
 
+    "Already finalized" is read from a marker set inside
+    ``Namespace.__init_subclass__`` via ``__dict__`` rather than ``getattr``,
+    so a child Namespace mid-definition does not inherit its parent's marker
+    and fire callbacks early.
+
     If the enclosing Namespace has *already* finalized when this hook is
     called (e.g. a decorator applied post-hoc to an existing class), the
     callback fires immediately rather than queueing into a slot that will
     never drain.
     """
-    namespace_name = getattr(cls, "__namespace__", None)
-    namespace_cls = _NAMESPACE_REGISTRY.get(namespace_name) if namespace_name else None
-    if namespace_cls is not None:
+    namespace_cls = getattr(cls, "__namespace_cls__", None)
+    if namespace_cls is not None and namespace_cls.__dict__.get(_FINALIZED_ATTR):
         callback(cls, namespace_cls)
         return
     _NAMESPACE_FINALIZE_CALLBACKS.setdefault(cls, []).append(callback)
+
+
+def _stamp_namespace(cls: type, namespace_cls: type) -> None:
+    """Record the owning namespace on *cls*, as both a name and a class.
+
+    The two stamps are always written together and never separately: the name
+    is what renderers and the model group by, the class is what reducer
+    discovery and reflection resolve through. Letting them drift would make a
+    graph silently attribute an event to a different namespace of the same
+    name.
+    """
+    cls.__namespace__ = namespace_cls.__name__  # type: ignore[attr-defined]
+    cls.__namespace_cls__ = namespace_cls  # type: ignore[attr-defined]
 
 
 def _iter_nested_events(container: type, *, recurse_commands: bool) -> list[type]:
@@ -183,20 +200,16 @@ class Namespace:
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
-        existing = _NAMESPACE_REGISTRY.get(cls.__name__)
-        if existing is not None and existing is not cls:
-            raise TypeError(
-                f"Namespace {cls.__name__!r} is already defined at "
-                f"{existing.__module__}.{existing.__qualname__}. Namespace "
-                f"class names must be unique within a process."
-            )
         cls.__namespace_name__ = cls.__name__
         cls.__reducers__ = _collect_namespace_reducers(cls)
-        _NAMESPACE_REGISTRY[cls.__namespace_name__] = cls
+        # Marks the point from which ``on_namespace_finalize`` fires callbacks
+        # immediately instead of queueing them. Set before the stamping passes
+        # below, matching the sequence callers have always observed.
+        setattr(cls, _FINALIZED_ATTR, True)
         # Second-pass stamp: DomainEvents nested inside a Command have their
         # __namespace__ left as None by the metaclass (Command.__namespace__ isn't
         # known at that point). Fill them in now.
-        _stamp_nested_namespace(cls, cls.__name__)
+        _stamp_nested_namespace(cls, cls)
         _attach_command_outcomes(cls)
         _drain_namespace_finalize(cls, cls)
 
@@ -257,9 +270,9 @@ def _attach_command_outcomes(namespace_cls: type) -> None:
         )
 
 
-def _stamp_nested_namespace(container: type, namespace_name: str) -> None:
-    """Walk ``container`` and set ``__namespace__`` on any nested ``Event``
-    subclass that doesn't have one yet.
+def _stamp_nested_namespace(container: type, namespace_cls: type) -> None:
+    """Walk ``container`` and stamp the owning namespace on any nested
+    ``Event`` subclass that doesn't have one yet.
 
     Covers DomainEvents nested inside a Command (their metaclass runs before
     the Command's ``__namespace__`` is known), and non-DomainEvent events
@@ -273,9 +286,9 @@ def _stamp_nested_namespace(container: type, namespace_name: str) -> None:
         if not issubclass(attr, Event):
             continue
         if getattr(attr, "__namespace__", None) is None:
-            attr.__namespace__ = namespace_name  # type: ignore[attr-defined]
+            _stamp_namespace(attr, namespace_cls)
         if issubclass(attr, Command):
-            _stamp_nested_namespace(attr, namespace_name)
+            _stamp_nested_namespace(attr, namespace_cls)
 
 
 def _is_nested_in_class(cls: type) -> bool:
@@ -313,10 +326,10 @@ class _NestedEventMeta(type):
                     f"Command {cls.__name__!r} must be nested inside a "
                     f"Namespace subclass, got owner {owner.__name__!r}"
                 )
-            cls.__namespace__ = owner.__name__
+            _stamp_namespace(cls, owner)
         elif issubclass(cls, DomainEvent):
             if isinstance(owner, type) and issubclass(owner, Namespace):
-                cls.__namespace__ = owner.__name__
+                _stamp_namespace(cls, owner)
                 cls.__command__ = None
             elif isinstance(owner, type) and issubclass(owner, Command):
                 cls.__command__ = owner
@@ -433,6 +446,7 @@ class Command(Event, _event_base=True, metaclass=_NestedEventMeta):
     """
 
     __namespace__: ClassVar[str | None] = None
+    __namespace_cls__: ClassVar[type | None] = None
     __command_handler__: ClassVar[Any] = None
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
@@ -533,6 +547,7 @@ class DomainEvent(Event, _event_base=True, metaclass=_NestedEventMeta):
     """
 
     __namespace__: ClassVar[str | None] = None
+    __namespace_cls__: ClassVar[type | None] = None
     __command__: ClassVar[type | None] = None
 
     def __init_subclass__(cls, **kwargs: Any) -> None:

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -56,7 +56,14 @@ from langgraph_events._namespace import NamespaceModel
 from langgraph_events._namespace._command_privacy import enforce_command_privacy
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
+    from collections.abc import (
+        AsyncIterator,
+        Callable,
+        Iterable,
+        Iterator,
+        Mapping,
+        Sequence,
+    )
 
     from langchain_core.runnables import RunnableConfig
     from langgraph.graph.state import CompiledStateGraph
@@ -401,39 +408,114 @@ def _verify_inline_outcome_coverage(meta: HandlerMeta, info: ReturnInfo) -> None
     )
 
 
+def _register_graph_namespaces(
+    event_types: Iterable[type], found: dict[str, type[Namespace]]
+) -> None:
+    """Record each event's owning namespace into *found*, rejecting collisions.
+
+    Two *distinct* classes sharing a name is rejected: reducer discovery and
+    reflection both group by name, so within a single graph the name must
+    identify one class. Across graphs it need not, and does not — that is what
+    lets several independent engine lifetimes coexist in one process (#148).
+
+    Called once for subscribed types and again for produced ones. A handler
+    subscribing to one lifetime and returning another's class would otherwise
+    merge the two silently, and reflection would answer from whichever arrived
+    first.
+    """
+    for et in event_types:
+        namespace_cls = getattr(et, "__namespace_cls__", None)
+        if namespace_cls is None:
+            continue
+        existing = found.setdefault(namespace_cls.__name__, namespace_cls)
+        if existing is namespace_cls:
+            continue
+        # Two lifetimes of one module render identically as module.qualname,
+        # which is precisely the case this check exists for — say what
+        # actually differs instead of printing one string twice.
+        here = f"{existing.__module__}.{existing.__qualname__}"
+        there = f"{namespace_cls.__module__}.{namespace_cls.__qualname__}"
+        detail = (
+            f"{here} and {there}"
+            if here != there
+            else (
+                f"two distinct definitions of {here} "
+                f"({id(existing):#x} and {id(namespace_cls):#x}) — most likely "
+                f"one module reloaded between engine lifetimes"
+            )
+        )
+        raise TypeError(
+            f"Two different namespaces named {namespace_cls.__name__!r} "
+            f"reached this graph: {detail}. Namespace names must be unique "
+            f"within a graph."
+        )
+
+
+def _register_produced_types(
+    handler_metas: list[HandlerMeta],
+    return_info: dict[str, ReturnInfo],
+    namespaces: dict[str, type[Namespace]],
+) -> None:
+    """Fold handlers' return types into the graph's namespace registry, then
+    warn about events produced but never consumed.
+
+    Both jobs need the same subscribed/produced split, and both are only
+    possible once return-type introspection has run. Registering here completes
+    the registry: a namespace reachable only through a handler's return type is
+    as much part of this graph as a subscribed one, and just as able to collide.
+    """
+    subscribed: set[type[Event]] = set()
+    for meta in handler_metas:
+        subscribed.update(meta.event_types)
+    produced: set[type[Event]] = set()
+    for info in return_info.values():
+        produced.update(info.event_types)
+        produced.update(info.scatter_types)
+
+    _register_graph_namespaces(produced, namespaces)
+
+    orphaned = {
+        t
+        for t in produced
+        if not issubclass(t, (Halted, Interrupted))
+        # A DomainEvent owned by a Namespace or Command — as an outcome
+        # (__command__ set) or as a free-standing domain fact
+        # (__namespace__ set) — is a terminal by design; having no
+        # subscriber is idiomatic, not an orphan.
+        and not (
+            issubclass(t, DomainEvent)
+            and (
+                getattr(t, "__command__", None) is not None
+                or getattr(t, "__namespace__", None) is not None
+            )
+        )
+        and not any(issubclass(t, s) for s in subscribed)
+    }
+    if orphaned:
+        names = ", ".join(sorted(t.__name__ for t in orphaned))
+        warnings.warn(
+            f"Event type(s) {names} are returned by handlers but no handler "
+            f"subscribes to them. These events will be produced but never "
+            f"processed.",
+            category=OrphanedEventWarning,
+            # __init__ calls this helper, so the user's EventGraph(...) call
+            # site is one frame further out than it was inline.
+            stacklevel=3,
+        )
+
+
 def _collect_graph_namespaces(
     handlers: list[Callable[..., Any]],
 ) -> dict[str, type[Namespace]]:
-    """Name → Namespace class for every namespace this graph touches.
+    """Name → Namespace class for the namespaces this graph's handlers subscribe to.
 
-    The graph's own registry. Namespaces are stamped onto their nested events
-    at class-definition time (``__namespace_cls__``), so the map is derived
-    from the handlers rather than from process-global state — which is what
-    lets several independent engine lifetimes coexist in one process (#148).
-
-    Two *distinct* classes sharing a name is rejected here: reducer discovery
-    and reflection both group by name, so within a single graph the name must
-    identify one class. Across graphs it need not, and does not.
-
-    Scope: subscribed event types, the same reach reducer discovery has. A
-    collision visible only through *produced* types surfaces later, in the
-    model — return-type introspection has not run at this point.
+    The graph's own registry, seeded from the ``__namespace_cls__`` stamps
+    rather than from process-global state. Produced types are folded in later
+    in ``EventGraph.__init__``, once return-type introspection has run.
     """
     found: dict[str, type[Namespace]] = {}
     for fn in handlers:
-        for et in getattr(fn, "_event_types", ()):
-            namespace_cls = getattr(et, "__namespace_cls__", None)
-            if namespace_cls is None:
-                continue
-            existing = found.setdefault(namespace_cls.__name__, namespace_cls)
-            if existing is not namespace_cls:
-                raise TypeError(
-                    f"Two different namespaces named {namespace_cls.__name__!r} "
-                    f"reached this graph: "
-                    f"{existing.__module__}.{existing.__qualname__} and "
-                    f"{namespace_cls.__module__}.{namespace_cls.__qualname__}. "
-                    f"Namespace names must be unique within a graph."
-                )
+        _register_graph_namespaces(getattr(fn, "_event_types", ()), found)
     return found
 
 
@@ -817,40 +899,9 @@ class EventGraph:
             self._return_contracts[meta.name] = _compute_return_contract(meta, info)
             _verify_inline_outcome_coverage(meta, info)
 
-        # Warn about event types that are produced but never consumed
-        subscribed: set[type[Event]] = set()
-        for meta in self._handler_metas:
-            subscribed.update(meta.event_types)
-        produced: set[type[Event]] = set()
-        for info in self._return_info.values():
-            produced.update(info.event_types)
-            produced.update(info.scatter_types)
-        orphaned = {
-            t
-            for t in produced
-            if not issubclass(t, (Halted, Interrupted))
-            # A DomainEvent owned by a Namespace or Command — as an outcome
-            # (__command__ set) or as a free-standing domain fact
-            # (__namespace__ set) — is a terminal by design; having no
-            # subscriber is idiomatic, not an orphan.
-            and not (
-                issubclass(t, DomainEvent)
-                and (
-                    getattr(t, "__command__", None) is not None
-                    or getattr(t, "__namespace__", None) is not None
-                )
-            )
-            and not any(issubclass(t, s) for s in subscribed)
-        }
-        if orphaned:
-            names = ", ".join(sorted(t.__name__ for t in orphaned))
-            warnings.warn(
-                f"Event type(s) {names} are returned by handlers but no handler "
-                f"subscribes to them. These events will be produced but never "
-                f"processed.",
-                category=OrphanedEventWarning,
-                stacklevel=2,
-            )
+        _register_produced_types(
+            self._handler_metas, self._return_info, self._namespaces
+        )
 
         enforce_command_privacy(self._handler_metas, self._return_info)
         self._verify_error_handling()

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -15,7 +15,6 @@ from langgraph.types import Command as LGCommand
 
 from langgraph_events._custom_event import STATE_SNAPSHOT_EVENT_NAME
 from langgraph_events._event import (
-    _NAMESPACE_REGISTRY,
     OUTCOMES_ATTR,
     Command,
     DomainEvent,
@@ -402,15 +401,52 @@ def _verify_inline_outcome_coverage(meta: HandlerMeta, info: ReturnInfo) -> None
     )
 
 
-def _discover_namespace_reducers(
+def _collect_graph_namespaces(
     handlers: list[Callable[..., Any]],
+) -> dict[str, type[Namespace]]:
+    """Name → Namespace class for every namespace this graph touches.
+
+    The graph's own registry. Namespaces are stamped onto their nested events
+    at class-definition time (``__namespace_cls__``), so the map is derived
+    from the handlers rather than from process-global state — which is what
+    lets several independent engine lifetimes coexist in one process (#148).
+
+    Two *distinct* classes sharing a name is rejected here: reducer discovery
+    and reflection both group by name, so within a single graph the name must
+    identify one class. Across graphs it need not, and does not.
+
+    Scope: subscribed event types, the same reach reducer discovery has. A
+    collision visible only through *produced* types surfaces later, in the
+    model — return-type introspection has not run at this point.
+    """
+    found: dict[str, type[Namespace]] = {}
+    for fn in handlers:
+        for et in getattr(fn, "_event_types", ()):
+            namespace_cls = getattr(et, "__namespace_cls__", None)
+            if namespace_cls is None:
+                continue
+            existing = found.setdefault(namespace_cls.__name__, namespace_cls)
+            if existing is not namespace_cls:
+                raise TypeError(
+                    f"Two different namespaces named {namespace_cls.__name__!r} "
+                    f"reached this graph: "
+                    f"{existing.__module__}.{existing.__qualname__} and "
+                    f"{namespace_cls.__module__}.{namespace_cls.__qualname__}. "
+                    f"Namespace names must be unique within a graph."
+                )
+    return found
+
+
+def _discover_namespace_reducers(
+    namespaces: dict[str, type[Namespace]],
     explicit_reducers: dict[str, BaseReducer],
 ) -> None:
-    """Auto-register reducers declared on domains referenced by handlers.
+    """Auto-register reducers declared on the graph's namespaces.
 
-    Walks each handler's ``_event_types`` (set by ``@on(...)``), finds the
-    owning domain via ``__namespace__`` + ``_NAMESPACE_REGISTRY``, and unions that
-    domain's ``__reducers__`` into *explicit_reducers*.
+    Unions each namespace's ``__reducers__`` into *explicit_reducers*.
+    *namespaces* is the graph's own registry from
+    ``_collect_graph_namespaces``, so discovery never reaches a same-named
+    namespace belonging to another graph.
 
     Collisions:
     - Two different discovered reducers with the same name → ``TypeError``.
@@ -418,23 +454,16 @@ def _discover_namespace_reducers(
       one → explicit wins; discovered one is skipped silently.
     """
     discovered: dict[str, BaseReducer] = {}
-    for fn in handlers:
-        for et in getattr(fn, "_event_types", ()):
-            namespace_name = getattr(et, "__namespace__", None)
-            if not namespace_name:
-                continue
-            namespace_cls = _NAMESPACE_REGISTRY.get(namespace_name)
-            if namespace_cls is None:
-                continue
-            for r in namespace_cls.__reducers__:
-                existing = discovered.get(r.name)
-                if existing is None:
-                    discovered[r.name] = r
-                elif existing is not r:
-                    raise TypeError(
-                        f"Reducer name {r.name!r} collides between domains: "
-                        f"{existing!r} and {r!r}"
-                    )
+    for namespace_cls in namespaces.values():
+        for r in namespace_cls.__reducers__:
+            existing = discovered.get(r.name)
+            if existing is None:
+                discovered[r.name] = r
+            elif existing is not r:
+                raise TypeError(
+                    f"Reducer name {r.name!r} collides between domains: "
+                    f"{existing!r} and {r!r}"
+                )
     # Merge into explicit; explicit wins on name conflict.
     for name, r in discovered.items():
         explicit_reducers.setdefault(name, r)
@@ -730,7 +759,8 @@ class EventGraph:
         self._checkpointer = checkpointer
         self._store = store
         self._reducers: dict[str, BaseReducer] = {r.name: r for r in (reducers or [])}
-        _discover_namespace_reducers(handlers, self._reducers)
+        self._namespaces = _collect_graph_namespaces(handlers)
+        _discover_namespace_reducers(self._namespaces, self._reducers)
         conflicts = set(self._reducers.keys()) & set(_BASE_FIELDS.keys())
         if conflicts:
             raise ValueError(

--- a/src/langgraph_events/_namespace/_model.py
+++ b/src/langgraph_events/_namespace/_model.py
@@ -203,11 +203,18 @@ class NamespaceModel:
         ``events`` holds any ``Event`` nested in the domain that is not an
         outcome of one of its commands — typically free-standing DomainEvents,
         but also ``Halted`` subtypes nested in the domain for locality.
+
+        ``cls`` is the Namespace class itself, carried so consumers can walk
+        the real class body for nested events no handler references. ``None``
+        for a namespace reconstructed without one. Deliberately absent from
+        ``to_dict()`` / ``json()`` — a class object has no place in a JSON
+        snapshot.
         """
 
         name: str
         commands: dict[str, NamespaceModel.Command]
         events: tuple[type[Event], ...]
+        cls: type | None = None
 
     @dataclass(frozen=True)
     class Command:
@@ -397,6 +404,21 @@ Reaction: TypeAlias = NamespaceModel.CommandHandler | NamespaceModel.Policy
 # ---------------------------------------------------------------------------
 
 
+def _namespace_entry(
+    namespaces: dict[str, dict[str, Any]], name: str, event_type: type
+) -> dict[str, Any]:
+    """Bucket for *name*, recording the owning Namespace class on first sight.
+
+    The class comes off the event's ``__namespace_cls__`` stamp rather than a
+    global lookup, so a model built from one graph's handlers never resolves a
+    same-named namespace belonging to another (#148).
+    """
+    entry = namespaces.setdefault(name, {"commands": {}, "events": [], "cls": None})
+    if entry["cls"] is None:
+        entry["cls"] = getattr(event_type, "__namespace_cls__", None)
+    return entry
+
+
 def _classify_event_bucket(  # noqa: PLR0911, PLR0912
     event_type: type[Event],
     namespaces: dict[str, dict[str, Any]],
@@ -425,7 +447,7 @@ def _classify_event_bucket(  # noqa: PLR0911, PLR0912
         namespace_name = getattr(event_type, "__namespace__", None)
         if namespace_name is None:
             return
-        entry = namespaces.setdefault(namespace_name, {"commands": {}, "events": []})
+        entry = _namespace_entry(namespaces, namespace_name, event_type)
         cmd_entry = entry["commands"].setdefault(
             event_type.__name__, {"type": event_type, "outcomes": []}
         )
@@ -446,7 +468,7 @@ def _classify_event_bucket(  # noqa: PLR0911, PLR0912
         namespace_name = getattr(event_type, "__namespace__", None)
         if namespace_name is None:
             return
-        entry = namespaces.setdefault(namespace_name, {"commands": {}, "events": []})
+        entry = _namespace_entry(namespaces, namespace_name, event_type)
         cmd = getattr(event_type, "__command__", None)
         if cmd is not None:
             cmd_entry = entry["commands"].setdefault(
@@ -462,7 +484,7 @@ def _classify_event_bucket(  # noqa: PLR0911, PLR0912
     # membership beats IntegrationEvent/SystemEvent classification.
     namespace_name = getattr(event_type, "__namespace__", None)
     if namespace_name is not None:
-        entry = namespaces.setdefault(namespace_name, {"commands": {}, "events": []})
+        entry = _namespace_entry(namespaces, namespace_name, event_type)
         if event_type not in entry["events"]:
             entry["events"].append(event_type)
         return
@@ -615,6 +637,7 @@ def _build_domain_model(  # noqa: PLR0912
             name=namespace_name,
             commands=commands,
             events=tuple(raw["events"]),
+            cls=raw["cls"],
         )
 
     # Seed events: sources that never appear as targets, excluding

--- a/src/langgraph_events/_reducer.py
+++ b/src/langgraph_events/_reducer.py
@@ -79,10 +79,15 @@ def _last_write_wins(existing: Any, new: Any) -> Any:
 
 
 def _matches_namespace(event: Any, dom: type[Namespace] | None) -> bool:
-    """Return True if *event* belongs to *dom* (or *dom* is None = no filter)."""
+    """Return True if *event* belongs to *dom* (or *dom* is None = no filter).
+
+    Membership is the namespace *object*. Names are unique only within a
+    graph, so matching on ``__namespace__`` would let one engine lifetime's
+    reducer fold an event from another lifetime of the same module (#148).
+    """
     if dom is None:
         return True
-    return getattr(type(event), "__namespace__", None) == dom.__namespace_name__
+    return getattr(type(event), "__namespace_cls__", None) is dom
 
 
 class BaseReducer(ABC):

--- a/src/langgraph_events/_reflection/_tool.py
+++ b/src/langgraph_events/_reflection/_tool.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from langgraph_events._event import (
-    _NAMESPACE_REGISTRY,
     Command,
     DomainEvent,
     Event,
@@ -56,14 +55,13 @@ class QueryTool:
 
 
 def _model_classes(model: NamespaceModel, log: EventLog) -> list[type[Event]]:
-    """Every event class queryable by name: registered namespaces (walked via
-    the framework's blessed nested-event iterator), model-only namespaces,
-    integration/system events, and anything present in the log."""
+    """Every event class queryable by name: namespaces that carry their class
+    (walked via the framework's blessed nested-event iterator), model-only
+    namespaces, integration/system events, and anything present in the log."""
     classes: list[type[Event]] = []
-    for name, namespace in model.namespaces.items():
-        registered = _NAMESPACE_REGISTRY.get(name)
-        if registered is not None:
-            classes.extend(_iter_nested_events(registered, recurse_commands=True))
+    for namespace in model.namespaces.values():
+        if namespace.cls is not None:
+            classes.extend(_iter_nested_events(namespace.cls, recurse_commands=True))
         else:
             for command in namespace.commands.values():
                 classes.append(command.cls)

--- a/src/langgraph_events/serde/migrations/_core.py
+++ b/src/langgraph_events/serde/migrations/_core.py
@@ -534,9 +534,10 @@ def migrate_from(
 
     Metadata is stashed on the class as ``__lge_migrate_from__`` (and
     ``__lge_origin_backfill__`` for the per-origin fills).
-    :class:`NamespaceAwareSerde` walks ``_NAMESPACE_REGISTRY`` at
-    construction and assembles a :class:`Migration` per decorated class
-    automatically — no separate collection step is required.
+    :class:`NamespaceAwareSerde` walks the namespaces passed to its
+    ``namespaces=`` argument at construction and assembles a
+    :class:`Migration` per decorated class automatically — no separate
+    collection step is required.
     """
     if not old_qualnames:
         raise ValueError("@migrate_from requires at least one historic qualname.")

--- a/tests/_lifetime_namespaces.py
+++ b/tests/_lifetime_namespaces.py
@@ -1,0 +1,25 @@
+"""A consumer's namespace module, reloaded once per engine lifetime.
+
+Module-level so the serde's identity walk resolves it, and so inline handler
+return annotations resolve at runtime. See tests/test_lifetimes.py.
+"""
+
+from __future__ import annotations
+
+from langgraph_events import Command, DomainEvent, Namespace, ScalarReducer
+
+
+class Trading(Namespace):
+    last_symbol = ScalarReducer(
+        event_type=Command,
+        fn=lambda e: getattr(e, "sym", None),
+    )
+
+    class Place(Command):
+        sym: str
+
+        class Placed(DomainEvent):
+            sym: str
+
+        def handle(self) -> Trading.Place.Placed:
+            return Trading.Place.Placed(sym=self.sym)

--- a/tests/_lifetime_namespaces.py
+++ b/tests/_lifetime_namespaces.py
@@ -15,6 +15,9 @@ class Trading(Namespace):
         fn=lambda e: getattr(e, "sym", None),
     )
 
+    class Noted(DomainEvent):
+        sym: str
+
     class Place(Command):
         sym: str
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,20 +110,3 @@ def linear_chain():
         return Ended(result=f"done:{event.data}")
 
     return EventGraph([step1, step2])
-
-
-@pytest.fixture(autouse=True)
-def _reset_domain_registry():
-    """Restore ``_NAMESPACE_REGISTRY`` after each test.
-
-    Namespace names are enforced unique process-wide. Tests that define their
-    own ``class X(Namespace)`` would otherwise leak into the registry and
-    collide with later tests using the same short name. conftest-scoped
-    domains (e.g. ``Order``) are captured in the snapshot and survive.
-    """
-    from langgraph_events import _event as _e
-
-    snapshot = dict(_e._NAMESPACE_REGISTRY)
-    yield
-    _e._NAMESPACE_REGISTRY.clear()
-    _e._NAMESPACE_REGISTRY.update(snapshot)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -289,16 +289,42 @@ def describe_Namespace():
 
     def when_redefined():
 
+        # Namespace names are scoped to the graph that uses them, not to the
+        # process — a second engine lifetime redefining the same name is
+        # valid. The collision that matters (two classes, one name, one
+        # graph) is caught at graph build. See issue #148.
         def with_colliding_name():
 
-            def it_raises():
+            def it_does_not_raise():
                 class Widget(Namespace):
                     pass
 
-                with pytest.raises(TypeError, match=r"already defined"):
+                first = Widget
 
-                    class Widget(Namespace):
+                class Widget(Namespace):
+                    pass
+
+                assert Widget is not first
+
+    def when_nested_events_are_stamped():
+
+        def it_records_the_owning_namespace_class():
+            class Widget(Namespace):
+                class Build(Command):
+                    class Built(DomainEvent):
                         pass
+
+            assert Widget.Build.__namespace_cls__ is Widget
+            assert Widget.Build.Built.__namespace_cls__ is Widget
+
+        def it_keeps_both_stamps_in_step():
+            class Widget(Namespace):
+                class Build(Command):
+                    class Built(DomainEvent):
+                        pass
+
+            for cls in (Widget.Build, Widget.Build.Built):
+                assert cls.__namespace__ == cls.__namespace_cls__.__name__
 
 
 def describe_Command():

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -746,6 +746,39 @@ def describe_on_namespace_finalize():
 
             assert captured == [LateRefNs.Sibling]
 
+    def when_registered_while_the_enclosing_Namespace_is_still_being_created():
+        def it_queues_rather_than_firing_on_a_half_built_class():
+            # A nested class is stamped with __namespace_cls__ by
+            # __set_name__, which runs *before* the Namespace's
+            # __init_subclass__. Anything running in that window — here a
+            # sibling descriptor's own __set_name__ — must still queue: the
+            # enclosing class has not attached Command.Outcomes yet, which
+            # is the whole reason this hook exists.
+            seen_outcomes: list[object] = []
+
+            class Sentinel:
+                def __set_name__(self, owner, name):
+                    cmd = owner.__dict__["Cmd"]
+                    assert getattr(cmd, "__namespace_cls__", None) is not None
+                    on_namespace_finalize(
+                        cmd,
+                        lambda c, ns: seen_outcomes.append(
+                            getattr(c, "Outcomes", None)
+                        ),
+                    )
+                    # Firing now would hand the callback a Command with no
+                    # Outcomes attached.
+                    assert seen_outcomes == []
+
+            class MidBuildNs(Namespace):
+                class Cmd(Command):
+                    class Done(DomainEvent):
+                        pass
+
+                sentinel = Sentinel()
+
+            assert seen_outcomes == [MidBuildNs.Cmd.Done]
+
     def when_registered_after_the_enclosing_Namespace_finalized():
         def it_fires_immediately_instead_of_silently_dropping():
             class FinishedNs(Namespace):

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -3908,6 +3908,28 @@ def describe_OrphanedEventWarning():
             with pytest.warns(OrphanedEventWarning, match="Orphan"):
                 EventGraph([produce_orphan])
 
+        def it_points_at_user_code_not_library_internals():
+            # Regression guard: stacklevel must walk past the library frames
+            # so the warning surfaces the user's `EventGraph(...)` line. Went
+            # unpinned until the emit moved out of __init__ into a helper and
+            # the stale stacklevel anchored the warning at `sys:1`.
+            class AnchorOrphan(IntegrationEvent):
+                pass
+
+            @on(Started)
+            def produce_orphan(event: Started) -> AnchorOrphan:
+                return AnchorOrphan()
+
+            with pytest.warns(OrphanedEventWarning) as captured:
+                EventGraph([produce_orphan])
+
+            filename = captured[0].filename
+            assert "langgraph_events" not in filename, (
+                f"warning anchored to library file {filename!r}; expected user "
+                f"code. Check stacklevel in _register_produced_types."
+            )
+            assert filename.endswith("test_event_graph.py")
+
         def it_warns_for_orphaned_scatter_types():
             class ScatterOrphan(IntegrationEvent):
                 pass

--- a/tests/test_lifetimes.py
+++ b/tests/test_lifetimes.py
@@ -1,0 +1,141 @@
+"""Several independent engine lifetimes in one process (issue #148).
+
+Namespace names identify a namespace within a *graph*, not within a process,
+so a second lifetime may redefine a name the first one used. These tests are
+the end-to-end proof: a lifetime runs, checkpoints, ends, and a fresh lifetime
+resumes the same log against freshly-defined classes.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import _lifetime_namespaces
+import pytest
+from langgraph.checkpoint.memory import MemorySaver
+
+from langgraph_events import Command, DomainEvent, EventGraph, Namespace, on
+from langgraph_events.serde import NamespaceAwareSerde
+
+
+def _next_lifetime():
+    """End the current lifetime and start a new one, as a redeploy would."""
+    importlib.reload(_lifetime_namespaces)
+    return _lifetime_namespaces.Trading
+
+
+def _make_trading():
+    """A `Trading` namespace unrelated to any other `Trading`."""
+
+    class Trading(Namespace):
+        class Place(Command):
+            sym: str
+
+            class Placed(DomainEvent):
+                sym: str
+
+    return Trading
+
+
+def describe_sequential_lifetimes():
+
+    def when_a_second_lifetime_redefines_the_same_namespace_name():
+
+        def it_does_not_raise():
+            first = _next_lifetime()
+            second = _next_lifetime()
+
+            assert first is not second
+            assert first.__namespace_name__ == second.__namespace_name__ == "Trading"
+
+        def it_gives_each_graph_its_own_namespace():
+            first = _next_lifetime()
+            graph_one = EventGraph([first.Place])
+            second = _next_lifetime()
+            graph_two = EventGraph([second.Place])
+
+            assert graph_one._namespaces["Trading"] is first
+            assert graph_two._namespaces["Trading"] is second
+
+        def it_discovers_reducers_from_its_own_lifetime():
+            first = _next_lifetime()
+            graph_one = EventGraph([first.Place])
+            second = _next_lifetime()
+            graph_two = EventGraph([second.Place])
+
+            # Same reducer *name* either side; the objects must not be shared.
+            assert graph_one._reducers["last_symbol"] is first.last_symbol
+            assert graph_two._reducers["last_symbol"] is second.last_symbol
+            assert first.last_symbol is not second.last_symbol
+
+    def when_the_second_lifetime_resumes_the_first_lifetimes_checkpoint():
+
+        def it_revives_the_log_against_the_new_classes():
+            saver = MemorySaver()
+            config = {"configurable": {"thread_id": "lifetimes"}}
+
+            first = _next_lifetime()
+            saver.serde = NamespaceAwareSerde(namespaces=[first])
+            EventGraph([first.Place], checkpointer=saver).invoke(
+                first.Place(sym="AAPL"), config=config
+            )
+
+            second = _next_lifetime()
+            saver.serde = NamespaceAwareSerde(namespaces=[second])
+            graph_two = EventGraph([second.Place], checkpointer=saver)
+
+            revived = graph_two.get_state(config).events.latest(second.Place.Placed)
+
+            assert revived.sym == "AAPL"
+            assert type(revived) is second.Place.Placed
+            assert type(revived) is not first.Place.Placed
+
+    def when_reflection_queries_the_second_lifetime():
+
+        def it_resolves_names_to_that_lifetimes_classes():
+            first = _next_lifetime()
+            EventGraph([first.Place]).namespaces()
+            second = _next_lifetime()
+
+            model = EventGraph([second.Place]).namespaces()
+
+            assert model.namespaces["Trading"].cls is second
+            assert model.namespaces["Trading"].commands["Place"].cls is second.Place
+
+
+def describe_namespaces_reaching_one_graph():
+
+    # Within a single graph the name must identify one class: reducer
+    # discovery and reflection both group by it.
+    def when_two_different_namespaces_share_a_name():
+
+        def it_raises_naming_both_classes():
+            one, two = _make_trading(), _make_trading()
+
+            @on(one.Place)
+            def handle_one(event: object) -> None:
+                return None
+
+            @on(two.Place)
+            def handle_two(event: object) -> None:
+                return None
+
+            with pytest.raises(
+                TypeError, match=r"Two different namespaces named 'Trading'"
+            ):
+                EventGraph([handle_one, handle_two])
+
+    def when_two_handlers_share_one_namespace():
+
+        def it_does_not_raise():
+            one = _make_trading()
+
+            @on(one.Place)
+            def handle_a(event: object) -> None:
+                return None
+
+            @on(one.Place.Placed)
+            def handle_b(event: object) -> None:
+                return None
+
+            assert EventGraph([handle_a, handle_b])._namespaces["Trading"] is one

--- a/tests/test_lifetimes.py
+++ b/tests/test_lifetimes.py
@@ -6,8 +6,6 @@ the end-to-end proof: a lifetime runs, checkpoints, ends, and a fresh lifetime
 resumes the same log against freshly-defined classes.
 """
 
-from __future__ import annotations
-
 import importlib
 
 import _lifetime_namespaces
@@ -15,6 +13,7 @@ import pytest
 from langgraph.checkpoint.memory import MemorySaver
 
 from langgraph_events import Command, DomainEvent, EventGraph, Namespace, on
+from langgraph_events._reducer import _matches_namespace
 from langgraph_events.serde import NamespaceAwareSerde
 
 
@@ -125,6 +124,49 @@ def describe_namespaces_reaching_one_graph():
             ):
                 EventGraph([handle_one, handle_two])
 
+    def when_a_produced_type_belongs_to_another_lifetime():
+
+        # Subscribed types alone are not enough: a handler can subscribe to
+        # one lifetime and *return* another's class, which merges the two
+        # silently in the model and makes reflection answer from the wrong
+        # lifetime.
+        def it_raises():
+            first = _next_lifetime()
+            second = _next_lifetime()
+
+            @on(first.Noted)
+            def react(event: object) -> second.Place:
+                return second.Place(sym="AAPL")
+
+            with pytest.raises(
+                TypeError, match=r"Two different namespaces named 'Trading'"
+            ):
+                EventGraph([react])
+
+    def when_both_definitions_come_from_one_module():
+
+        # Two lifetimes of one module render identically as
+        # module.qualname, so the message has to say more than that or it
+        # names the same string twice and explains nothing.
+        def it_does_not_name_the_same_string_twice():
+            first = _next_lifetime()
+            second = _next_lifetime()
+
+            @on(first.Place)
+            def handle_one(event: object) -> None:
+                return None
+
+            @on(second.Place)
+            def handle_two(event: object) -> None:
+                return None
+
+            with pytest.raises(TypeError) as exc:
+                EventGraph([handle_one, handle_two])
+
+            label = f"{first.__module__}.{first.__qualname__}"
+            assert f"{label} and {label}" not in str(exc.value)
+            assert "reloaded" in str(exc.value)
+
     def when_two_handlers_share_one_namespace():
 
         def it_does_not_raise():
@@ -139,3 +181,26 @@ def describe_namespaces_reaching_one_graph():
                 return None
 
             assert EventGraph([handle_a, handle_b])._namespaces["Trading"] is one
+
+
+def describe_namespace_scoped_reducers():
+
+    # A declarative reducer on a Namespace folds only that namespace's
+    # events. Membership is the namespace *object*, not its name — with
+    # names no longer unique process-wide, a name match would let one
+    # lifetime's reducer fold another's event. Tested at the predicate
+    # because the graph-build guards make an end-to-end repro unreachable.
+    def when_the_event_belongs_to_another_lifetime():
+
+        def it_does_not_match():
+            first = _next_lifetime()
+            second = _next_lifetime()
+
+            assert not _matches_namespace(first.Place.Placed(sym="AAPL"), second)
+
+    def when_the_event_belongs_to_that_namespace():
+
+        def it_matches():
+            first = _next_lifetime()
+
+            assert _matches_namespace(first.Place.Placed(sym="AAPL"), first)

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -2757,8 +2757,6 @@ def describe_renamed_inline_command_resume():
             def it_resumes_a_checkpoint_paused_under_the_old_class():
                 import sys
 
-                from langgraph_events._event import _NAMESPACE_REGISTRY
-
                 @on(_RelockGo)
                 def go(event: _RelockGo) -> None:
                     return None
@@ -2775,7 +2773,6 @@ def describe_renamed_inline_command_resume():
                     # The new release: the old class definition is gone, the
                     # surviving class declares both rename tracks.
                     delattr(mod, "OldLocker")
-                    _NAMESPACE_REGISTRY.pop("OldLocker", None)
                     saver.serde = NamespaceAwareSerde(namespaces=[Locker])
                     after = EventGraph([Locker.Persist, go], checkpointer=saver)
 
@@ -2786,7 +2783,6 @@ def describe_renamed_inline_command_resume():
                     assert log.has(Locker.Persist)
                 finally:
                     mod.OldLocker = old_ns
-                    _NAMESPACE_REGISTRY["OldLocker"] = old_ns
 
 
 def describe_assert_all_baselined_handlers_cover():


### PR DESCRIPTION
Closes #148.

## Problem

`Namespace` kept a process-global `_NAMESPACE_REGISTRY` and raised `TypeError` when a name was already taken. A consumer wanting two engine lifetimes in one process — lifetime 1 defines `Trading` and checkpoints, lifetime 2 resumes that log — had to spawn a subprocess per lifetime or hand the log across processes through a file.

## Why the registry existed, and why it does not need to

It was **definition-time state serving build-time lookups**. `__namespace__` is a name string, so a global map was the only way back from a name to the class. But the class object was already in hand at every stamping site: `_NestedEventMeta.__set_name__` receives `owner` and already stamped `cls.__command__ = owner` as a direct reference.

Nested events now carry `__namespace_cls__` alongside `__namespace__`, written together by a single `_stamp_namespace` helper so the two can never drift, and `EventGraph` builds its own `_namespaces` map from its handlers.

The three former readers are all local now:

| Reader | Now |
|---|---|
| `_discover_namespace_reducers` | consumes the graph's `_namespaces` map |
| `_reflection/_tool.py::_model_classes` | reads `NamespaceModel.Namespace.cls` |
| `on_namespace_finalize` | reads a `__lge_namespace_finalized__` marker via `__dict__`, so a child Namespace never inherits its parent's |

The uniqueness guard moves to where ambiguity causes harm. Two *different* namespaces of one name reaching a single graph is still a `TypeError`, now naming both classes with their modules:

```
TypeError: Two different namespaces named 'Trading' reached this graph:
app.a.Trading and app.b.Trading. Namespace names must be unique within a graph.
```

Across graphs the name is free — which is what makes lifetimes work:

```python
importlib.reload(app.trading)          # lifetime 2
second = app.trading.Trading
saver.serde = NamespaceAwareSerde(namespaces=[second])
graph = EventGraph([second.Place], checkpointer=saver)
graph.get_state(config).events.latest(second.Place.Placed)   # lifetime 1's log, lifetime 2's class
```

## Known bound: sequential, not concurrent

Checkpointed events are keyed by `(__module__, __qualname__)` and resolved by import, so two lifetimes of one module share that identity — once lifetime 2 exists, lifetime 1's graph no longer revives its own events. Namespaces must also be importable at module scope; one defined inside a function cannot be revived at all.

Both are pre-existing properties of `_resolve_identity`, which this PR neither causes nor worsens. Filed as #150. The docs section carries the warning explicitly.

## Compatibility

Non-breaking. Code that worked before had at most one class per namespace name, or it would already have raised at import — so nothing that passed starts failing. The one thing lost is the import-time `TypeError` itself, which matters only to code that deliberately asserted on it.

`NamespaceModel.Namespace` gains `cls` with a default, deliberately absent from `to_dict()` / `json()` — a class object has no place in a JSON snapshot — so `schema_version` is unchanged.

## Verification

```
1276 passed, 1 skipped     ruff: All checks passed
mypy: no issues (44 files) 80 files already formatted
```

The strongest signal: `tests/conftest.py`'s autouse `_reset_domain_registry` fixture is **deleted**. It existed solely to snapshot and restore the global, and 1200+ existing tests stay green without it.

New `tests/test_lifetimes.py` covers redefinition, per-graph reducer discovery, per-graph reflection, the cross-lifetime checkpoint resume, and both collision cases. I mutation-tested it — disabling the collision `raise` and dropping `cls=raw["cls"]` each killed exactly the test that should catch it, so it is not passing vacuously.

## Incidental

- Reducer discovery consumes the graph's namespace map rather than re-walking the handlers; this also gives `_namespaces` a production reader instead of leaving it speculative state.
- Corrects a pre-existing docstring in `serde/migrations/_core.py` claiming `NamespaceAwareSerde` walks `_NAMESPACE_REGISTRY` — it walks `namespaces=`.

Also filed while investigating: #150 (scoped serde resolution) and #151 (a misleading outcome-coverage diagnostic). Neither blocks this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
