### PR TITLE
feat!: remove namespace subclassing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **Namespace subclassing** — `class Child(Base)` where `Base` is a `Namespace` now raises
+  `TypeError`. Deprecated in 0.27.0 with a one-minor-version grace period, removed here.
+
+  Only reducers ever inherited. Nested commands and events did not, which left a child namespace
+  quietly incomplete: `EventGraph.from_namespaces` skipped its inherited inline handlers, and its
+  inherited events fell outside a serde's scope and bled across engine lifetimes
+  ([#157](https://github.com/cadance-io/langgraph-events/issues/157)).
+
+  Declare each namespace independently. To share a reducer, declare it free-standing — with no
+  owning namespace — and pass it via `reducers=[...]`. A reducer declared on the old parent stays
+  bound to that parent and folds nothing for anyone else.
+
+  Composing a non-`Namespace` mixin (`class Task(Namespace, Auditable)`) is unaffected.
+
 ## [0.27.0] - 2026-08-28
 
 ### Added

--- a/docs/reducers.md
+++ b/docs/reducers.md
@@ -41,7 +41,7 @@ graph = EventGraph([Order.Place])   # reducer auto-discovered from Order
 ```
 
 - Only sees events whose `__namespace__` matches.
-- Child namespaces inherit parent reducers (dedup by name). **Deprecated** — subclassing a `Namespace` emits a `DeprecationWarning` and will be removed. Only reducers ever inherited; nested commands and events do not, so a child namespace is incomplete for graph building and serde scoping. Declare each namespace independently. To share a reducer, declare it free-standing (no owning namespace) and pass it via `reducers=[...]` — a reducer declared on the parent namespace stays bound to that namespace and would fold nothing for the child.
+- Namespaces do not inherit: `class Child(Base)` where `Base` is a `Namespace` raises `TypeError`. To share a reducer, declare it free-standing (no owning namespace) and pass it via `reducers=[...]`.
 - Cross-namespace name collisions raise `TypeError` at graph construction.
 - Explicit `reducers=[...]` wins on conflict with an auto-discovered reducer.
 

--- a/src/langgraph_events/_event.py
+++ b/src/langgraph_events/_event.py
@@ -12,8 +12,6 @@ import weakref
 from dataclasses import fields as dc_fields
 from typing import TYPE_CHECKING, Any, ClassVar, dataclass_transform
 
-from langgraph_events._warn import warn_user
-
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -207,36 +205,28 @@ class Namespace:
         # Subclassing one Namespace from another was never a designed
         # capability — it fell out of the MRO walk that collects declarative
         # reducers, and only reducers ever inherited. Nested commands and
-        # events do not, which makes a child namespace quietly incomplete:
-        # its inherited commands are skipped by ``EventGraph.from_namespaces``
-        # and its inherited events fall outside a serde's scope, reviving by
+        # events did not, which left a child namespace quietly incomplete:
+        # its inherited commands skipped by ``EventGraph.from_namespaces``
+        # and its inherited events outside a serde's scope, reviving by
         # import and so bleeding across engine lifetimes (#148, #150).
-        # Deprecated rather than widened: the library moved toward
-        # composition, and #141 forbade Command inheritance outright.
-        if any(
-            base is not Namespace
+        # Deprecated in 0.27.0, removed here. A non-Namespace mixin is
+        # unaffected — that is composition, not a second namespace.
+        inherited = [
+            base
+            for base in cls.__bases__
+            if base is not Namespace
             and isinstance(base, type)
             and issubclass(base, Namespace)
-            for base in cls.__bases__
-        ):
-            inherited = ", ".join(
-                b.__name__
-                for b in cls.__bases__
-                if b is not Namespace
-                and isinstance(b, type)
-                and issubclass(b, Namespace)
-            )
-            warn_user(
-                f"Namespace subclassing is deprecated: {cls.__name__!r} "
-                f"inherits from {inherited}. Only reducers inherit — nested "
-                f"commands and events do not, so the child namespace is "
-                f"incomplete for graph building and serde scoping. Declare "
-                f"the namespace independently. To share a reducer, declare "
-                f"it free-standing (no owning namespace) and pass it via "
-                f"`reducers=[...]` — a reducer declared on the parent stays "
-                f"bound to the parent and would fold nothing. Support will "
-                f"be removed in a future release.",
-                DeprecationWarning,
+        ]
+        if inherited:
+            names = ", ".join(b.__name__ for b in inherited)
+            raise TypeError(
+                f"Namespace subclassing is not supported: {cls.__name__!r} "
+                f"inherits from {names}. Only reducers ever inherited, which "
+                f"left the child incomplete for graph building and serde "
+                f"scoping. Declare each namespace independently; to share a "
+                f"reducer, declare it free-standing (no owning namespace) "
+                f"and pass it via `reducers=[...]`."
             )
         cls.__namespace_name__ = cls.__name__
         cls.__reducers__ = _collect_namespace_reducers(cls)
@@ -255,7 +245,8 @@ class Namespace:
 def _collect_namespace_reducers(cls: type) -> tuple[Any, ...]:
     """Walk the MRO and collect declarative reducers from class bodies.
 
-    Child domains inherit parent domain's reducers; dedup by name.
+    Namespaces cannot inherit from one another, so the walk only ever reaches
+    *cls* itself and any non-Namespace mixins it composes. Dedup by name.
     Runtime import of ``BaseReducer`` to avoid module-level circular
     dependency with ``_reducer``.
     """

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -22,7 +22,6 @@ from langgraph_events import (
     Namespace,
     Resumed,
     RunPaused,
-    ScalarReducer,
     SystemEvent,
     on_namespace_finalize,
 )
@@ -300,31 +299,19 @@ def describe_Namespace():
 
     def when_subclassing_another_namespace():
 
-        # Namespace inheritance was never a requested capability — the MRO
-        # walk that grants it arrived incidentally, and the library moved
-        # toward composition instead (see #141 forbidding Command
-        # inheritance). Deprecated; reducers still inherit meanwhile.
-        def it_warns_that_inheritance_is_deprecated():
+        # Removed in v0.28.0 after one minor version of deprecation. Only
+        # reducers ever inherited; nested commands and events did not, so a
+        # child namespace was quietly incomplete — its inherited commands
+        # skipped by EventGraph.from_namespaces, its inherited events outside
+        # a serde's scope and bleeding across engine lifetimes.
+        def it_raises():
             class Parent(Namespace):
                 pass
 
-            with pytest.deprecated_call(match=r"Namespace subclassing"):
+            with pytest.raises(TypeError, match=r"Namespace subclassing"):
 
                 class Kid(Parent):
                     pass
-
-        def it_blames_the_class_definition_not_the_importer():
-            # __init_subclass__ runs from type.__new__, which is C and adds
-            # no Python frame. An off-by-one here attributes the warning to
-            # the importing module's `import` line.
-            import _deprecated_namespace_fixture as fixture
-
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter("always")
-                fixture.define_child()
-
-            assert caught
-            assert caught[0].filename.endswith("_deprecated_namespace_fixture.py")
 
         def it_names_only_the_namespace_bases():
             class Mixin:
@@ -333,25 +320,22 @@ def describe_Namespace():
             class Root(Namespace):
                 pass
 
-            with pytest.deprecated_call() as caught:
+            with pytest.raises(TypeError) as exc:
 
                 class Kid(Mixin, Root):
                     pass
 
-            message = str(caught[0].message)
-            assert "Root" in message
-            assert "Mixin" not in message
+            assert "Root" in str(exc.value)
+            assert "Mixin" not in str(exc.value)
 
-        def it_still_inherits_parent_reducers_meanwhile():
-            class Stock(Namespace):
-                shared = ScalarReducer(event_type=Event, fn=lambda e: None)
+        def it_still_allows_a_plain_mixin():
+            class Mixin:
+                pass
 
-            with pytest.deprecated_call():
+            class Solo(Namespace, Mixin):
+                pass
 
-                class Bond(Stock):
-                    pass
-
-            assert [r.name for r in Bond.__reducers__] == ["shared"]
+            assert Solo.__namespace_name__ == "Solo"
 
     def when_redefined():
 

--- a/tests/test_reducer_namespace.py
+++ b/tests/test_reducer_namespace.py
@@ -130,21 +130,16 @@ def describe_Namespace():
 
         def when_subclass_domain_adds_more():
 
-            def it_inherits_parent_reducers_and_adds_child():
-                # Namespace subclassing is deprecated — only reducers ever
-                # inherited, which is what makes a child namespace incomplete.
-                # Behaviour is kept for one minor version, so the assertion
-                # stands alongside the warning it now raises.
+            # Namespace subclassing is gone; this used to assert that a child
+            # inherited its parent's reducers. Sharing is now explicit.
+            def it_raises():
                 class Parent(Namespace):
                     shared = ScalarReducer(event_type=Event, fn=lambda e: None)
 
-                with pytest.deprecated_call(match=r"Namespace subclassing"):
+                with pytest.raises(TypeError, match=r"Namespace subclassing"):
 
                     class Child(Parent):
                         extra = ScalarReducer(event_type=Event, fn=lambda e: None)
-
-                names = {r.name for r in Child.__reducers__}
-                assert names == {"shared", "extra"}
 
 
 def describe_namespace_scope_filter():


### PR DESCRIPTION
Completes the deprecation cycle started in v0.27.0. `class Child(Base)` where `Base` is a `Namespace` now raises `TypeError`.

```
TypeError: Namespace subclassing is not supported: 'Kid' inherits from Parent.
Only reducers ever inherited, which left the child incomplete for graph building
and serde scoping. Declare each namespace independently; to share a reducer,
declare it free-standing (no owning namespace) and pass it via `reducers=[...]`.
```

## Why it went

Namespace inheritance was never a designed capability — the MRO walk that granted it arrived incidentally in the v0.4.x taxonomy commit, and only reducers ever inherited. Nested commands and events did not, which left a child namespace quietly incomplete:

- `EventGraph.from_namespaces(Child)` silently skipped its inherited inline handlers
- its inherited events fell outside a serde's scope, resolving by import and bleeding across engine lifetimes (#157)

The library had already moved the other way — #141 forbade Command inheritance, `migrate_from` is "not MRO-inherited", and the archetypes work chose composition.

## One deviation from the plan

I had proposed also dropping the MRO walk in `_collect_namespace_reducers`. On inspection it serves a second path: a **non-Namespace mixin** carrying a reducer, which is composition rather than a second namespace. With subclassing rejected the walk is inert for namespaces, so removing it would only have broken mixins — an unrelated change. It stays; its docstring no longer claims inheritance.

`class Task(Namespace, Auditable)` (as `examples/supervisor.py` uses) is unaffected, and now has a test.

## Verification

```
1314 passed, 1 skipped     ruff: All checks passed
mypy: no issues (46 files) 87 files already formatted
```

Written test-first, then mutation-checked:

| Mutant | |
|---|---|
| rejection removed entirely | killed (3) |
| rejection widened to catch plain mixins | killed (2) |

Breaking, so this wants a **minor** release (v0.28.0) with the `!` already in the commit subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
