### PR TITLE
fix: serde writes only init fields, so an init=False field round-trips (closes #172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An `init=False` dataclass field now round-trips through `NamespaceAwareSerde`.**
+  Closes [#172](https://github.com/cadance-io/langgraph-events/issues/172). The encoder wrote
+  every `dataclasses.fields()` name of an event. The constructor rejected an `init=False` field
+  on read with `Cannot revive ... unexpected keyword argument`. The encoder now writes only
+  fields with `init=True`. An `init=False` field is rebuilt by `__post_init__` on read.
+  `assert_all_baselined_revive` agrees: its placeholder helper gives an `init=False` field no
+  placeholder.
+
 - **A pydantic payload nested inside a class no longer revives silently as a raw `dict`.**
   Closes [#167](https://github.com/cadance-io/langgraph-events/issues/167). The LangGraph
   serializer stores a pydantic payload by `__name__` and revives it with one `getattr` on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,9 +89,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Closes [#172](https://github.com/cadance-io/langgraph-events/issues/172). The encoder wrote
   every `dataclasses.fields()` name of an event. The constructor rejected an `init=False` field
   on read with `Cannot revive ... unexpected keyword argument`. The encoder now writes only
-  fields with `init=True`. An `init=False` field is rebuilt by `__post_init__` on read.
-  `assert_all_baselined_revive` agrees: its placeholder helper gives an `init=False` field no
-  placeholder.
+  fields with `init=True`. An `init=False` field is rebuilt by `__post_init__` on read. A
+  checkpoint written before this fix still carries the field and still fails to revive: settle
+  or abandon such a thread. `assert_all_baselined_revive` agrees: its placeholder helper gives
+  an `init=False` field no placeholder. A `@backfill` on an `init=False` field is refused at
+  serde construction with the existing "has no field" message.
 
 - **A pydantic payload nested inside a class no longer revives silently as a raw `dict`.**
   Closes [#167](https://github.com/cadance-io/langgraph-events/issues/167). The LangGraph

--- a/src/langgraph_events/serde/_jsonplus.py
+++ b/src/langgraph_events/serde/_jsonplus.py
@@ -152,6 +152,9 @@ def _make_default(
     gated on the class being in this map — out-of-scope decorated classes
     fall through to their current qualname so bytes never reference a
     historic name the serde's own read path can't migrate back.
+
+    Only fields with ``init=True`` are written: an ``init=False`` field is
+    rebuilt by the constructor on read, which rejects it as a kwarg (#172).
     """
 
     def _default(obj: Any) -> Any:
@@ -174,7 +177,11 @@ def _make_default(
                     (
                         module,
                         qualname,
-                        {f.name: getattr(obj, f.name) for f in dataclasses.fields(obj)},
+                        {
+                            f.name: getattr(obj, f.name)
+                            for f in dataclasses.fields(obj)
+                            if f.init
+                        },
                     ),
                     default=_default,
                     option=_option,

--- a/src/langgraph_events/serde/migrations/_core.py
+++ b/src/langgraph_events/serde/migrations/_core.py
@@ -343,10 +343,12 @@ def _bucket_addfields(
         # as a dataclass TypeError at first production read — catch the
         # typo here instead. ``live_identity`` always resolves: post-rename
         # targets were just probed, origin targets point at a chain
-        # terminus ``_resolve_chain_terminus`` already validated.
+        # terminus ``_resolve_chain_terminus`` already validated. Only
+        # ``init=True`` fields count: an ``init=False`` field is not a kwarg
+        # the constructor accepts, so a fill on it breaks every read (#172).
         live_cls = _resolve_identity(*live_identity, scope=scope)
         if is_dataclass(live_cls) and op.field not in {
-            f.name for f in fields(live_cls)
+            f.name for f in fields(live_cls) if f.init
         }:
             raise ValueError(
                 f"AddField({op.module}:{op.qualname!r}, {op.field!r}) in "

--- a/src/langgraph_events/serde/migrations/testing.py
+++ b/src/langgraph_events/serde/migrations/testing.py
@@ -72,7 +72,9 @@ def _required_field_placeholders(
     scope: Mapping[tuple[str, str], type] | None = None,
 ) -> dict[str, Any]:
     """``{name: None}`` for every required (no-default) field of the live
-    class at ``(module, qualname)``, except those in *skip*.
+    class at ``(module, qualname)``, except those in *skip*. An
+    ``init=False`` field gets no placeholder: the encoder does not write it
+    and the constructor rejects it as a kwarg (#172).
 
     Reads the fields off whichever class the read path would build — hence
     *scope*, the serde's ``namespaces=`` map, ahead of the import walk.
@@ -96,7 +98,8 @@ def _required_field_placeholders(
     return {
         f.name: None
         for f in dataclasses.fields(obj)
-        if f.name not in skip
+        if f.init
+        and f.name not in skip
         and f.default is dataclasses.MISSING
         and f.default_factory is dataclasses.MISSING
     }

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -397,6 +397,15 @@ class DecoBackfillTypoField(Namespace):
         note: str = ""
 
 
+# Fixture for #172. A fill on an ``init=False`` field is not a kwarg the
+# constructor accepts, so the serde must refuse it at construction.
+class DecoBackfillInitFalse(Namespace):
+    @backfill("derived", default=0)
+    class Placed(DomainEvent):
+        total: int
+        derived: int = dataclasses.field(init=False, default=0)
+
+
 # Fixture proving the revive gate exercises origin fills instead of
 # masking them with ``None`` placeholders: ``__post_init__`` rejects
 # anything but a real discriminator, so the gate only passes if the
@@ -3005,6 +3014,13 @@ def describe_origin_scoped_backfill():
         def it_guards_the_class_global_decorator_too():
             with pytest.raises(ValueError, match="command_idd"):
                 NamespaceAwareSerde(namespaces=[DecoBackfillTypoField])
+
+    def when_a_fill_names_an_init_false_field():
+        def it_is_rejected_at_serde_construction():
+            # The encoder never writes the field and the constructor rejects
+            # it as a kwarg, so the fill can only break every read.
+            with pytest.raises(ValueError, match="has no field 'derived'"):
+                NamespaceAwareSerde(namespaces=[DecoBackfillInitFalse])
 
     def when_legacy_write_meets_origin_scoped_fills():
         def it_is_rejected_at_serde_construction():

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -116,6 +116,30 @@ class FieldShape(Namespace):
         reason: str
 
 
+# Fixture for #172. ``derived`` is ``init=False`` and is rebuilt in
+# ``__post_init__``. The serde must not write it: the constructor rejects it.
+class DerivedField(Namespace):
+    class Placed(DomainEvent):
+        total: int
+        derived: int = dataclasses.field(init=False, default=0)
+
+        def __post_init__(self) -> None:
+            object.__setattr__(self, "derived", self.total * 2)
+
+
+# Fixture for the revive gate under #172. ``derived`` is ``init=False`` with
+# no default. The placeholder helper must not fill it: it is not a kwarg.
+# ``__post_init__`` does not read ``total``, so the ``None`` placeholder for
+# ``total`` is accepted, as the revive gate documents.
+class DerivedNoDefault(Namespace):
+    class Placed(DomainEvent):
+        total: int
+        derived: int = dataclasses.field(init=False)
+
+        def __post_init__(self) -> None:
+            object.__setattr__(self, "derived", 2)
+
+
 # Fixtures for the decorator-driven migration tests. Module-level so their
 # qualnames resolve through ``importlib.import_module`` + dotted ``getattr``
 # at serde-construction validation time. Function-local classes acquire
@@ -709,6 +733,18 @@ def describe_NamespaceAwareSerde():
                 assert not isinstance(s_back, Persona.Approve.Approved)
                 assert p_back.note == "persona"
                 assert s_back.note == "story"
+
+        def when_an_event_has_an_init_false_field():
+            def it_round_trips_and_recomputes_the_derived_value():
+                serde = NamespaceAwareSerde(namespaces=(DerivedField,))
+                ev = DerivedField.Placed(total=1)
+                assert ev.derived == 2
+
+                back = serde.loads_typed(serde.dumps_typed(ev))
+
+                assert isinstance(back, DerivedField.Placed)
+                assert back.total == 1
+                assert back.derived == 2
 
     def describe_checkpoint_roundtrip():
         def when_two_namespaces_share_a_leaf_event_name():
@@ -2382,6 +2418,20 @@ def describe_NamespaceAwareSerde():
                     tmp_path,
                     (DecoReorg.__module__, "DecoReorg.Persisted"),
                     (DecoReorg.__module__, "DecoReorg.Persist.Persisted"),
+                )
+
+                assert_all_baselined_revive(serde, baseline)
+
+        def when_an_init_false_field_has_no_default():
+            def it_gives_that_field_no_placeholder(tmp_path: Any):
+                from langgraph_events.serde.migrations import (
+                    assert_all_baselined_revive,
+                )
+
+                serde = NamespaceAwareSerde(namespaces=[DerivedNoDefault])
+                baseline = _baseline_file(
+                    tmp_path,
+                    (DerivedNoDefault.__module__, "DerivedNoDefault.Placed"),
                 )
 
                 assert_all_baselined_revive(serde, baseline)


### PR DESCRIPTION
## Summary

`NamespaceAwareSerde` now writes only fields with `init=True`. An event with an `init=False` field round-trips through `dumps_typed` / `loads_typed`. Closes #172.

## Why

The encoder wrote every `dataclasses.fields()` name of an event. A field declared with `init=False` was included. On read, the constructor rejected that field with `Cannot revive ... unexpected keyword argument '<name>'`. An `init=False` field is rebuilt by `__post_init__` on construction. The serde must not write it.

## What changed

- `src/langgraph_events/serde/_jsonplus.py`: `_make_default` writes only fields with `init=True`. One sentence in the docstring states the rule.
- `src/langgraph_events/serde/migrations/testing.py`: `_required_field_placeholders` gives an `init=False` field no placeholder. The revive gate now agrees with the encoder.
- `src/langgraph_events/serde/migrations/_core.py`: `_bucket_addfields` validates a fill name against `init=True` fields only. A `@backfill` on an `init=False` field is refused at serde construction with the existing "has no field" message. Before, the fill passed the check and every read failed.
- `tests/test_serde.py`: three module-level fixtures and three tests. One test round-trips the issue's event and asserts the derived value is recomputed. One test runs `assert_all_baselined_revive` on a class whose `init=False` field has no default. One test asserts a `@backfill` on an `init=False` field raises `ValueError` at construction.
- `CHANGELOG.md`: one entry under `[Unreleased]` / Fixed. It notes that a checkpoint written before this fix still carries the field and still fails to revive. Settle or abandon such a thread.

`detect.py` is not touched. PR #173 changes that file.

## Verification

- Each test was run red first. The two round-trip tests failed with `unexpected keyword argument 'derived'`. The backfill test failed with `DID NOT RAISE`.
- `uv run pytest tests/`: 1393 passed, 1 skipped.
- `uv run ruff check src/ tests/`: clean.
- `uv run mypy src/`: clean.
- The pre-commit hook passed on each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsQPjuKEjSdeh7VorVphBe
