### PR TITLE
test: pin revivable_identities to the namespace walk exactly (#154)

### DIFF
--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -18,6 +18,7 @@ from langgraph_events import (
     Command,
     DomainEvent,
     EventGraph,
+    Halted,
     IntegrationEvent,
     Interrupted,
     Namespace,
@@ -429,6 +430,53 @@ class FactoryScoped(Namespace):
     class Persisted(DomainEvent):
         tags: list[str]
         note: str = ""
+
+
+# Fixture that carries one of every member shape a ``Namespace`` body can
+# hold, so ``revivable_identities`` can be pinned as an exact set rather
+# than by membership. Set membership is what makes an OVER-BROAD identity
+# set invisible, and an over-broad set is the direction that silently
+# weakens ``assert_all_baselined_cover`` (#154). Deliberately carries no
+# ``@migrate_from``: the walk and the rename table are pinned separately.
+class WalkShapes(Namespace):
+    # Not a class at all — the walk must step over it.
+    LABEL = "not-an-event"
+
+    # A class that is not an ``Event`` — likewise stepped over.
+    class Helper:
+        pass
+
+    # DomainEvent nested directly in the Namespace.
+    class Recorded(DomainEvent):
+        note: str = ""
+
+    # Non-DomainEvent event nested in the Namespace for locality. The
+    # metaclass never fires for these, so only the walk reaches them.
+    class Blocked(Halted):
+        reason: str = ""
+
+    # Single-outcome Command: ``Outcomes`` is the nested class itself, the
+    # alias ``_iter_nested_events`` skips so it is not re-visited.
+    class Record(Command):
+        note: str = ""
+
+        # Reached only because the walk recurses into Commands.
+        class Stored(DomainEvent):
+            note: str = ""
+
+        # Non-DomainEvent nested inside a Command — same recursion.
+        class Stalled(Halted):
+            reason: str = ""
+
+    # Multi-outcome Command: ``Outcomes`` is a ``UnionType``, not a class.
+    class Amend(Command):
+        note: str = ""
+
+        class Amended(DomainEvent):
+            note: str = ""
+
+        class Rejected(DomainEvent):
+            reason: str = ""
 
 
 # Namespace whose nested ``Reviewed`` is an ``Interrupted`` subclass. This is
@@ -2017,8 +2065,44 @@ def describe_NamespaceAwareSerde():
         # unioned — users want one question answered, "will this revive?",
         # not "live or migrated?").
 
-        def it_returns_every_revivable_identity():
+        def it_equals_the_identities_the_namespace_walk_reaches():
+            # Exact equality, not membership: the gate that consumes this
+            # set (``assert_all_baselined_cover``) only asks whether a
+            # baselined identity is present, so an identity the walk never
+            # reached would make the gate pass on a checkpoint the read
+            # path cannot actually revive (#154).
+            module = WalkShapes.__module__
 
+            ids = NamespaceAwareSerde(namespaces=[WalkShapes]).revivable_identities()
+
+            assert ids == {
+                # DomainEvent nested directly in the Namespace.
+                (module, "WalkShapes.Recorded"),
+                # Non-DomainEvent nested in the Namespace for locality.
+                (module, "WalkShapes.Blocked"),
+                # The Command classes themselves — they are Events too, and
+                # a checkpointed command is as revivable as its outcomes.
+                (module, "WalkShapes.Record"),
+                (module, "WalkShapes.Amend"),
+                # Nested inside a Command: reached only by the
+                # ``recurse_commands=True`` descent.
+                (module, "WalkShapes.Record.Stored"),
+                (module, "WalkShapes.Record.Stalled"),
+                (module, "WalkShapes.Amend.Amended"),
+                (module, "WalkShapes.Amend.Rejected"),
+            }
+            # The namespace itself, its non-event members and the synthesized
+            # ``Outcomes`` aliases contribute nothing — asserted by the
+            # equality above, called out here because each is a distinct
+            # branch of the walk.
+            assert (module, "WalkShapes") not in ids
+            assert (module, "WalkShapes.Helper") not in ids
+
+        def it_unions_the_walk_and_every_rename_source():
+            # The other half of the set: historic identities are revivable
+            # because a rename rewrites them, from either source of
+            # migrations. Exact equality again — AddField targets and
+            # rename *destinations* must add nothing of their own.
             serde = NamespaceAwareSerde(
                 namespaces=[DecoReorg],
                 migrations=[
@@ -2028,12 +2112,15 @@ def describe_NamespaceAwareSerde():
 
             ids = serde.revivable_identities()
 
-            # Live class reached by the namespace walk.
-            assert (DecoReorg.__module__, "DecoReorg.Persist.Persisted") in ids
-            # Decorator-driven historic source.
-            assert (DecoReorg.__module__, "DecoReorg.Persisted") in ids
-            # Hand-authored historic source.
-            assert ("legacy.persona", "Legacy.Approved") in ids
+            assert ids == {
+                # Live classes reached by the namespace walk.
+                (DecoReorg.__module__, "DecoReorg.Persist"),
+                (DecoReorg.__module__, "DecoReorg.Persist.Persisted"),
+                # Decorator-driven historic source.
+                (DecoReorg.__module__, "DecoReorg.Persisted"),
+                # Hand-authored historic source.
+                ("legacy.persona", "Legacy.Approved"),
+            }
 
         def it_returns_a_read_only_frozenset():
             serde = NamespaceAwareSerde(namespaces=[DecoReorg])

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -2091,10 +2091,18 @@ def describe_NamespaceAwareSerde():
                 (module, "WalkShapes.Amend.Amended"),
                 (module, "WalkShapes.Amend.Rejected"),
             }
-            # The namespace itself, its non-event members and the synthesized
-            # ``Outcomes`` aliases contribute nothing — asserted by the
-            # equality above, called out here because each is a distinct
-            # branch of the walk.
+            # The namespace itself and its non-event members contribute
+            # nothing — asserted by the equality above, called out here
+            # because each is a distinct branch of the walk.
+            #
+            # The ``Outcomes`` aliases are NOT pinned here, and this set
+            # cannot pin them: for single-outcome ``Record`` the alias is the
+            # same class object as ``Stored``, which set semantics absorb,
+            # and for multi-outcome ``Amend`` it is a ``UnionType`` that
+            # fails the walk's ``isinstance(attr, type)`` guard on its own.
+            # The ``OUTCOMES_ATTR`` skip earns its keep in the walk's *list*
+            # (double-visited callbacks, double-applied AddFields), which
+            # ``it_lists_the_outcome_only_once`` covers.
             assert (module, "WalkShapes") not in ids
             assert (module, "WalkShapes.Helper") not in ids
 
@@ -2103,10 +2111,23 @@ def describe_NamespaceAwareSerde():
             # because a rename rewrites them, from either source of
             # migrations. Exact equality again — AddField targets and
             # rename *destinations* must add nothing of their own.
+            #
+            # The AddField is keyed on a live class OUTSIDE namespaces=, so
+            # it lands in _addfield_table with no overlap against the walk or
+            # the rename sources. Without it the claim about AddField targets
+            # would be a comment rather than an assertion: an empty table
+            # cannot distinguish "not unioned in" from "nothing to union".
             serde = NamespaceAwareSerde(
                 namespaces=[DecoReorg],
                 migrations=[
                     _persona_rename("legacy-rename"),
+                    _add_field_migration(
+                        "out-of-scope-fill",
+                        module=Persona.__module__,
+                        qualname="Persona.Approve.Approved",
+                        field="note",
+                        default="",
+                    ),
                 ],
             )
 


### PR DESCRIPTION
Closes #154.

## The gap

`assert_all_baselined_cover` is a set-membership gate over `NamespaceAwareSerde.revivable_identities()`. That makes it exactly as trustworthy as that set being what the namespace walk actually reached — and nothing pinned it. An **over-broad** set makes the gate pass on a checkpoint the read path cannot revive, which is the direction that matters: the gate exists to stop a checkpoint becoming unrevivable across a release.

Reproduced on `main` before touching anything, with the issue's own mutant:

```python
self._live_identities = frozenset(scope) | {("x", "Y")}
```
```
1291 passed, 1 skipped
```

Unmoved. The opposite mutant (`frozenset()`) *is* caught — 2 failures — so the set was pinned as non-empty, never as accurate.

## What this pins

A `WalkShapes` fixture carrying one of every member shape a `Namespace` body can hold, and an **exact set equality** on `revivable_identities()` rather than membership of a few:

- `DomainEvent` nested directly in the `Namespace`
- `DomainEvent`s nested inside a `Command` (the `recurse_commands=True` descent)
- the `Command` classes themselves
- a non-`DomainEvent` event nested for locality (`Halted`), both in the `Namespace` and inside a `Command`
- non-class members and non-`Event` classes, which must contribute nothing
- the synthesized `Outcomes` alias, single-outcome (a class) and multi-outcome (a `UnionType`)

The existing membership test on the migration half is upgraded to exact equality too, so rename *destinations* and `AddField` targets are pinned as adding nothing of their own.

## Mutants run against the new tests

| # | Mutant | Result |
|---|---|---|
| 1 | `_live_identities ∪ {("x","Y")}` (the issue's) | caught — `Extra items in the left set: ('x', 'Y')` |
| 2 | `frozenset(list(scope)[1:])` — drop a legitimate identity | caught, both tests |
| 3 | `recurse_commands=False` in the collect walk | caught — 4 nested identities missing |
| 4 | walk narrowed to `DomainEvent` only | caught — Commands and `Halted` subclasses missing |
| 5 | `revivable_identities` also unions rename destinations | caught — `Persona.Approve.Approved` leaks in |
| 6 | `revivable_identities` drops the rename table | caught — both historic sources missing |
| 7 | `_iter_nested_events` stops skipping `Outcomes` | **not caught here**, by design — see below |

## No runtime check, deliberately

The issue asks whether an unexpected extra identity should be a runtime error. It should not, because there is no non-tautological form of that check. `_live_identities` is `frozenset(scope)` — the same walk that would have to supply the oracle. A guard comparing the set to its own source asserts `X == X`: it is unreachable without monkeypatching, and it cannot see an over-broad *walk*, because the walk is the definition of truth. The only oracle that is genuinely independent is a test that writes the expected set down by hand, which is what this PR adds.

A refactor collapsing `_live_identities` into a `frozenset(self._scope)` computed in `revivable_identities()` was considered and rejected: it makes the two structurally un-driftable but only relocates the hole, and it is a production change with no test pressure behind it.

## Test-only

No behaviour change, so no `CHANGELOG.md` entry and no `docs/event-migrations.md` change. `revivable_identities()` semantics are untouched — in particular it is **not** widened to count importable-but-out-of-scope identities (rejected in #150).

## Verification

```
1292 passed, 1 skipped
ruff check: clean · ruff format --check: 80 files already formatted · mypy: No issues found
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
