### PR TITLE
fix: settle halted threads so on_unresumable='halt' leaves them inert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Halted` dispatch gate silently — a later `invoke()` on the same thread appended its event but
   never dispatched it, with no handler firing and no error raised.
 
-  Both are fixed by settling the thread through a three-superstep clear/append/clear write
-  (`clear` → append the terminal event with `_cursor`/`_pending` reset → `clear`) instead of a
-  single `update_state`, so a halted thread ends with nothing scheduled, no stale pending state,
-  and any completed sibling writes from a fanned-out superstep intact.
+Both are fixed by settling the thread through a three-superstep clear/append/clear write
+(`clear` → append the terminal event with `_cursor`/`_pending` reset → `clear`) instead of a
+single `update_state`, so a halted thread ends with nothing scheduled, no stale pending state,
+and any completed sibling writes from a fanned-out superstep intact.
 
 ## [0.28.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`on_unresumable="halt"` re-armed the thread it was supposed to retire.** The policy appended
-  its terminal `Unresumable(Halted)` with a single `update_state`, which re-ran routing against the
-  checkpoint's stale `_pending` and rescheduled the already-paused node. A later `resume()` then
-  passed the pending check and ran for real, writing the retired `Interrupted` identity back into
-  the event log.
+  its terminal `Unresumable(Halted)` event with a single `update_state` call. That call re-ran
+  routing against the checkpoint's stale `_pending` state. Routing then rescheduled the
+  already-paused node. A later `resume()` call then passed the pending check. It ran for real
+  and wrote the retired `Interrupted` identity back into the event log.
 
-- **A halted thread came back dead.** The same `update_state` call left `_cursor` behind the
-  appended terminal event, so it re-entered the *next* run's pending window and tripped the
-  `Halted` dispatch gate silently — a later `invoke()` on the same thread appended its event but
-  never dispatched it, with no handler firing and no error raised.
+- **A halted thread stopped dispatching events.** The same `update_state` call left `_cursor`
+  behind the appended terminal event. The event then re-entered the *next* run's pending window.
+  This tripped the `Halted` dispatch gate without an error. A later `invoke()` on the same
+  thread appended its event but did not dispatch it. No handler fired, and no error was raised.
 
-Both are fixed by settling the thread through a three-superstep clear/append/clear write
-(`clear` → append the terminal event with `_cursor`/`_pending` reset → `clear`) instead of a
-single `update_state`, so a halted thread ends with nothing scheduled, no stale pending state,
-and any completed sibling writes from a fanned-out superstep intact.
+Both defects are fixed by a three-superstep clear/append/clear write. The write clears pending
+tasks, appends the terminal event with `_cursor` and `_pending` reset, then clears again. This
+replaces the single `update_state` call. A halted thread now ends with nothing scheduled and no
+stale pending state. Any completed sibling write from a fanned-out superstep survives.
 
 ## [0.28.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`on_unresumable="halt"` re-armed the thread it was supposed to retire.** The policy appended
+  its terminal `Unresumable(Halted)` with a single `update_state`, which re-ran routing against the
+  checkpoint's stale `_pending` and rescheduled the already-paused node. A later `resume()` then
+  passed the pending check and ran for real, writing the retired `Interrupted` identity back into
+  the event log.
+
+- **A halted thread came back dead.** The same `update_state` call left `_cursor` behind the
+  appended terminal event, so it re-entered the *next* run's pending window and tripped the
+  `Halted` dispatch gate silently — a later `invoke()` on the same thread appended its event but
+  never dispatched it, with no handler firing and no error raised.
+
+  Both are fixed by settling the thread through a three-superstep clear/append/clear write
+  (`clear` → append the terminal event with `_cursor`/`_pending` reset → `clear`) instead of a
+  single `update_state`, so a halted thread ends with nothing scheduled, no stale pending state,
+  and any completed sibling writes from a fanned-out superstep intact.
+
 ## [0.28.0] - 2026-08-28
 
 ### Removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,47 @@
 
 Event-driven abstraction for LangGraph. State IS events.
 
+## Writing style
+
+CRITICAL: Always prioritise clarity of expression.
+
+Write in ASD-STE100 Simplified Technical English. This applies to every output: chat replies,
+commit messages, MR descriptions, issue text, plans, docstrings and code comments.
+
+| Limit | Value |
+|---|---|
+| Ideas per sentence | 1 |
+| Words per instruction / description | 20 / 25 |
+| Nouns per cluster (articles, adjectives excluded) | 3 |
+| Sentences per paragraph, one topic each | 6 |
+| Modals allowed | must, do not, can, recommended |
+
+- An instruction must use active voice. A description can stay passive. Do not invent an actor
+  to remove a passive.
+- Use simple tenses. Keep the subject, the verb and the article explicit.
+- Give each word one meaning and one part of speech. Pick one verb per action, then reuse it.
+- Keep a technical term when it is the right term. Define it on first use in each reply. Do not
+  reuse a term coined earlier in the session as if it were common vocabulary.
+- Do not use slang, metaphor or a contraction.
+- A parenthesis or an em-dash carries only a reference or a short aside. A requirement must be
+  its own sentence or table row.
+- `/` means "or" outside a code span. Do not join clauses with a semicolon.
+- Put the condition, and any warning, before the instruction. A warning must state the
+  consequence and the avoidance.
+
+Re-read any long-form output against this list before you send it. Long-form output means an MR
+description, issue text, a plan or a session summary. Cut what only makes sense from inside the
+conversation.
+
+Reason: a long session drifts. The model conditions on its own earlier output, so dense phrasing
+compounds until the reader cannot use it.
+
+WARNING: Never trade clarity for brevity. A cut scope qualifier or safety condition makes the
+text wrong. Cut words, keep every qualifier and condition.
+
 ## Commands
+
+Run all tooling through `uv`. Do not call bare `python` or `pytest`.
 
 - **Tests:** `uv run pytest tests/`
 - **Lint:** `uv run ruff check src/ tests/`
@@ -14,28 +54,39 @@ Event-driven abstraction for LangGraph. State IS events.
 - `src/langgraph_events/` — library source
 - `tests/` — BDD-style with pytest-describe (`describe_`/`when_`/`it_`)
 - `examples/` — usage examples
-- `scripts/release.py` — release automation (see below)
-
-## Release
-
-Use `uv run scripts/release.py {major|minor|patch|X.Y.Z}` — do not hand-edit version strings. The script bumps `pyproject.toml`/`README.md`/`docs/index.md`, stamps `[Unreleased]` in `CHANGELOG.md` with today's date, runs `uv lock`, commits as `release: vX.Y.Z`, and tags. Preflight requires a clean working tree on `main` or any `release/*` branch, plus a non-empty `[Unreleased]` section. Add `--dry-run` to preview. After it runs, the final message prints the exact `git push origin <branch> vX.Y.Z` command to run, which triggers the TestPyPI → PyPI publish workflow.
+- `scripts/release.py` — release automation
 
 ## Conventions
 
-- Python 3.11+, line length 88
-- Use `uv` to run all tooling (not bare `python` or `pytest`)
-- Ruff for linting and formatting (config in pyproject.toml)
-- mypy strict mode
-- Tests: `describe_` groups by API surface, `when_` mirrors code branches, `it_` names the assertion. Test each behavior once at the API boundary where it's consumed. Shared event classes in `conftest.py`; scenario-specific events inline. Event classes used as handler type annotations must be defined at module level (not inside `describe_`/`when_` blocks) so Python can resolve forward references at runtime.
+- Python 3.11+. Line length 88. mypy strict. Ruff lints and formats, configured in
+  `pyproject.toml`.
+- `describe_` groups by API surface. `when_` mirrors a code branch. `it_` names the assertion.
+- Test each behaviour once, at the API boundary where it is consumed.
+- Put a shared event class in `conftest.py`. Put a scenario-specific event inline.
+- WARNING: Python resolves a forward reference at runtime. An event class used as a handler type
+  annotation must be defined at module level, not inside a `describe_` or `when_` block.
+
+## Release
+
+Run `uv run scripts/release.py {major|minor|patch|X.Y.Z}`. Add `--dry-run` to preview.
+
+WARNING: Do not hand-edit a version string. The script owns every one of them.
+
+The script bumps `pyproject.toml`, `README.md` and `docs/index.md`, stamps `[Unreleased]` in
+`CHANGELOG.md` with today's date, runs `uv lock`, commits as `release: vX.Y.Z`, then tags.
+Preflight requires a clean working tree on `main` or any `release/*` branch, and a non-empty
+`[Unreleased]` section. The final message prints the exact `git push origin <branch> vX.Y.Z`
+command. That push triggers the TestPyPI to PyPI publish workflow.
 
 ## TDD
 
 Iron law: no production code without a failing test first.
 
-1. **Red** — write one failing test for the next behavior.
-2. **Verify red** — `uv run pytest tests/path::test` and confirm it fails for the *expected* reason (feature missing, not typo).
-3. **Green** — minimal implementation to pass. No extras, no future-proofing.
-4. **Verify green** — same test passes; full `uv run pytest tests/` stays green.
-5. **Refactor** — clean up while green. No new behavior.
+1. **Red.** Write one failing test for the next behaviour.
+2. **Verify red.** Run `uv run pytest tests/path::test`. Confirm it fails for the expected
+   reason. A missing feature is expected. A typo is not.
+3. **Green.** Write the minimal implementation that passes. Add no extra. Do not future-proof.
+4. **Verify green.** The same test passes. The full `uv run pytest tests/` stays green.
+5. **Refactor.** Clean up while green. Add no new behaviour.
 
-Never write implementation before its test. If you do, delete it and start the cycle properly.
+WARNING: Never write an implementation before its test. If you do, delete it and start again.

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict, cast
 
 from langgraph.graph import END, START, StateGraph
 from langgraph.types import Command as LGCommand
+from langgraph.types import StateUpdate
 
 from langgraph_events._custom_event import STATE_SNAPSHOT_EVENT_NAME
 from langgraph_events._event import (
@@ -1450,41 +1451,100 @@ class EventGraph:
             return True
         return False
 
+    @staticmethod
+    def _settle_supersteps(
+        events: EventLog, terminal: Event
+    ) -> list[list[StateUpdate]]:
+        """Build the clear/append/clear supersteps that settle a thread onto
+        *terminal* at rest.
+
+        A plain single-superstep ``update_state`` re-runs routing against
+        whatever the checkpoint's ``_pending`` state key still holds — stale
+        once a node genuinely interrupted without ever writing its own
+        state update — re-scheduling that node for a later resume. It also
+        leaves ``_cursor`` behind the newly appended event, so the very next
+        dispatch treats *terminal* as freshly pending and, if it is a
+        ``Halted``, trips the halt gate silently.
+
+        Three supersteps fix both: the leading ``clear`` (``values=None,
+        as_node=END`` — LangGraph's documented "clear all tasks" branch,
+        which skips ``ERROR``/``INTERRUPT`` pending writes) discharges any
+        stale pending task *before* anything is appended, so a fanned-out
+        sibling's already-completed write is preserved rather than
+        superseded by a checkpoint that carries none of it. The middle
+        superstep appends *terminal* while resetting ``_cursor`` to the
+        post-append event count and clearing ``_pending``, so nothing is
+        left scheduled and the next run's cursor starts past *terminal*.
+        The trailing ``clear`` empties ``next``.
+        """
+        return [
+            [StateUpdate(None, END)],
+            [
+                StateUpdate(
+                    {
+                        "events": [terminal],
+                        "_cursor": len(events) + 1,
+                        "_pending": [],
+                    },
+                    "__seed__",
+                )
+            ],
+            [StateUpdate(None, END)],
+        ]
+
+    def _settle(self, config: Any, terminal: Event) -> EventLog:
+        """Append *terminal* and settle the thread to a clean rest state.
+
+        Runs the three-superstep clear/append/clear recipe (see
+        :meth:`_settle_supersteps`) through the sync checkpoint API, so the
+        thread ends with nothing scheduled and no stale ``_pending`` to
+        re-arm routing on a later resume, while preserving any sibling
+        writes from a fanned-out superstep.
+        """
+        events = self.get_state(config).events
+        self._compile().bulk_update_state(
+            cast("RunnableConfig", config),
+            self._settle_supersteps(events, terminal),
+        )
+        return self.get_state(config).events
+
+    async def _asettle(self, config: Any, terminal: Event) -> EventLog:
+        """Async sibling of :meth:`_settle` — every checkpoint read/write
+        uses the async API (``aget_state``/``abulk_update_state``) so
+        async-only checkpointers aren't driven synchronously."""
+        events = (await self.aget_state(config)).events
+        await self._compile().abulk_update_state(
+            cast("RunnableConfig", config),
+            self._settle_supersteps(events, terminal),
+        )
+        return (await self.aget_state(config)).events
+
     def _apply_unresumable_policy(
         self, value: Event, kwargs: dict[str, Any]
     ) -> EventLog:
         """Sync ``on_unresumable`` for a resume that would be a no-op.
 
         Called only when :meth:`_resume_is_pending` is ``False``. The ``halt``
-        arm appends a terminal ``Unresumable(Halted)`` so the abandoned thread
-        ends observably; the thread is already inert (not pending), so
-        ``update_state`` only records the event.
+        arm settles the thread onto a terminal ``Unresumable(Halted)`` (see
+        :meth:`_settle`) so the abandoned thread ends observably, with
+        nothing left scheduled and no stale pending state to trip on a
+        later resume or dispatch.
         """
         config = kwargs.get("config")
         if self._unresumable_short_circuits():
             return self.get_state(config).events
-        self._compile().update_state(
-            cast("RunnableConfig", config),
-            {"events": [self._unresumable_event(value)]},
-            as_node="__seed__",
-        )
-        return self.get_state(config).events
+        return self._settle(config, self._unresumable_event(value))
 
     async def _aapply_unresumable_policy(
         self, value: Event, kwargs: dict[str, Any]
     ) -> EventLog:
         """Async sibling of :meth:`_apply_unresumable_policy` — every checkpoint
-        read/write uses the async API (``aget_state``/``aupdate_state``) so
+        read/write uses the async API (``aget_state``/``_asettle``) so
         async-only checkpointers aren't driven synchronously."""
         config = kwargs.get("config")
         if self._unresumable_short_circuits():
             return (await self.aget_state(config)).events
-        await self._compile().aupdate_state(
-            cast("RunnableConfig", config),
-            {"events": [self._unresumable_event(value)]},
-            as_node="__seed__",
-        )
-        return (await self.aget_state(config)).events
+        return await self._asettle(config, self._unresumable_event(value))
 
     @staticmethod
     def _unresumable_event(value: Event) -> Unresumable:

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -1466,24 +1466,37 @@ class EventGraph:
         dispatch treats *terminal* as freshly pending and, if it is a
         ``Halted``, trips the halt gate silently.
 
-        Three supersteps fix both: the leading ``clear`` (``values=None,
-        as_node=END`` — LangGraph's documented "clear all tasks" branch,
-        which skips ``ERROR``/``INTERRUPT`` pending writes) discharges any
-        stale pending task *before* anything is appended, so a fanned-out
-        sibling's already-completed write is preserved rather than
-        superseded by a checkpoint that carries none of it. The middle
-        superstep appends *terminal* while resetting ``_cursor`` to the
-        post-append event count and clearing ``_pending``, so nothing is
-        left scheduled and the next run's cursor starts past *terminal*.
-        The trailing ``clear`` empties ``next``.
+        The leading ``clear`` (``values=None, as_node=END`` — LangGraph's
+        documented "clear all tasks" branch, which skips ``ERROR``/
+        ``INTERRUPT`` pending writes) discharges any stale pending task
+        *before* anything is appended, so a fanned-out sibling's
+        already-completed write is preserved rather than superseded by a
+        checkpoint that carries none of it. The middle superstep appends
+        *terminal* while resetting ``_cursor`` to the post-append event
+        count, so the next run's cursor starts past *terminal* instead of
+        re-entering its pending window. These two are pinned by the test
+        suite: dropping either fails
+        ``it_preserves_completed_sibling_writes`` or
+        ``it_leaves_the_thread_usable`` respectively.
+
+        The trailing ``clear`` and clearing ``_pending`` alongside the
+        append are deliberate belt-and-braces against the stale-``_pending``
+        re-arming this primitive exists to fix, but neither is independently
+        pinned by the suite as it stands: ablating either one alone still
+        leaves every current test green (only dropping both fails). Kept
+        anyway — they're cheap, and the mechanism they guard against
+        (routing re-run against a stale ``_pending`` on some future
+        checkpointer/LangGraph combination this suite doesn't exercise) is
+        exactly what defect 1 was.
         """
+        appended = [terminal]
         return [
             [StateUpdate(None, END)],
             [
                 StateUpdate(
                     {
-                        "events": [terminal],
-                        "_cursor": len(events) + 1,
+                        "events": appended,
+                        "_cursor": len(events) + len(appended),
                         "_pending": [],
                     },
                     "__seed__",
@@ -1501,6 +1514,14 @@ class EventGraph:
         re-arm routing on a later resume, while preserving any sibling
         writes from a fanned-out superstep.
         """
+        # Must read through `get_state`, not the checkpoint directly: its
+        # snapshot applies pending writes the same way the leading clear in
+        # `_settle_supersteps` will commit them, so `len(events)` here
+        # matches what the leading clear actually lands. A direct
+        # checkpoint read (e.g. `checkpointer.get_tuple` or a `get_state`
+        # pinned to a `checkpoint_id`, either of which skips pending-write
+        # application) would undercount, leaving `_cursor` short and
+        # putting the terminal event back in the next run's pending window.
         events = self.get_state(config).events
         self._compile().bulk_update_state(
             cast("RunnableConfig", config),
@@ -1512,6 +1533,8 @@ class EventGraph:
         """Async sibling of :meth:`_settle` — every checkpoint read/write
         uses the async API (``aget_state``/``abulk_update_state``) so
         async-only checkpointers aren't driven synchronously."""
+        # See `_settle` — must read through `aget_state`, not the
+        # checkpoint directly, for the same pending-writes-applied reason.
         events = (await self.aget_state(config)).events
         await self._compile().abulk_update_state(
             cast("RunnableConfig", config),

--- a/src/langgraph_events/_graph.py
+++ b/src/langgraph_events/_graph.py
@@ -1458,36 +1458,14 @@ class EventGraph:
         """Build the clear/append/clear supersteps that settle a thread onto
         *terminal* at rest.
 
-        A plain single-superstep ``update_state`` re-runs routing against
-        whatever the checkpoint's ``_pending`` state key still holds — stale
-        once a node genuinely interrupted without ever writing its own
-        state update — re-scheduling that node for a later resume. It also
-        leaves ``_cursor`` behind the newly appended event, so the very next
-        dispatch treats *terminal* as freshly pending and, if it is a
-        ``Halted``, trips the halt gate silently.
+        The leading clear (``values=None, as_node=END``, LangGraph's
+        clear-all-tasks branch) skips ``ERROR``/``INTERRUPT`` pending
+        writes, preserving an already-completed write from a fanned-out
+        sibling.
 
-        The leading ``clear`` (``values=None, as_node=END`` — LangGraph's
-        documented "clear all tasks" branch, which skips ``ERROR``/
-        ``INTERRUPT`` pending writes) discharges any stale pending task
-        *before* anything is appended, so a fanned-out sibling's
-        already-completed write is preserved rather than superseded by a
-        checkpoint that carries none of it. The middle superstep appends
-        *terminal* while resetting ``_cursor`` to the post-append event
-        count, so the next run's cursor starts past *terminal* instead of
-        re-entering its pending window. These two are pinned by the test
-        suite: dropping either fails
-        ``it_preserves_completed_sibling_writes`` or
-        ``it_leaves_the_thread_usable`` respectively.
-
-        The trailing ``clear`` and clearing ``_pending`` alongside the
-        append are deliberate belt-and-braces against the stale-``_pending``
-        re-arming this primitive exists to fix, but neither is independently
-        pinned by the suite as it stands: ablating either one alone still
-        leaves every current test green (only dropping both fails). Kept
-        anyway — they're cheap, and the mechanism they guard against
-        (routing re-run against a stale ``_pending`` on some future
-        checkpointer/LangGraph combination this suite doesn't exercise) is
-        exactly what defect 1 was.
+        The suite pins the leading clear and the ``_cursor`` reset, each
+        with its own failing test. The trailing clear and
+        ``_pending: []`` are a second guard. Neither is pinned alone.
         """
         appended = [terminal]
         return [
@@ -1506,22 +1484,11 @@ class EventGraph:
         ]
 
     def _settle(self, config: Any, terminal: Event) -> EventLog:
-        """Append *terminal* and settle the thread to a clean rest state.
-
-        Runs the three-superstep clear/append/clear recipe (see
-        :meth:`_settle_supersteps`) through the sync checkpoint API, so the
-        thread ends with nothing scheduled and no stale ``_pending`` to
-        re-arm routing on a later resume, while preserving any sibling
-        writes from a fanned-out superstep.
-        """
-        # Must read through `get_state`, not the checkpoint directly: its
-        # snapshot applies pending writes the same way the leading clear in
-        # `_settle_supersteps` will commit them, so `len(events)` here
-        # matches what the leading clear actually lands. A direct
-        # checkpoint read (e.g. `checkpointer.get_tuple` or a `get_state`
-        # pinned to a `checkpoint_id`, either of which skips pending-write
-        # application) would undercount, leaving `_cursor` short and
-        # putting the terminal event back in the next run's pending window.
+        """Append *terminal* and settle the thread via :meth:`_settle_supersteps`."""
+        # `_cursor` is correct only because this reads via `get_state`,
+        # whose snapshot applies the same pending writes the leading
+        # clear commits. A direct checkpoint read undercounts `_cursor`
+        # without raising an error, and no test in this suite catches it.
         events = self.get_state(config).events
         self._compile().bulk_update_state(
             cast("RunnableConfig", config),
@@ -1530,11 +1497,8 @@ class EventGraph:
         return self.get_state(config).events
 
     async def _asettle(self, config: Any, terminal: Event) -> EventLog:
-        """Async sibling of :meth:`_settle` — every checkpoint read/write
-        uses the async API (``aget_state``/``abulk_update_state``) so
-        async-only checkpointers aren't driven synchronously."""
-        # See `_settle` — must read through `aget_state`, not the
-        # checkpoint directly, for the same pending-writes-applied reason.
+        """Async sibling of :meth:`_settle`."""
+        # Same `_cursor` reasoning as `_settle`, via `aget_state`.
         events = (await self.aget_state(config)).events
         await self._compile().abulk_update_state(
             cast("RunnableConfig", config),
@@ -1547,11 +1511,8 @@ class EventGraph:
     ) -> EventLog:
         """Sync ``on_unresumable`` for a resume that would be a no-op.
 
-        Called only when :meth:`_resume_is_pending` is ``False``. The ``halt``
-        arm settles the thread onto a terminal ``Unresumable(Halted)`` (see
-        :meth:`_settle`) so the abandoned thread ends observably, with
-        nothing left scheduled and no stale pending state to trip on a
-        later resume or dispatch.
+        Runs only when :meth:`_resume_is_pending` is ``False``, so no
+        completed sibling write can be lost on this path.
         """
         config = kwargs.get("config")
         if self._unresumable_short_circuits():
@@ -1561,9 +1522,7 @@ class EventGraph:
     async def _aapply_unresumable_policy(
         self, value: Event, kwargs: dict[str, Any]
     ) -> EventLog:
-        """Async sibling of :meth:`_apply_unresumable_policy` — every checkpoint
-        read/write uses the async API (``aget_state``/``_asettle``) so
-        async-only checkpointers aren't driven synchronously."""
+        """Async sibling of :meth:`_apply_unresumable_policy`."""
         config = kwargs.get("config")
         if self._unresumable_short_circuits():
             return (await self.aget_state(config)).events

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -4243,6 +4243,23 @@ def _resumable_pair(saver, tid: str, **kwargs: typing.Any):
     return EventGraph([_go_noop], checkpointer=saver, **kwargs), cfg
 
 
+def _abandoned_pair(saver, tid: str, **kwargs: typing.Any):
+    """A genuinely-interrupted thread whose pending task was cleared out
+    from under it — the shape a future ``abandon()`` will leave behind.
+
+    ``_pending`` still stale-references the still-registered paused node
+    (``_waiter``), while the checkpoint's own ``next`` reports empty, via a
+    bare "clear all tasks" ``bulk_update_state`` through LangGraph's public
+    ``compiled`` property. Returns the graph (still with ``_waiter``
+    registered) and the paused thread config.
+    """
+    cfg = {"configurable": {"thread_id": tid}}
+    graph = EventGraph([_waiter, _go_noop], checkpointer=saver, **kwargs)
+    graph.invoke(Started(data="x"), config=cfg)
+    graph.compiled.bulk_update_state(cfg, [[StateUpdate(None, END)]])
+    return graph, cfg
+
+
 def describe_on_unresumable():
     # resume() on a thread that is not awaiting input (paused handler removed,
     # already-finished, or double-resume) is governed by
@@ -4293,18 +4310,12 @@ def describe_on_unresumable():
             assert not v2.get_state(cfg).is_interrupted
 
         def it_leaves_nothing_scheduled():
-            # Simulates a thread whose pending interrupt was already cleared
-            # out from under it (the shape a future `abandon()` will leave
-            # behind): `_pending` still stales-references the still-
-            # registered paused node, which the buggy single-superstep
-            # write re-schedules.
-            saver = MemorySaver()
-            cfg = {"configurable": {"thread_id": "unres-halt-next"}}
-            graph = EventGraph(
-                [_waiter, _go_noop], checkpointer=saver, on_unresumable="halt"
+            # `_abandoned_pair`: `_pending` still stales-references the
+            # still-registered paused node, which the buggy single-
+            # superstep write re-schedules.
+            graph, cfg = _abandoned_pair(
+                MemorySaver(), "unres-halt-next", on_unresumable="halt"
             )
-            graph.invoke(Started(data="x"), config=cfg)
-            graph.compiled.bulk_update_state(cfg, [[StateUpdate(None, END)]])
 
             graph.resume(_Go(), config=cfg)
 
@@ -4324,17 +4335,14 @@ def describe_on_unresumable():
             assert log.latest(Ended) == Ended(result="went")
 
         def it_does_not_resurrect_the_retired_identity():
-            # Same stale-scheduling setup as `it_leaves_nothing_scheduled`.
-            # If the halt policy re-arms the paused node, a second resume()
-            # then passes `_resume_is_pending` and runs `_waiter` for real,
-            # writing the retired `_Pause` identity back into the log.
-            saver = MemorySaver()
-            cfg = {"configurable": {"thread_id": "unres-halt-resurrect"}}
-            graph = EventGraph(
-                [_waiter, _go_noop], checkpointer=saver, on_unresumable="halt"
+            # Same `_abandoned_pair` stale-scheduling setup as
+            # `it_leaves_nothing_scheduled`. If the halt policy re-arms the
+            # paused node, a second resume() then passes
+            # `_resume_is_pending` and runs `_waiter` for real, writing the
+            # retired `_Pause` identity back into the log.
+            graph, cfg = _abandoned_pair(
+                MemorySaver(), "unres-halt-resurrect", on_unresumable="halt"
             )
-            graph.invoke(Started(data="x"), config=cfg)
-            graph.compiled.bulk_update_state(cfg, [[StateUpdate(None, END)]])
             graph.resume(_Go(), config=cfg)
 
             log = graph.resume(_Go(), config=cfg)
@@ -4434,6 +4442,17 @@ def describe_async_only_checkpointer():
         )
         return EventGraph([_go_noop], checkpointer=saver, **kwargs), cfg
 
+    async def _aabandoned_pair(tid: str, **kwargs: typing.Any):
+        """Async mirror of ``_abandoned_pair`` — a genuinely-interrupted
+        thread whose pending task was cleared out from under it, still
+        registering ``_waiter``, driven through ``_AsyncOnlySaver``."""
+        saver = _AsyncOnlySaver()
+        cfg = {"configurable": {"thread_id": tid}}
+        graph = EventGraph([_waiter, _go_noop], checkpointer=saver, **kwargs)
+        await graph.ainvoke(Started(data="x"), config=cfg)
+        await graph.compiled.abulk_update_state(cfg, [[StateUpdate(None, END)]])
+        return graph, cfg
+
     def when_the_thread_is_genuinely_pending():
         def without_sync_checkpointer_access():
 
@@ -4483,15 +4502,11 @@ def describe_async_only_checkpointer():
         @pytest.mark.asyncio
         async def it_aresume_halt_leaves_nothing_scheduled():
             # Async mirror of the sync `it_leaves_nothing_scheduled` — same
-            # stale-scheduling setup, driven through the async-only
-            # checkpointer to exercise `_asettle`.
-            saver = _AsyncOnlySaver()
-            cfg = {"configurable": {"thread_id": "async-only-halt-next"}}
-            graph = EventGraph(
-                [_waiter, _go_noop], checkpointer=saver, on_unresumable="halt"
+            # `_aabandoned_pair` stale-scheduling setup, driven through the
+            # async-only checkpointer to exercise `_asettle`.
+            graph, cfg = await _aabandoned_pair(
+                "async-only-halt-next", on_unresumable="halt"
             )
-            await graph.ainvoke(Started(data="x"), config=cfg)
-            await graph.compiled.abulk_update_state(cfg, [[StateUpdate(None, END)]])
 
             await graph.aresume(_Go(), config=cfg)
 

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -23,6 +23,8 @@ from langchain_core.messages import (
     SystemMessage,
 )
 from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END
+from langgraph.types import StateUpdate
 
 from langgraph_events import (
     STATE_SNAPSHOT_EVENT_NAME,
@@ -4204,10 +4206,20 @@ class _Go(IntegrationEvent):
     pass
 
 
+class _SideDone(IntegrationEvent):
+    pass
+
+
 @on(Started)
 def _waiter(event: Started) -> _Pause:
     """Pauses the run so resume-policy suites have an interrupted thread."""
     return _Pause()
+
+
+@on(Started)
+def _side_effect(event: Started) -> _SideDone:
+    """Fan-out sibling of _waiter: completes normally in the same superstep."""
+    return _SideDone()
 
 
 @on(_Go)
@@ -4279,6 +4291,69 @@ def describe_on_unresumable():
             assert isinstance(log.latest(Unresumable), Unresumable)
             assert isinstance(log.latest(Unresumable), Halted)
             assert not v2.get_state(cfg).is_interrupted
+
+        def it_leaves_nothing_scheduled():
+            # Simulates a thread whose pending interrupt was already cleared
+            # out from under it (the shape a future `abandon()` will leave
+            # behind): `_pending` still stales-references the still-
+            # registered paused node, which the buggy single-superstep
+            # write re-schedules.
+            saver = MemorySaver()
+            cfg = {"configurable": {"thread_id": "unres-halt-next"}}
+            graph = EventGraph(
+                [_waiter, _go_noop], checkpointer=saver, on_unresumable="halt"
+            )
+            graph.invoke(Started(data="x"), config=cfg)
+            graph.compiled.bulk_update_state(cfg, [[StateUpdate(None, END)]])
+
+            graph.resume(_Go(), config=cfg)
+
+            assert graph.compiled.get_state(cfg).next == ()
+
+        def it_leaves_the_thread_usable():
+            saver = MemorySaver()
+            cfg = {"configurable": {"thread_id": "unres-halt-usable"}}
+            EventGraph([_waiter, _go_noop], checkpointer=saver).invoke(
+                Started(data="x"), config=cfg
+            )
+            v2 = EventGraph([_go_ends], checkpointer=saver, on_unresumable="halt")
+            v2.resume(_Go(), config=cfg)
+
+            log = v2.invoke(_Go(), config=cfg)
+
+            assert log.latest(Ended) == Ended(result="went")
+
+        def it_does_not_resurrect_the_retired_identity():
+            # Same stale-scheduling setup as `it_leaves_nothing_scheduled`.
+            # If the halt policy re-arms the paused node, a second resume()
+            # then passes `_resume_is_pending` and runs `_waiter` for real,
+            # writing the retired `_Pause` identity back into the log.
+            saver = MemorySaver()
+            cfg = {"configurable": {"thread_id": "unres-halt-resurrect"}}
+            graph = EventGraph(
+                [_waiter, _go_noop], checkpointer=saver, on_unresumable="halt"
+            )
+            graph.invoke(Started(data="x"), config=cfg)
+            graph.compiled.bulk_update_state(cfg, [[StateUpdate(None, END)]])
+            graph.resume(_Go(), config=cfg)
+
+            log = graph.resume(_Go(), config=cfg)
+
+            assert not any(isinstance(e, _Pause) for e in log)
+
+        def it_preserves_completed_sibling_writes():
+            saver = MemorySaver()
+            cfg = {"configurable": {"thread_id": "unres-halt-sibling"}}
+            EventGraph([_waiter, _side_effect, _go_noop], checkpointer=saver).invoke(
+                Started(data="x"), config=cfg
+            )
+            v2 = EventGraph(
+                [_side_effect, _go_noop], checkpointer=saver, on_unresumable="halt"
+            )
+
+            log = v2.resume(_Go(), config=cfg)
+
+            assert log.has(_SideDone)
 
     def when_resumed_via_another_entrypoint():
         # Every resume entrypoint consults the same on_unresumable policy.
@@ -4404,6 +4479,24 @@ def describe_async_only_checkpointer():
             log = await v2.aresume(_Go(), config=cfg)
 
             assert log.latest(Unresumable) is not None
+
+        @pytest.mark.asyncio
+        async def it_aresume_halt_leaves_nothing_scheduled():
+            # Async mirror of the sync `it_leaves_nothing_scheduled` — same
+            # stale-scheduling setup, driven through the async-only
+            # checkpointer to exercise `_asettle`.
+            saver = _AsyncOnlySaver()
+            cfg = {"configurable": {"thread_id": "async-only-halt-next"}}
+            graph = EventGraph(
+                [_waiter, _go_noop], checkpointer=saver, on_unresumable="halt"
+            )
+            await graph.ainvoke(Started(data="x"), config=cfg)
+            await graph.compiled.abulk_update_state(cfg, [[StateUpdate(None, END)]])
+
+            await graph.aresume(_Go(), config=cfg)
+
+            state = await graph.compiled.aget_state(cfg)
+            assert state.next == ()
 
         @pytest.mark.asyncio
         async def it_astream_resume_halt_yields_the_terminal_event():

--- a/tests/test_event_graph.py
+++ b/tests/test_event_graph.py
@@ -4218,7 +4218,8 @@ def _waiter(event: Started) -> _Pause:
 
 @on(Started)
 def _side_effect(event: Started) -> _SideDone:
-    """Fan-out sibling of _waiter: completes normally in the same superstep."""
+    """Fan-out sibling of ``_waiter``. Completes normally in the same
+    superstep."""
     return _SideDone()
 
 
@@ -4245,13 +4246,16 @@ def _resumable_pair(saver, tid: str, **kwargs: typing.Any):
 
 def _abandoned_pair(saver, tid: str, **kwargs: typing.Any):
     """A genuinely-interrupted thread whose pending task was cleared out
-    from under it — the shape a future ``abandon()`` will leave behind.
+    from under it.
 
-    ``_pending`` still stale-references the still-registered paused node
-    (``_waiter``), while the checkpoint's own ``next`` reports empty, via a
-    bare "clear all tasks" ``bulk_update_state`` through LangGraph's public
-    ``compiled`` property. Returns the graph (still with ``_waiter``
-    registered) and the paused thread config.
+    This is the shape a future ``abandon()`` will leave behind.
+    ``_pending`` still stale-references the still-registered paused node,
+    ``_waiter``. The checkpoint's own ``next`` reports empty. A bare
+    "clear all tasks" ``bulk_update_state`` call produces this state. The
+    call runs through LangGraph's public ``compiled`` property.
+
+    Returns the graph, still with ``_waiter`` registered, and the paused
+    thread config.
     """
     cfg = {"configurable": {"thread_id": tid}}
     graph = EventGraph([_waiter, _go_noop], checkpointer=saver, **kwargs)
@@ -4310,9 +4314,9 @@ def describe_on_unresumable():
             assert not v2.get_state(cfg).is_interrupted
 
         def it_leaves_nothing_scheduled():
-            # `_abandoned_pair`: `_pending` still stales-references the
-            # still-registered paused node, which the buggy single-
-            # superstep write re-schedules.
+            # `_abandoned_pair` sets up a thread where `_pending` still
+            # stale-references the still-registered paused node. A
+            # single-superstep write reschedules that node.
             graph, cfg = _abandoned_pair(
                 MemorySaver(), "unres-halt-next", on_unresumable="halt"
             )
@@ -4336,10 +4340,10 @@ def describe_on_unresumable():
 
         def it_does_not_resurrect_the_retired_identity():
             # Same `_abandoned_pair` stale-scheduling setup as
-            # `it_leaves_nothing_scheduled`. If the halt policy re-arms the
-            # paused node, a second resume() then passes
-            # `_resume_is_pending` and runs `_waiter` for real, writing the
-            # retired `_Pause` identity back into the log.
+            # `it_leaves_nothing_scheduled`. If the halt policy re-arms
+            # the paused node, a second `resume()` call passes
+            # `_resume_is_pending`. It then runs `_waiter` for real,
+            # writing the retired `_Pause` identity back into the log.
             graph, cfg = _abandoned_pair(
                 MemorySaver(), "unres-halt-resurrect", on_unresumable="halt"
             )
@@ -4443,9 +4447,12 @@ def describe_async_only_checkpointer():
         return EventGraph([_go_noop], checkpointer=saver, **kwargs), cfg
 
     async def _aabandoned_pair(tid: str, **kwargs: typing.Any):
-        """Async mirror of ``_abandoned_pair`` — a genuinely-interrupted
-        thread whose pending task was cleared out from under it, still
-        registering ``_waiter``, driven through ``_AsyncOnlySaver``."""
+        """Async mirror of ``_abandoned_pair``.
+
+        Builds a genuinely-interrupted thread whose pending task was
+        cleared out from under it. ``_waiter`` is still registered. The
+        setup runs through ``_AsyncOnlySaver``.
+        """
         saver = _AsyncOnlySaver()
         cfg = {"configurable": {"thread_id": tid}}
         graph = EventGraph([_waiter, _go_noop], checkpointer=saver, **kwargs)
@@ -4501,9 +4508,10 @@ def describe_async_only_checkpointer():
 
         @pytest.mark.asyncio
         async def it_aresume_halt_leaves_nothing_scheduled():
-            # Async mirror of the sync `it_leaves_nothing_scheduled` — same
-            # `_aabandoned_pair` stale-scheduling setup, driven through the
-            # async-only checkpointer to exercise `_asettle`.
+            # Async mirror of the sync `it_leaves_nothing_scheduled`. It
+            # uses the same `_aabandoned_pair` stale-scheduling setup.
+            # The test runs through the async-only checkpointer to
+            # exercise `_asettle`.
             graph, cfg = await _aabandoned_pair(
                 "async-only-halt-next", on_unresumable="halt"
             )


### PR DESCRIPTION
## Problem

`on_unresumable="halt"` has two defects. Both exist on `main` today. Neither depends on a new
feature.

### Defect 1: the policy re-arms the thread

`_apply_unresumable_policy` appends the terminal `Unresumable` with
`update_state(..., as_node="__seed__")`. That call runs routing again against the stale
`_pending` channel and schedules the paused node again. `next` becomes non-empty, and
`is_interrupted` stays `False`.

A second `resume()` then passes `_resume_is_pending()` and runs the graph. The run writes the
paused `Interrupted` identity back into the event log.

```
after settle       next=()
after 1st resume   next=('waiter',)   is_interrupted=False
after 2nd resume   [Started, Cancelled, Unresumable, Approve, Go, Resumed]
                                                     ^^^^^^^ back in the log
```

### Defect 2: the thread cannot run again

The policy leaves `_cursor` behind the appended terminal event. The `Halted` event then enters
the `_pending` window of the next run, and the `Halted` gate in `_internal.py` routes the run to
`END`.

A later `invoke()` appends its event and dispatches nothing. No handler runs. The library
reports no warning and no error.

## Fix

This PR adds one settle primitive. `_settle` and `_asettle` call the pure helper
`_settle_supersteps`, which writes three supersteps instead of one.

```python
[[StateUpdate(None, END)],
 [StateUpdate({"events": appended,
               "_cursor": len(events) + len(appended),
               "_pending": []}, "__seed__")],
 [StateUpdate(None, END)]]
```

WARNING: the order matters. An append before the first clear loses data. A measured log read
`[Started, SideDone]` before the call and `[Started, Cancelled]` after it. `SideDone` was the
output of a sibling handler that had completed. An append writes a new checkpoint that carries
none of the pending writes of the previous checkpoint, so the final clear finds nothing to
replay.

`_apply_unresumable_policy` and `_aapply_unresumable_policy` keep their signature and return
type. All four resume entry points stay unchanged.

## Notes for the reviewer

The sync path and the async path are duplicated on purpose. The duplication mirrors the existing
policy pair. An async-only checkpointer must never run under a sync call. See #95.

WARNING: `_cursor = len(events) + len(appended)` is correct only because the read uses
`get_state`. The snapshot of `get_state` applies the same pending writes that the first clear
commits. A read direct from the checkpoint undercounts, defect 2 returns, and every test stays
green. A comment marks both read sites.

The docstring of `_settle_supersteps` states which parts the test suite pins. The first clear
and the `_cursor` reset each have a test that fails without them. The final clear and
`_pending: []` are redundant against the current suite and are kept as a second guard. The
docstring says so, to stop a later edit pruning them.

## Also in this PR

This branch adds a writing style section to `CLAUDE.md`. It requires ASD-STE100 Simplified
Technical English for chat replies, commit messages, MR descriptions, issue text, plans,
docstrings and code comments. The docstrings and comments in this PR follow it.

## Testing

This PR adds four tests to `describe_on_unresumable`. Each new test fails against the
`_graph.py` of `main`. Each new test passes with the fix. The eight existing tests pass in both
states.

The full suite reports 1319 passed and 1 skipped. `ruff` and `mypy --strict` report no issue.

## Stack

#164 adds `abandon()` on top of this branch. Review this PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMKf65d57Z3DYKwckDBVNN
